### PR TITLE
Introduced tf-keras for compatibility with tensorflow>2.15

### DIFF
--- a/mhcflurry/class1_neural_network.py
+++ b/mhcflurry/class1_neural_network.py
@@ -217,7 +217,7 @@ class Class1NeuralNetwork(object):
         if key not in klass.KERAS_MODELS_CACHE:
             # Cache miss.
             configure_tensorflow()
-            from tensorflow.keras.models import model_from_json
+            from tf_keras.models import model_from_json
 
             network = model_from_json(network_json)
             existing_weights = None
@@ -258,7 +258,7 @@ class Class1NeuralNetwork(object):
                 )
             else:
                 configure_tensorflow()
-                from tensorflow import keras
+                import tf_keras as keras
 
                 # Hack to fix an issue caused by a change introduced in
                 # tensorflow 2.3.0, in which our models fit using tensorflow 2.2
@@ -568,7 +568,7 @@ class Class1NeuralNetwork(object):
         progress_print_interval : float
         """
         configure_tensorflow()
-        from tensorflow.keras import backend as K
+        from tf_keras import backend as K
 
         fit_info = collections.defaultdict(list)
 
@@ -775,7 +775,7 @@ class Class1NeuralNetwork(object):
             disable.
         """
         configure_tensorflow()
-        from tensorflow.keras import backend as K
+        from tf_keras import backend as K
 
         encodable_peptides = EncodableSequences.create(peptides)
         peptide_encoding = self.peptides_to_network_input(encodable_peptides)
@@ -1192,9 +1192,9 @@ class Class1NeuralNetwork(object):
 
         """
         configure_tensorflow()
-        from tensorflow.keras import backend as K
-        from tensorflow.keras.layers import Input, average, add, concatenate
-        from tensorflow.keras.models import Model
+        from tf_keras import backend as K
+        from tf_keras.layers import Input, add, average, concatenate
+        from tf_keras.models import Model
 
         if len(models) == 1:
             return models[0]
@@ -1337,8 +1337,8 @@ class Class1NeuralNetwork(object):
         # We import keras here to avoid tensorflow debug output, etc. unless we
         # are actually about to use Keras.
         configure_tensorflow()
-        from tensorflow import keras
-        from tensorflow.keras.layers import (
+        import tf_keras as keras
+        from tf_keras.layers import (
             Input,
             Dense,
             Flatten,
@@ -1500,7 +1500,7 @@ class Class1NeuralNetwork(object):
                   m is the length of the vectors used to represent amino acids
         """
         configure_tensorflow()
-        from tensorflow.keras.models import clone_model
+        from tf_keras.models import clone_model
 
         reshaped = allele_representations.reshape(
             (

--- a/mhcflurry/class1_processing_neural_network.py
+++ b/mhcflurry/class1_processing_neural_network.py
@@ -111,7 +111,7 @@ class Class1ProcessingNeuralNetwork(object):
         if self._network is None and self.network_json is not None:
             # NOTE
             # Instead of calling:
-            #   from tensorflow.keras.models import model_from_json
+            #   from tf_keras.models import model_from_json
             #   self._network = model_from_json(self.network_json)
             # We are re-creating the network here using the hyperparameters.
             # This is because the network uses Lambda layers, which break
@@ -399,8 +399,7 @@ class Class1ProcessingNeuralNetwork(object):
         # We import keras here to avoid tensorflow debug output, etc. unless we
         # are actually about to use Keras.
         configure_tensorflow()
-        from tensorflow import keras
-        from keras.layers import (
+        from tf_keras.layers import (
             Input,
             Dense,
             Dropout,
@@ -408,8 +407,8 @@ class Class1ProcessingNeuralNetwork(object):
             Conv1D,
             Lambda,
         )
-        from keras.models import Model
-        from keras import regularizers, initializers
+        from tf_keras.models import Model
+        from tf_keras import regularizers, initializers
 
         model_inputs = {}
 

--- a/mhcflurry/common.py
+++ b/mhcflurry/common.py
@@ -95,7 +95,7 @@ def configure_tensorflow(backend=None, gpu_device_nums=None, num_threads=None):
     """
     import tensorflow as tf
     
-    # mhcflurry models use keras 2. Tensorflow, now defaults to keras 3, so to load these
+    # mhcflurry models use keras 2. Tensorflow now defaults to keras 3, so to load these
     # old models, we need to set the environment variable to use legacy keras. Ideally,
     # these models such be regenerated with keras 3.
     os.environ["TF_USE_LEGACY_KERAS"] = "1"

--- a/mhcflurry/common.py
+++ b/mhcflurry/common.py
@@ -94,7 +94,12 @@ def configure_tensorflow(backend=None, gpu_device_nums=None, num_threads=None):
 
     """
     import tensorflow as tf
-
+    
+    # mhcflurry models use keras 2. Tensorflow, now defaults to keras 3, so to load these
+    # old models, we need to set the environment variable to use legacy keras. Ideally,
+    # these models such be regenerated with keras 3.
+    os.environ["TF_USE_LEGACY_KERAS"] = "1"
+    
     global TENSORFLOW_CONFIGURED
 
     if TENSORFLOW_CONFIGURED:

--- a/mhcflurry/custom_loss.py
+++ b/mhcflurry/custom_loss.py
@@ -64,7 +64,7 @@ class Loss(object):
 
     def get_keras_loss(self, reduction="sum_over_batch_size"):
         configure_tensorflow()
-        from tensorflow.keras.losses import LossFunctionWrapper
+        from tf_keras.losses import LossFunctionWrapper
         return LossFunctionWrapper(
             self.loss, reduction=reduction, name=self.name)
 
@@ -169,7 +169,7 @@ class MSEWithInequalities(Loss):
         configure_tensorflow()
         import tensorflow as tf
 
-        # from tensorflow.keras import backend as K
+        # from tf_keras import backend as K
         y_true = tf.reshape(y_true, [-1])
         y_pred = tf.reshape(y_pred, [-1])
 

--- a/mhcflurry/data_dependent_weights_initialization.py
+++ b/mhcflurry/data_dependent_weights_initialization.py
@@ -59,7 +59,7 @@ def svd_orthonormal(shape):
 
 def get_activations(model, layer, X_batch):
     configure_tensorflow()
-    from tensorflow.keras.models import Model
+    from tf_keras.models import Model
     intermediate_layer_model = Model(
         inputs=model.input,
         outputs=layer.get_output_at(0)
@@ -93,7 +93,7 @@ def lsuv_init(model, batch, verbose=True, margin=0.1, max_iter=100):
         Same as what was passed in.
     """
     configure_tensorflow()
-    from tensorflow.keras.layers import Dense, Convolution2D
+    from tf_keras.layers import Dense, Convolution2D
     needed_variance = 1.0
     layers_inintialized = 0
     for layer in model.layers:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 six
 pandas>=0.20.3
-tensorflow>=2.12.0,<2.16.0
+tensorflow>=2.15.0,<2.17.0
+tf-keras
 appdirs
 scikit-learn
 mhcgnomes

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,8 @@ if __name__ == "__main__":
         "mhcgnomes>=0.8.4",
         "pyyaml",
         "tqdm",
-        "tensorflow>=2.12.0,<2.16.0",
+        "tensorflow>=2.15.0,<2.17.0",
+        "tf-keras"
     ]
 
     setup(


### PR DESCRIPTION
In line with the [release documentation for tensorflow 2.16.1](https://github.com/tensorflow/tensorflow/releases/tag/v2.16.1), I have updated the code to use `tf-keras` everywhere it is required. This is because `tensorflow==2.16.1` onwards uses keras 3 rather than keras 2 by default. As a result, all models using keras 2 require tf-keras for loading. 

As a result of introducing `tf-keras`, I have increased the minimum version of tensorflow to `2.15.0`. This is because the first version of `tf-keras` which has a tensorflow dependency compatibility restrictions (2.15.1) has `tensorflow>=2.15`.
 
I have checked all tests pass locally and the the examples from the README run.