### PR TITLE
Add Loader to yaml.load call

### DIFF
--- a/mhcflurry/downloads.py
+++ b/mhcflurry/downloads.py
@@ -50,7 +50,7 @@ def get_downloads_metadata():
     """
     global _METADATA
     if _METADATA is None:
-        _METADATA = yaml.load(resource_string(__name__, "downloads.yml"))
+        _METADATA = yaml.load(resource_string(__name__, "downloads.yml"), Loader=yaml.FullLoader)
     return _METADATA
 
 


### PR DESCRIPTION
This fixes the `calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe` warning messages.

See https://msg.pyyaml.org/load.