### PR TITLE
Cap tensorflow version to < 2.18. 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 six
 pandas>=0.20.3
-tensorflow>=2.15.0
+tensorflow>=2.15.0,<2.18.0
 tf-keras
 appdirs
 scikit-learn

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
         "mhcgnomes>=0.8.4",
         "pyyaml",
         "tqdm",
-        "tensorflow>=2.15.0",
+        "tensorflow>=2.15.0,<2.18.0",
         "tf-keras"
     ]
 


### PR DESCRIPTION
TF 2.18 uses numpy 2.0, which we don't support (yet).

Related: #245 #246 