### PR TITLE
Phase 1+2 pan-allele training perf fixes (#268): encoding cache, non-daemonic Pool, DataLoader prefetch

### DIFF
--- a/docs/issues-to-file/01-training-no-dataloader.md
+++ b/docs/issues-to-file/01-training-no-dataloader.md
@@ -1,0 +1,66 @@
+# Training loop: no DataLoader, every batch encoded synchronously on main thread
+
+## Observation
+
+In `mhcflurry/class1_neural_network.py` around line 2045, the per-epoch batch
+loop does CPU data prep on the main thread right before dispatching each batch
+to the GPU:
+
+```python
+for epoch in range(max_epochs):
+    # per-epoch CPU work: generate random negatives, encode peptides, shuffle
+    ...
+    for batch_start in range(0, n_train, batch_size):
+        batch_idx = train_indices[batch_start:batch_start + batch_size]
+        peptide_batch = torch.from_numpy(x_peptide[batch_idx]).float().to(device)
+        y_batch       = torch.from_numpy(y_encoded[batch_idx].astype(numpy.float32)).to(device)
+        ...
+        predictions = network(inputs)
+        loss = loss_obj(predictions, y_batch, ...)
+        loss.backward()
+        optimizer.step()
+        train_losses.append(loss.item())   # forces GPU → CPU sync every batch
+```
+
+No `torch.utils.data.DataLoader` with `num_workers>0`, no pinned memory,
+no `non_blocking=True` on `.to(device)`, and `.item()` per batch forces a
+GPU→CPU sync that serializes kernels.
+
+## Impact
+
+Observed empirically on a Brev 8×A100 box running the public GENERATE.sh
+recipe: per-epoch wall time 200–450 s for a 1024×512 dense model that should
+be <10 s on an A100. GPU memory utilization 1–5% across all 8 GPUs, GPU util
+in single digits. Both OpenMP oversubscription (separate issue) and this
+synchronous batch loop contribute.
+
+## Suggested fix
+
+Opt-in behind a hyperparameter / env var so default reproducibility is
+preserved:
+
+```python
+dataset = TensorDataset(x_peptide_tensor, x_allele_tensor, y_tensor)
+loader = DataLoader(
+    dataset, batch_size=self.hyperparameters["minibatch_size"], shuffle=True,
+    num_workers=4, pin_memory=True, persistent_workers=True,
+)
+for batch in loader:
+    peptide_batch = batch[0].to(device, non_blocking=True)
+    allele_batch  = batch[1].to(device, non_blocking=True)
+    y_batch       = batch[2].to(device, non_blocking=True)
+    ...
+```
+
+Plus: accumulate losses as a running tensor sum and materialize with `.item()`
+once at epoch end instead of per batch.
+
+## Complication
+
+`random_negatives_planner.get_peptides()` is called once per epoch at
+line 1995. Moving that into a DataLoader-compatible sampler requires
+restructuring — not hard but more than a trivial diff.
+
+## Expected speedup
+
+2–5× on top of the OMP fix (see sibling issues) for this workload.

--- a/docs/issues-to-file/02-training-blocking-gpu-transfer.md
+++ b/docs/issues-to-file/02-training-blocking-gpu-transfer.md
@@ -1,0 +1,35 @@
+# Training loop: .to(device) is blocking + no pinned memory
+
+## Observation
+
+In `mhcflurry/class1_neural_network.py` around line 2048:
+
+```python
+peptide_batch = torch.from_numpy(x_peptide[batch_idx]).float().to(device)
+y_batch       = torch.from_numpy(y_encoded[batch_idx].astype(numpy.float32)).to(device)
+...
+if x_allele is not None:
+    allele_batch = torch.from_numpy(x_allele[batch_idx]).float().to(device)
+```
+
+Each `.to(device)` call is synchronous by default and the source numpy
+arrays aren't pinned, so every transfer stalls the main thread for the
+duration of the PCIe copy.
+
+## Suggested fix
+
+Pin the source tensors once, then pass `non_blocking=True` on each
+`.to(device)`:
+
+```python
+# one-time at start of fit():
+x_peptide_t = torch.from_numpy(x_peptide).float().pin_memory()
+y_t         = torch.from_numpy(y_encoded.astype(numpy.float32)).pin_memory()
+
+# per batch:
+peptide_batch = x_peptide_t[batch_idx].to(device, non_blocking=True)
+y_batch       = y_t[batch_idx].to(device, non_blocking=True)
+```
+
+Prerequisite for effective DataLoader-based async data loading (sibling
+issue `01-training-no-dataloader.md`).

--- a/docs/issues-to-file/03-omp-num-threads-trap.md
+++ b/docs/issues-to-file/03-omp-num-threads-trap.md
@@ -1,0 +1,43 @@
+# Training recipe: GENERATE.sh relies on OMP_NUM_THREADS=1 but it's not obvious from the code
+
+## Observation
+
+The public release recipe `models_class1_pan/GENERATE.sh` sets at line 60:
+
+```bash
+export OMP_NUM_THREADS=1
+```
+
+Without this, numpy/MKL inside each mhcflurry worker multi-threads across
+all available CPU cores. With N parallel workers (one per GPU on a
+multi-GPU box), you get N × cores threads fighting for cores = extreme
+oversubscription.
+
+## Impact (reproduced)
+
+On Brev `denvr_A100_sxm4x8` (120 vCPUs, 8 A100s), running the release-exact
+GENERATE.sh port **without** `OMP_NUM_THREADS=1`:
+
+- Load average: **713** (6× oversubscription)
+- Per-epoch wall time: **200–450 s** for 1024×512 dense (should be <10 s on A100)
+- GPU memory utilization: **1–5%** across all 8 GPUs
+- ~9 networks trained in 11 hours vs expected ~20–40 networks
+
+After adding `OMP_NUM_THREADS=1` to the recipe, the bottleneck disappears.
+
+## Suggestion
+
+This should either:
+
+1. **Be set inside mhcflurry's training code** when it spawns workers
+   (`cluster_parallelism.py` or `class1_train_pan_allele_models.py`), so
+   users running a raw `mhcflurry-class1-train-pan-allele-models` without
+   the recipe wrapper still benefit.
+
+2. **Be prominently documented** in the training docs / README. It's
+   currently just a line in the release GENERATE.sh that you'd miss if
+   porting the recipe or writing a new harness.
+
+Option (1) is probably safer — any sharp edge that the public recipe's
+author learned the hard way should be encoded in the library, not left to
+rediscovery.

--- a/jobs/pan_allele_dsl.py
+++ b/jobs/pan_allele_dsl.py
@@ -29,7 +29,7 @@ image = (
     Image.from_registry("pytorch/pytorch:2.4.0-cuda12.1-cudnn9-runtime")
     .apt_install("bzip2", "wget", "rsync", "build-essential", "git")
     .pip_install(
-        "runplz>=3.6.2",  # the in-container bootstrap runs `python -m runplz._bootstrap`
+        "runplz>=3.7.2",  # the in-container bootstrap runs `python -m runplz._bootstrap`
         "pandas>=2.0",
         "appdirs",
         "scikit-learn",

--- a/jobs/pan_allele_dsl.py
+++ b/jobs/pan_allele_dsl.py
@@ -15,7 +15,15 @@ from runplz import App, BrevConfig, Image
 
 app = App(
     "pan-allele-dsl",
-    brev=BrevConfig(auto_create=True, mode="container"),
+    brev=BrevConfig(
+        auto_create=True,
+        mode="container",
+        # Pin Denvr A100 (40GB) — known-reliable provider. The default
+        # cheapest match is MassedCompute, whose DGX-class boxes have
+        # been observed "RUNNING" on Brev's side but unreachable on
+        # port 2222 for extended periods.
+        instance_type="denvr_A100_sxm4",
+    ),
 )
 
 image = (

--- a/jobs/pan_allele_dsl.py
+++ b/jobs/pan_allele_dsl.py
@@ -29,7 +29,7 @@ image = (
     Image.from_registry("pytorch/pytorch:2.4.0-cuda12.1-cudnn9-runtime")
     .apt_install("bzip2", "wget", "rsync", "build-essential", "git")
     .pip_install(
-        "runplz>=3.2.0",  # the in-container bootstrap runs `python -m runplz._bootstrap`
+        "runplz>=3.6.2",  # the in-container bootstrap runs `python -m runplz._bootstrap`
         "pandas>=2.0",
         "appdirs",
         "scikit-learn",

--- a/jobs/pan_allele_dsl.py
+++ b/jobs/pan_allele_dsl.py
@@ -16,7 +16,6 @@ from runplz import App, BrevConfig, Image
 app = App(
     "pan-allele-dsl",
     brev=BrevConfig(
-        auto_create=True,
         mode="container",
         # Pin Denvr A100 (40GB) — known-reliable provider. The default
         # cheapest match is MassedCompute, whose DGX-class boxes have

--- a/jobs/pan_allele_dsl.py
+++ b/jobs/pan_allele_dsl.py
@@ -15,7 +15,7 @@ from runplz import App, BrevConfig, Image
 
 app = App(
     "pan-allele-dsl",
-    brev=BrevConfig(
+    brev_config=BrevConfig(
         mode="container",
         # Pin Denvr A100 (40GB) — known-reliable provider. The default
         # cheapest match is MassedCompute, whose DGX-class boxes have
@@ -29,7 +29,7 @@ image = (
     Image.from_registry("pytorch/pytorch:2.4.0-cuda12.1-cudnn9-runtime")
     .apt_install("bzip2", "wget", "rsync", "build-essential", "git")
     .pip_install(
-        "runplz>=1.5.0",  # the in-container bootstrap runs `python -m runplz._bootstrap`
+        "runplz>=3.0.0",  # the in-container bootstrap runs `python -m runplz._bootstrap`
         "pandas>=2.0",
         "appdirs",
         "scikit-learn",

--- a/jobs/pan_allele_dsl.py
+++ b/jobs/pan_allele_dsl.py
@@ -15,7 +15,7 @@ from runplz import App, BrevConfig, Image
 
 app = App(
     "pan-allele-dsl",
-    brev=BrevConfig(auto_create=False, mode="vm"),
+    brev=BrevConfig(auto_create=True, mode="container"),
 )
 
 image = (
@@ -39,10 +39,10 @@ image = (
     # Resource requests — GB for everything memory/disk-related.
     # 26 GB RAM avoids the SIGKILL we hit on 16 GB boxes during
     # mhcflurry's full-data peptide encoding.
-    gpu="T4",
+    gpu="A100",
     min_cpu=4,
     min_memory=26,         # GB
-    min_gpu_memory=16,     # GB VRAM
+    min_gpu_memory=40,     # GB VRAM (A100-40GB)
     min_disk=100,          # GB
     timeout=6 * 60 * 60,
     env={

--- a/jobs/pan_allele_dsl.py
+++ b/jobs/pan_allele_dsl.py
@@ -30,6 +30,7 @@ image = (
     Image.from_registry("pytorch/pytorch:2.4.0-cuda12.1-cudnn9-runtime")
     .apt_install("bzip2", "wget", "rsync", "build-essential", "git")
     .pip_install(
+        "runplz>=1.4.2",  # the in-container bootstrap runs `python -m runplz._bootstrap`
         "pandas>=2.0",
         "appdirs",
         "scikit-learn",

--- a/jobs/pan_allele_dsl.py
+++ b/jobs/pan_allele_dsl.py
@@ -29,7 +29,7 @@ image = (
     Image.from_registry("pytorch/pytorch:2.4.0-cuda12.1-cudnn9-runtime")
     .apt_install("bzip2", "wget", "rsync", "build-essential", "git")
     .pip_install(
-        "runplz>=3.0.0",  # the in-container bootstrap runs `python -m runplz._bootstrap`
+        "runplz>=3.2.0",  # the in-container bootstrap runs `python -m runplz._bootstrap`
         "pandas>=2.0",
         "appdirs",
         "scikit-learn",

--- a/jobs/pan_allele_dsl.py
+++ b/jobs/pan_allele_dsl.py
@@ -30,7 +30,7 @@ image = (
     Image.from_registry("pytorch/pytorch:2.4.0-cuda12.1-cudnn9-runtime")
     .apt_install("bzip2", "wget", "rsync", "build-essential", "git")
     .pip_install(
-        "runplz>=1.4.2",  # the in-container bootstrap runs `python -m runplz._bootstrap`
+        "runplz>=1.5.0",  # the in-container bootstrap runs `python -m runplz._bootstrap`
         "pandas>=2.0",
         "appdirs",
         "scikit-learn",

--- a/jobs/pan_allele_omp_smoketest.py
+++ b/jobs/pan_allele_omp_smoketest.py
@@ -27,7 +27,7 @@ image = (
     Image.from_registry("pytorch/pytorch:2.4.0-cuda12.1-cudnn9-runtime")
     .apt_install("bzip2", "wget", "rsync", "build-essential", "git")
     .pip_install(
-        "runplz>=3.2.0",
+        "runplz>=3.6.2",
         "pandas>=2.0",
         "appdirs",
         "scikit-learn",

--- a/jobs/pan_allele_omp_smoketest.py
+++ b/jobs/pan_allele_omp_smoketest.py
@@ -27,7 +27,7 @@ image = (
     Image.from_registry("pytorch/pytorch:2.4.0-cuda12.1-cudnn9-runtime")
     .apt_install("bzip2", "wget", "rsync", "build-essential", "git")
     .pip_install(
-        "runplz>=3.0.0",
+        "runplz>=3.2.0",
         "pandas>=2.0",
         "appdirs",
         "scikit-learn",

--- a/jobs/pan_allele_omp_smoketest.py
+++ b/jobs/pan_allele_omp_smoketest.py
@@ -20,7 +20,7 @@ from runplz import App, BrevConfig, Image
 
 app = App(
     "pan-allele-omp-smoketest",
-    brev=BrevConfig(auto_create=True, mode="container", instance_type="denvr_A100_sxm4"),
+    brev=BrevConfig(mode="container", instance_type="denvr_A100_sxm4"),
 )
 
 image = (

--- a/jobs/pan_allele_omp_smoketest.py
+++ b/jobs/pan_allele_omp_smoketest.py
@@ -27,7 +27,7 @@ image = (
     Image.from_registry("pytorch/pytorch:2.4.0-cuda12.1-cudnn9-runtime")
     .apt_install("bzip2", "wget", "rsync", "build-essential", "git")
     .pip_install(
-        "runplz>=3.6.2",
+        "runplz>=3.7.2",
         "pandas>=2.0",
         "appdirs",
         "scikit-learn",

--- a/jobs/pan_allele_omp_smoketest.py
+++ b/jobs/pan_allele_omp_smoketest.py
@@ -1,0 +1,64 @@
+"""OMP smoke test — verifies OMP_NUM_THREADS=1 gives the expected
+per-epoch speedup on a single A100 before committing to the expensive
+full release-exact run.
+
+Launch:
+    runplz brev --instance mhcflurry-omp-smoketest jobs/pan_allele_omp_smoketest.py
+
+Expected wall time: ~30-60 min (fetch + 1 fold × 2 arches × ≤20 epochs
+with pretrain capped at 5 epochs). Budget: ~$3 on denvr_A100_sxm4.
+
+Success signal: per-epoch times in LOG-worker.*.txt show <20 sec/epoch
+(ideally <10). Failure signal: >50 sec/epoch means OMP fix didn't help
+or there's a different bottleneck.
+"""
+
+import os
+import subprocess
+
+from runplz import App, BrevConfig, Image
+
+app = App(
+    "pan-allele-omp-smoketest",
+    brev=BrevConfig(auto_create=True, mode="container", instance_type="denvr_A100_sxm4"),
+)
+
+image = (
+    Image.from_registry("pytorch/pytorch:2.4.0-cuda12.1-cudnn9-runtime")
+    .apt_install("bzip2", "wget", "rsync", "build-essential", "git")
+    .pip_install(
+        "runplz>=1.5.0",
+        "pandas>=2.0",
+        "appdirs",
+        "scikit-learn",
+        "mhcgnomes>=3.0.1",
+        "numpy>=1.22.4",
+        "pyyaml",
+        "tqdm",
+    )
+    .pip_install_local_dir(".", editable=True)
+)
+
+
+@app.function(
+    image=image,
+    gpu="A100",
+    min_cpu=4,
+    min_memory=26,
+    min_gpu_memory=40,
+    min_disk=100,
+    timeout=2 * 60 * 60,
+)
+def train():
+    env = os.environ.copy()
+    env["MHCFLURRY_OUT"] = env["RUNPLZ_OUT"]
+    subprocess.run(
+        ["bash", "scripts/training/pan_allele_omp_smoketest.sh"],
+        check=True,
+        env=env,
+    )
+
+
+@app.local_entrypoint()
+def main():
+    train.remote()

--- a/jobs/pan_allele_omp_smoketest.py
+++ b/jobs/pan_allele_omp_smoketest.py
@@ -20,14 +20,14 @@ from runplz import App, BrevConfig, Image
 
 app = App(
     "pan-allele-omp-smoketest",
-    brev=BrevConfig(mode="container", instance_type="denvr_A100_sxm4"),
+    brev_config=BrevConfig(mode="container", instance_type="denvr_A100_sxm4"),
 )
 
 image = (
     Image.from_registry("pytorch/pytorch:2.4.0-cuda12.1-cudnn9-runtime")
     .apt_install("bzip2", "wget", "rsync", "build-essential", "git")
     .pip_install(
-        "runplz>=1.5.0",
+        "runplz>=3.0.0",
         "pandas>=2.0",
         "appdirs",
         "scikit-learn",

--- a/jobs/pan_allele_presentation_subset.py
+++ b/jobs/pan_allele_presentation_subset.py
@@ -27,15 +27,23 @@ app = App(
     "pan-allele-presentation-subset",
     brev_config=BrevConfig(
         mode="container",
-        instance_type="denvr_A100_sxm4x8",
+        # Single-A100 fallback — org's $30/hr cap blocks GCP 8×A100, and
+        # verda/massedcompute 8×A100 shadeform paths both went STATUS:
+        # FAILURE. MassedCompute 1×A100-80GB is $1.49/hr, 2m30s boot,
+        # reliable historically. Wall time ~8-12 hr vs 4-6 hr on 8×.
+        instance_type="massedcompute_A100_sxm4_80G",
+        auto_create_instances=True,
     ),
 )
 
 image = (
-    Image.from_registry("pytorch/pytorch:2.4.0-cuda12.1-cudnn9-runtime")
+    # devel variant ships `nsys` (Nsight Systems CLI) at
+    # /usr/local/cuda/bin/nsys — needed for the NSYS_PROFILE=1 gate in
+    # scripts/training/pan_allele_presentation_subset.sh.
+    Image.from_registry("pytorch/pytorch:2.4.0-cuda12.1-cudnn9-devel")
     .apt_install("bzip2", "wget", "rsync", "build-essential", "git")
     .pip_install(
-        "runplz>=3.0.0",
+        "runplz>=3.2.0",
         "pandas>=2.0",
         "appdirs",
         "scikit-learn",
@@ -51,11 +59,20 @@ image = (
 @app.function(
     image=image,
     gpu="A100",
-    min_cpu=96,
-    min_memory=400,
+    # Sized for the pinned 1×A100-80GB MassedCompute shape (14 vCPU,
+    # ~80 GB RAM, 625 GB disk, 80 GB VRAM). Overstating min_cpu/min_memory
+    # here has previously blocked `brev search` from matching the shape.
+    min_cpu=14,
+    min_memory=80,
     min_gpu_memory=40,
-    min_disk=1000,
-    timeout=10 * 60 * 60,  # 10h cap; expect 4-6h
+    min_disk=100,
+    timeout=18 * 60 * 60,  # 18h cap; single-GPU wall time ~8-12h
+    env={
+        # Wrap stage 1 affinity training in `nsys profile` for the first
+        # ~3 min to capture a representative slice (startup + pretrain +
+        # first finetune epochs). Rest of the run is uninstrumented.
+        "NSYS_PROFILE": "1",
+    },
 )
 def train():
     env = os.environ.copy()

--- a/jobs/pan_allele_presentation_subset.py
+++ b/jobs/pan_allele_presentation_subset.py
@@ -43,7 +43,7 @@ image = (
     Image.from_registry("pytorch/pytorch:2.4.0-cuda12.1-cudnn9-devel")
     .apt_install("bzip2", "wget", "rsync", "build-essential", "git")
     .pip_install(
-        "runplz>=3.2.0",
+        "runplz>=3.6.2",
         "pandas>=2.0",
         "appdirs",
         "scikit-learn",

--- a/jobs/pan_allele_presentation_subset.py
+++ b/jobs/pan_allele_presentation_subset.py
@@ -1,0 +1,72 @@
+"""Full presentation-predictor subset run: affinity → processing →
+presentation end-to-end, but with a small per-variant architecture
+sweep so the whole pipeline fits in ~$100 on 8×A100.
+
+Launch:
+    runplz brev --instance mhcflurry-presentation-subset \
+        jobs/pan_allele_presentation_subset.py
+
+Stages (with OMP_NUM_THREADS=1 now set everywhere):
+  1. Affinity — 4 folds × 8 architectures × 1 replicate (32 networks)
+  2. Processing — 4 folds × 8 architectures × 2 variants
+     (no_flank + short_flanks, which are the ones Class1PresentationPredictor
+     actually consumes; with_flanks is skipped) = 64 networks
+  3. Presentation — logistic regression over (affinity, processing);
+     cheap (minutes), plus percentile-rank calibration.
+
+Pinned to denvr_A100_sxm4x8 at $12/hr; expected wall time ~4-6 hours
+including boot + data downloads.
+"""
+
+import os
+import subprocess
+
+from runplz import App, BrevConfig, Image
+
+app = App(
+    "pan-allele-presentation-subset",
+    brev_config=BrevConfig(
+        mode="container",
+        instance_type="denvr_A100_sxm4x8",
+    ),
+)
+
+image = (
+    Image.from_registry("pytorch/pytorch:2.4.0-cuda12.1-cudnn9-runtime")
+    .apt_install("bzip2", "wget", "rsync", "build-essential", "git")
+    .pip_install(
+        "runplz>=3.0.0",
+        "pandas>=2.0",
+        "appdirs",
+        "scikit-learn",
+        "mhcgnomes>=3.0.1",
+        "numpy>=1.22.4",
+        "pyyaml",
+        "tqdm",
+    )
+    .pip_install_local_dir(".", editable=True)
+)
+
+
+@app.function(
+    image=image,
+    gpu="A100",
+    min_cpu=96,
+    min_memory=400,
+    min_gpu_memory=40,
+    min_disk=1000,
+    timeout=10 * 60 * 60,  # 10h cap; expect 4-6h
+)
+def train():
+    env = os.environ.copy()
+    env["MHCFLURRY_OUT"] = env["RUNPLZ_OUT"]
+    subprocess.run(
+        ["bash", "scripts/training/pan_allele_presentation_subset.sh"],
+        check=True,
+        env=env,
+    )
+
+
+@app.local_entrypoint()
+def main():
+    train.remote()

--- a/jobs/pan_allele_presentation_subset.py
+++ b/jobs/pan_allele_presentation_subset.py
@@ -43,7 +43,7 @@ image = (
     Image.from_registry("pytorch/pytorch:2.4.0-cuda12.1-cudnn9-devel")
     .apt_install("bzip2", "wget", "rsync", "build-essential", "git")
     .pip_install(
-        "runplz>=3.6.2",
+        "runplz>=3.7.2",
         "pandas>=2.0",
         "appdirs",
         "scikit-learn",

--- a/jobs/pan_allele_release_exact.py
+++ b/jobs/pan_allele_release_exact.py
@@ -56,9 +56,15 @@ image = (
     min_disk=1000,       # GB — ~140 networks × ~10MB weights + init info
     timeout=60 * 60 * 60,  # 60 hours — safety margin above 28h estimate
     env={
-        # MHCFLURRY_OUT is wired to RUNPLZ_OUT inside train() so we
-        # don't hard-code a container path that conflicts with the
-        # backend's chosen output dir. Everything else is default.
+        # denvr_A100_sxm4x8 is 8× A100-40GB. Per-worker GPU memory on
+        # mhcflurry pan-allele training peaks at 16-22 GB during
+        # pretrain validation inference — tight on a 40 GB card.
+        # MAX_WORKERS_PER_GPU=1 gives us 8 workers across 8 GPUs. The
+        # NonDaemonPool (Phase 2 #268) means each training worker can
+        # still spawn its own DataLoader prefetch workers on top of
+        # that, but those consume CPU + host RAM, not VRAM, so no
+        # additional pressure on the A100.
+        "MAX_WORKERS_PER_GPU": "1",
     },
 )
 def train():

--- a/jobs/pan_allele_release_exact.py
+++ b/jobs/pan_allele_release_exact.py
@@ -1,0 +1,80 @@
+"""Exact replication of the public mhcflurry pan-allele release training
+recipe (models_class1_pan 2.2.0): same pretraining, same curated data,
+same 4 folds, same 35-architecture sweep, same selection step
+(--min-models 2 --max-models 8), same percentile-rank calibration.
+
+Launch:
+    runplz brev --instance mhcflurry-release-exact jobs/pan_allele_release_exact.py
+
+Compute: ~140 networks × ~90 min each on A100 → ~210 GPU-hours. On the
+pinned 8×A100 box that's ~28 hours wall-clock, ~$336.
+
+If the ssh session drops mid-run, re-launch runplz with the same command;
+the shell script uses `--continue-incomplete` to resume from the
+unselected/ checkpoint directory.
+"""
+
+import os
+import subprocess
+
+from runplz import App, BrevConfig, Image
+
+app = App(
+    "pan-allele-release-exact",
+    brev=BrevConfig(
+        auto_create=True,
+        mode="container",
+        # 8×A100-40GB, 120 vCPUs, 14 TB disk at $12/hr. Denvr has been
+        # reliable for us (MassedCompute timed out on SSH earlier). VRAM
+        # at 40GB is plenty — individual networks fit comfortably.
+        instance_type="denvr_A100_sxm4x8",
+    ),
+)
+
+image = (
+    Image.from_registry("pytorch/pytorch:2.4.0-cuda12.1-cudnn9-runtime")
+    .apt_install("bzip2", "wget", "rsync", "build-essential", "git")
+    .pip_install(
+        "runplz>=1.4.2",
+        "pandas>=2.0",
+        "appdirs",
+        "scikit-learn",
+        "mhcgnomes>=3.0.1",
+        "numpy>=1.22.4",
+        "pyyaml",
+        "tqdm",
+    )
+    .pip_install_local_dir(".", editable=True)
+)
+
+
+@app.function(
+    image=image,
+    gpu="A100",
+    min_cpu=96,          # match the 8-GPU machine's vCPU budget
+    min_memory=400,      # GB RAM — full data + pretraining buffer
+    min_gpu_memory=40,   # GB VRAM per GPU
+    min_disk=1000,       # GB — ~140 networks × ~10MB weights + init info
+    timeout=60 * 60 * 60,  # 60 hours — safety margin above 28h estimate
+    env={
+        # MHCFLURRY_OUT is wired to RUNPLZ_OUT inside train() so we
+        # don't hard-code a container path that conflicts with the
+        # backend's chosen output dir. Everything else is default.
+    },
+)
+def train():
+    # In Brev container-mode, RUNPLZ_OUT resolves to $HOME/runplz-out,
+    # which is where the backend will rsync from. The training shell
+    # script reads MHCFLURRY_OUT — point it at the same dir.
+    env = os.environ.copy()
+    env["MHCFLURRY_OUT"] = env["RUNPLZ_OUT"]
+    subprocess.run(
+        ["bash", "scripts/training/pan_allele_release_exact.sh"],
+        check=True,
+        env=env,
+    )
+
+
+@app.local_entrypoint()
+def main():
+    train.remote()

--- a/jobs/pan_allele_release_exact.py
+++ b/jobs/pan_allele_release_exact.py
@@ -35,7 +35,7 @@ image = (
     Image.from_registry("pytorch/pytorch:2.4.0-cuda12.1-cudnn9-runtime")
     .apt_install("bzip2", "wget", "rsync", "build-essential", "git")
     .pip_install(
-        "runplz>=1.4.2",
+        "runplz>=1.5.0",
         "pandas>=2.0",
         "appdirs",
         "scikit-learn",

--- a/jobs/pan_allele_release_exact.py
+++ b/jobs/pan_allele_release_exact.py
@@ -34,7 +34,7 @@ image = (
     Image.from_registry("pytorch/pytorch:2.4.0-cuda12.1-cudnn9-runtime")
     .apt_install("bzip2", "wget", "rsync", "build-essential", "git")
     .pip_install(
-        "runplz>=3.0.0",
+        "runplz>=3.2.0",
         "pandas>=2.0",
         "appdirs",
         "scikit-learn",

--- a/jobs/pan_allele_release_exact.py
+++ b/jobs/pan_allele_release_exact.py
@@ -28,11 +28,17 @@ app = App(
         # 2026-04-21 (Brev API EOF, mid-boot SSH drop, 1200s SSH
         # timeout). 80GB cards unlock MAX_WORKERS_PER_GPU=2 for 16
         # concurrent workers (vs 8 on 40GB Denvr) — halves wall time.
-        # Runplz 3.6.2 brought transient-EOF retry + SIGTERM cleanup
-        # so the earlier MassedCompute shadeform failures should no
-        # longer be as reliable a blocker.
         instance_type="massedcompute_A100_sxm4_80G_DGXx8",
         auto_create_instances=True,
+        # 8×A100 boots take 20-30 min on some provisioners (Denvr
+        # and MassedCompute DGXx8 both stretched past runplz's old
+        # 1200s default on 2026-04-21). 2400s = 40 min gives us
+        # enough headroom to outlast supply-constrained provisioning
+        # queues without being patient enough to burn a full hour on
+        # a truly dead instance. Runplz 3.7.2's new default is 1800s;
+        # this override is because DGXx8 specifically has been near
+        # the boundary. Closes runplz #34.
+        ssh_ready_wait_seconds=2400,
     ),
 )
 
@@ -40,7 +46,7 @@ image = (
     Image.from_registry("pytorch/pytorch:2.4.0-cuda12.1-cudnn9-runtime")
     .apt_install("bzip2", "wget", "rsync", "build-essential", "git")
     .pip_install(
-        "runplz>=3.6.2",
+        "runplz>=3.7.2",
         "pandas>=2.0",
         "appdirs",
         "scikit-learn",

--- a/jobs/pan_allele_release_exact.py
+++ b/jobs/pan_allele_release_exact.py
@@ -23,10 +23,16 @@ app = App(
     "pan-allele-release-exact",
     brev_config=BrevConfig(
         mode="container",
-        # 8×A100-40GB, 120 vCPUs, 14 TB disk at $12/hr. Denvr has been
-        # reliable for us (MassedCompute timed out on SSH earlier). VRAM
-        # at 40GB is plenty — individual networks fit comfortably.
-        instance_type="denvr_A100_sxm4x8",
+        # MassedCompute 8×A100-80GB DGXx8, 120 vCPUs, 10 TB disk at
+        # $12.29/hr. Chose over Denvr after 3/3 Denvr failures on
+        # 2026-04-21 (Brev API EOF, mid-boot SSH drop, 1200s SSH
+        # timeout). 80GB cards unlock MAX_WORKERS_PER_GPU=2 for 16
+        # concurrent workers (vs 8 on 40GB Denvr) — halves wall time.
+        # Runplz 3.6.2 brought transient-EOF retry + SIGTERM cleanup
+        # so the earlier MassedCompute shadeform failures should no
+        # longer be as reliable a blocker.
+        instance_type="massedcompute_A100_sxm4_80G_DGXx8",
+        auto_create_instances=True,
     ),
 )
 
@@ -34,7 +40,7 @@ image = (
     Image.from_registry("pytorch/pytorch:2.4.0-cuda12.1-cudnn9-runtime")
     .apt_install("bzip2", "wget", "rsync", "build-essential", "git")
     .pip_install(
-        "runplz>=3.2.0",
+        "runplz>=3.6.2",
         "pandas>=2.0",
         "appdirs",
         "scikit-learn",
@@ -56,15 +62,12 @@ image = (
     min_disk=1000,       # GB — ~140 networks × ~10MB weights + init info
     timeout=60 * 60 * 60,  # 60 hours — safety margin above 28h estimate
     env={
-        # denvr_A100_sxm4x8 is 8× A100-40GB. Per-worker GPU memory on
-        # mhcflurry pan-allele training peaks at 16-22 GB during
-        # pretrain validation inference — tight on a 40 GB card.
-        # MAX_WORKERS_PER_GPU=1 gives us 8 workers across 8 GPUs. The
-        # NonDaemonPool (Phase 2 #268) means each training worker can
-        # still spawn its own DataLoader prefetch workers on top of
-        # that, but those consume CPU + host RAM, not VRAM, so no
-        # additional pressure on the A100.
-        "MAX_WORKERS_PER_GPU": "1",
+        # massedcompute_A100_sxm4_80G_DGXx8 is 8× A100-80GB. 80GB cards
+        # fit 2 workers (each ~20 GB peak VRAM during validation
+        # inference), unlocking 16 concurrent training workers across
+        # 8 GPUs. With Phase 2 NonDaemonPool, each worker's DataLoader
+        # prefetch path is live in production too.
+        "MAX_WORKERS_PER_GPU": "2",
     },
 )
 def train():

--- a/jobs/pan_allele_release_exact.py
+++ b/jobs/pan_allele_release_exact.py
@@ -23,21 +23,26 @@ app = App(
     "pan-allele-release-exact",
     brev_config=BrevConfig(
         mode="container",
-        # MassedCompute 8×A100-80GB DGXx8, 120 vCPUs, 10 TB disk at
-        # $12.29/hr. Chose over Denvr after 3/3 Denvr failures on
-        # 2026-04-21 (Brev API EOF, mid-boot SSH drop, 1200s SSH
-        # timeout). 80GB cards unlock MAX_WORKERS_PER_GPU=2 for 16
-        # concurrent workers (vs 8 on 40GB Denvr) — halves wall time.
-        instance_type="massedcompute_A100_sxm4_80G_DGXx8",
+        # OCI 8×A100-80GB via Brev's direct launchpad integration.
+        # $19.30/hr, 128 vCPUs, 27 TB disk, 15 min boot.
+        #
+        # Routes around the shadeform broker entirely. All 5 failed
+        # 2026-04-21 provisioning attempts (3× Denvr, 2× MassedCompute
+        # DGXx8) went through shadeform and failed with
+        # `external nodes: skipping (list failed): not_found` — the
+        # shadeform broker losing track of its own capacity pool.
+        # OCI launchpad is a different provisioning path (direct from
+        # NVIDIA Brev to Oracle) so it's immune to that class of
+        # failure.
+        #
+        # 80GB cards support MAX_WORKERS_PER_GPU=2 = 16 concurrent
+        # workers (vs 8 on 40GB). Cost delta over MassedCompute
+        # ($19.30 vs $12.29/hr, +57%) is acceptable given 5/5
+        # shadeform failures today.
+        instance_type="oci.a100x8.sxm.brev-dgxc",
         auto_create_instances=True,
-        # 8×A100 boots take 20-30 min on some provisioners (Denvr
-        # and MassedCompute DGXx8 both stretched past runplz's old
-        # 1200s default on 2026-04-21). 2400s = 40 min gives us
-        # enough headroom to outlast supply-constrained provisioning
-        # queues without being patient enough to burn a full hour on
-        # a truly dead instance. Runplz 3.7.2's new default is 1800s;
-        # this override is because DGXx8 specifically has been near
-        # the boundary. Closes runplz #34.
+        # OCI boot advertised at 15 min; give 40 min margin against
+        # launchpad's own provisioning queue. Closes runplz #34.
         ssh_ready_wait_seconds=2400,
     ),
 )

--- a/jobs/pan_allele_release_exact.py
+++ b/jobs/pan_allele_release_exact.py
@@ -22,7 +22,6 @@ from runplz import App, BrevConfig, Image
 app = App(
     "pan-allele-release-exact",
     brev=BrevConfig(
-        auto_create=True,
         mode="container",
         # 8×A100-40GB, 120 vCPUs, 14 TB disk at $12/hr. Denvr has been
         # reliable for us (MassedCompute timed out on SSH earlier). VRAM

--- a/jobs/pan_allele_release_exact.py
+++ b/jobs/pan_allele_release_exact.py
@@ -21,7 +21,7 @@ from runplz import App, BrevConfig, Image
 
 app = App(
     "pan-allele-release-exact",
-    brev=BrevConfig(
+    brev_config=BrevConfig(
         mode="container",
         # 8×A100-40GB, 120 vCPUs, 14 TB disk at $12/hr. Denvr has been
         # reliable for us (MassedCompute timed out on SSH earlier). VRAM
@@ -34,7 +34,7 @@ image = (
     Image.from_registry("pytorch/pytorch:2.4.0-cuda12.1-cudnn9-runtime")
     .apt_install("bzip2", "wget", "rsync", "build-essential", "git")
     .pip_install(
-        "runplz>=1.5.0",
+        "runplz>=3.0.0",
         "pandas>=2.0",
         "appdirs",
         "scikit-learn",

--- a/jobs/pan_allele_smoketest.py
+++ b/jobs/pan_allele_smoketest.py
@@ -9,7 +9,7 @@ from runplz import App, BrevConfig, Image
 
 app = App(
     "pan-allele-smoketest",
-    brev=BrevConfig(auto_create=False),
+    brev_config=BrevConfig(auto_create_instances=False),
 )
 
 image = Image.from_dockerfile("docker/Dockerfile.train")

--- a/mhcflurry/class1_affinity_predictor.py
+++ b/mhcflurry/class1_affinity_predictor.py
@@ -1111,6 +1111,72 @@ class Class1AffinityPredictor(object):
                 sub_df.affinity, allele=allele, throw=throw)
         return df.result.values
 
+    def _prepare_peptides_with_optional_cache(
+            self, peptides, *, encoding_cache_dir=None):
+        """Return an EncodableSequences for the predict path.
+
+        If ``encoding_cache_dir`` is None: identical to
+        ``EncodableSequences.create(peptides)`` — current behavior.
+
+        If set, resolves the peptide_encoding params from the first
+        neural network's hyperparameters, looks up / builds the cache
+        entry for this peptide list, and returns an EncodableSequences
+        with the per-instance ``encoding_cache`` prepopulated.
+        Downstream calls to ``peptides_to_network_input`` in each network
+        hit the prepopulated cache and skip the BLOSUM62 pass.
+
+        When the ensemble's networks have heterogeneous
+        ``peptide_encoding`` configs, only the networks matching the
+        cache params benefit. Other networks fall through to direct
+        encoding — their peptides_to_network_input call misses the
+        cache and runs the encoder normally. No correctness impact.
+        """
+        if encoding_cache_dir is None:
+            return EncodableSequences.create(peptides)
+
+        # Need at least one network to read the encoding config from.
+        if not self.neural_networks:
+            return EncodableSequences.create(peptides)
+
+        # Import locally so module-level import doesn't pull cache deps
+        # into mhcflurry startup for callers who never use the cache.
+        from .encoding_cache import (
+            EncodingCache,
+            EncodingParams,
+            make_preencoded_encodable_sequences,
+        )
+
+        cfg = self.neural_networks[0].hyperparameters.get(
+            "peptide_encoding", {}
+        )
+        try:
+            params = EncodingParams(**cfg)
+        except TypeError:
+            # Unknown kwargs (e.g. a new field we don't support) — fall
+            # back to direct encoding rather than crash the predict call.
+            logging.warning(
+                "encoding_cache_dir was set but peptide_encoding %r "
+                "contains kwargs not accepted by EncodingParams. Falling "
+                "back to uncached encoding.", cfg
+            )
+            return EncodableSequences.create(peptides)
+
+        # Normalize peptide list; EncodingCache hashes list order +
+        # content, so consistent list type matters.
+        if hasattr(peptides, "sequences"):
+            peptide_list = list(peptides.sequences)
+        else:
+            peptide_list = list(peptides)
+
+        if not peptide_list:
+            return EncodableSequences.create(peptides)
+
+        cache = EncodingCache(cache_dir=encoding_cache_dir, params=params)
+        encoded, _peptide_to_idx = cache.get_or_build(peptide_list)
+        return make_preencoded_encodable_sequences(
+            peptide_list, encoded, params
+        )
+
     def predict(
             self,
             peptides,
@@ -1118,7 +1184,8 @@ class Class1AffinityPredictor(object):
             allele=None,
             throw=True,
             centrality_measure=DEFAULT_CENTRALITY_MEASURE,
-            model_kwargs={}):
+            model_kwargs={},
+            encoding_cache_dir=None):
         """
         Predict nM binding affinities.
 
@@ -1144,6 +1211,17 @@ class Class1AffinityPredictor(object):
             ensemble. Options include: mean, median, robust_mean.
         model_kwargs : dict
             Additional keyword arguments to pass to Class1NeuralNetwork.predict
+        encoding_cache_dir : string, optional
+            Directory for a shared BLOSUM62 peptide encoding cache. When set,
+            the peptide encoding is computed once (or memmap-loaded if the
+            cache entry already exists) and all networks in the ensemble hit
+            the prepopulated cache instead of re-encoding. Useful when the
+            same peptide list is scored by multiple predictors (e.g.
+            comparing against a reference model) or across many calls.
+            Uses ``self.neural_networks[0].hyperparameters["peptide_encoding"]``
+            to determine the cache params. Silently falls back to direct
+            encoding if the ensemble contains networks with heterogeneous
+            peptide_encoding configs (none matches would cache-miss anyway).
 
         Returns
         -------
@@ -1157,7 +1235,8 @@ class Class1AffinityPredictor(object):
             include_percentile_ranks=False,
             include_confidence_intervals=False,
             centrality_measure=centrality_measure,
-            model_kwargs=model_kwargs
+            model_kwargs=model_kwargs,
+            encoding_cache_dir=encoding_cache_dir,
         )
         return df.prediction.values
 
@@ -1171,7 +1250,8 @@ class Class1AffinityPredictor(object):
             include_percentile_ranks=True,
             include_confidence_intervals=True,
             centrality_measure=DEFAULT_CENTRALITY_MEASURE,
-            model_kwargs={}):
+            model_kwargs={},
+            encoding_cache_dir=None):
         """
         Predict nM binding affinities. Gives more detailed output than `predict`
         method, including 5-95% prediction intervals.
@@ -1217,7 +1297,9 @@ class Class1AffinityPredictor(object):
         if allele is None and alleles is None:
             raise ValueError("Must specify 'allele' or 'alleles'.")
 
-        peptides = EncodableSequences.create(peptides)
+        peptides = self._prepare_peptides_with_optional_cache(
+            peptides, encoding_cache_dir=encoding_cache_dir
+        )
         df = pandas.DataFrame({
             'peptide': peptides.sequences
         }, copy=False)

--- a/mhcflurry/class1_affinity_predictor.py
+++ b/mhcflurry/class1_affinity_predictor.py
@@ -1143,7 +1143,7 @@ class Class1AffinityPredictor(object):
         from .encoding_cache import (
             EncodingCache,
             EncodingParams,
-            make_preencoded_encodable_sequences,
+            make_prepopulated_encodable_sequences,
         )
 
         cfg = self.neural_networks[0].hyperparameters.get(
@@ -1173,7 +1173,7 @@ class Class1AffinityPredictor(object):
 
         cache = EncodingCache(cache_dir=encoding_cache_dir, params=params)
         encoded, _peptide_to_idx = cache.get_or_build(peptide_list)
-        return make_preencoded_encodable_sequences(
+        return make_prepopulated_encodable_sequences(
             peptide_list, encoded, params
         )
 

--- a/mhcflurry/class1_neural_network.py
+++ b/mhcflurry/class1_neural_network.py
@@ -1861,9 +1861,13 @@ class Class1NeuralNetwork(object):
                 except StopIteration:
                     break
 
-                # Convert to tensors
-                peptide_tensor = torch.from_numpy(x_dict["peptide"]).float().to(device)
-                allele_tensor = torch.from_numpy(x_dict["allele"]).float().to(device)
+                # GPU-side widening cast (see Phase 4a #268): when the
+                # encoding cache stores int8 (BLOSUM62 native width),
+                # H2D transfer is 4× smaller; widening to fp32 on GPU
+                # is essentially free. For fp32-native encodings this
+                # is a no-op.
+                peptide_tensor = torch.from_numpy(x_dict["peptide"]).to(device).float()
+                allele_tensor = torch.from_numpy(x_dict["allele"]).to(device).float()
                 y_tensor = torch.from_numpy(y.astype(numpy.float32)).to(device)
 
                 optimizer.zero_grad()
@@ -2316,26 +2320,34 @@ class Class1NeuralNetwork(object):
             )
 
             for batch in loader:
-                peptide_batch = batch["peptide"].float().to(
+                # ``.to(device).float()`` (GPU-side widening cast) is
+                # strictly better than ``.float().to(device)``:
+                #   - When the cache stores int8 (BLOSUM62 native width),
+                #     the H2D transfer is 4× smaller.
+                #   - The widening cast on GPU is ~free (wide-warp op,
+                #     often fused into the first Linear's matmul).
+                #   - When the cache already stores fp32 (other
+                #     encodings), the cast is a no-op.
+                peptide_batch = batch["peptide"].to(
                     device, non_blocking=non_blocking_h2d
-                )
+                ).float()
                 y_batch = batch["y"].to(
                     device, non_blocking=non_blocking_h2d
                 )
 
                 inputs = {"peptide": peptide_batch}
                 if "allele" in batch:
-                    inputs["allele"] = batch["allele"].float().to(
+                    inputs["allele"] = batch["allele"].to(
                         device, non_blocking=non_blocking_h2d
-                    )
+                    ).float()
 
                 optimizer.zero_grad()
                 predictions = network(inputs)
                 weights_batch = None
                 if "weight" in batch:
-                    weights_batch = batch["weight"].float().to(
+                    weights_batch = batch["weight"].to(
                         device, non_blocking=non_blocking_h2d
-                    )
+                    ).float()
                 loss = loss_obj(predictions, y_batch, sample_weights=weights_batch)
                 regularization_penalty = self._regularization_penalty(
                     regularization_parameters,

--- a/mhcflurry/class1_neural_network.py
+++ b/mhcflurry/class1_neural_network.py
@@ -6,6 +6,8 @@ import gc
 import time
 import collections
 import json
+import multiprocessing
+import sys
 import weakref
 import itertools
 import os
@@ -79,6 +81,43 @@ class _FitBatchDataset(torch.utils.data.Dataset):
         return sample
 
 
+_DAEMON_DOWNGRADE_WARNED = False
+
+
+def _effective_num_workers(num_workers):
+    """Downgrade ``num_workers`` to 0 when running inside a daemon process.
+
+    Python's ``multiprocessing`` disallows daemon processes from spawning
+    children — enforced by an ``AssertionError`` deep inside
+    ``DataLoader._MultiProcessingDataLoaderIter``. mhcflurry's training
+    orchestrator runs workers via ``multiprocessing.Pool``, whose workers
+    are daemonic by default. With ``dataloader_num_workers > 0`` that
+    detonates the whole training run at the first epoch's ``for batch
+    in loader`` line.
+
+    The right behavior under that constraint: silently fall back to
+    ``num_workers=0`` so the worker runs correctly (just without prefetch).
+    Orchestrator-level runs (e.g. tests, single-process CLI) keep the
+    configured value.
+
+    See ``test_dataloader_num_workers_downgrades_in_daemon_context`` for
+    the regression test that locks this behavior.
+    """
+    global _DAEMON_DOWNGRADE_WARNED
+    if num_workers > 0 and multiprocessing.current_process().daemon:
+        if not _DAEMON_DOWNGRADE_WARNED:
+            print(
+                f"[warn] dataloader_num_workers={num_workers} requested from a "
+                f"daemon process (mhcflurry Pool worker); downgrading to 0 to "
+                f"avoid 'daemonic processes are not allowed to have children'. "
+                f"Prefetch disabled inside this worker.",
+                file=sys.stderr,
+            )
+            _DAEMON_DOWNGRADE_WARNED = True
+        return 0
+    return num_workers
+
+
 def _make_fit_dataloader(
     dataset,
     batch_size,
@@ -94,6 +133,12 @@ def _make_fit_dataloader(
     prefetch minibatches into pinned host memory, overlapping CPU work
     with GPU compute.
 
+    If called from a daemon process (i.e. inside a
+    ``multiprocessing.Pool`` worker — the standard mhcflurry training
+    path), ``num_workers`` is forced to 0 and ``pin_memory`` to False
+    because daemon processes cannot spawn their own children. See
+    ``_effective_num_workers``.
+
     ``persistent_workers=True`` avoids respawning the worker processes
     between epochs. Currently only useful in narrow cases — ``fit()``
     constructs a new DataLoader per epoch (the x_peptide arrays change
@@ -102,14 +147,19 @@ def _make_fit_dataloader(
     Exposing the knob keeps the API forward-compatible with a Phase-2
     refactor that hoists DataLoader construction out of the epoch loop.
     """
+    effective_workers = _effective_num_workers(num_workers)
+    # pin_memory + non_blocking H2D only makes sense when prefetch workers
+    # exist to fill the pinned staging buffers. In num_workers=0 mode it
+    # just pays the pinning cost with no overlap benefit.
+    effective_pin = use_pinned_memory and effective_workers > 0
     kwargs = dict(
         dataset=dataset,
         batch_size=batch_size,
         shuffle=False,  # Dataset already reflects shuffled train_indices.
-        num_workers=num_workers,
-        pin_memory=use_pinned_memory,
+        num_workers=effective_workers,
+        pin_memory=effective_pin,
     )
-    if num_workers > 0:
+    if effective_workers > 0:
         # CUDA contexts aren't fork-safe. Using 'spawn' avoids copying the
         # training process's CUDA state into workers, at a ~200-500 ms
         # per-worker startup cost. Safe default.

--- a/mhcflurry/class1_neural_network.py
+++ b/mhcflurry/class1_neural_network.py
@@ -1754,6 +1754,31 @@ class Class1NeuralNetwork(object):
 
         output = loss_obj.encode_y(from_ic50(validation_affinities), **encode_y_kwargs)
 
+        # --- Validation tensors cached on device (Phase 1 #268 for fit_generator) ---
+        # The validation set is constant across pretrain epochs, but the
+        # original code re-ran ``torch.from_numpy(...).float().to(device)``
+        # on every epoch — three H2D copies × many epochs. For large
+        # validation sets that's tens of ms/epoch of pure wasted bandwidth.
+        # Hoist the copy to happen once before the epoch loop. Semantics
+        # are preserved: ``val_peptide_device`` / ``val_allele_device`` /
+        # ``val_y_device`` point at the same bytes the old inline copies
+        # would have produced.
+        val_peptide_device = torch.from_numpy(
+            validation_x_dict["peptide"]
+        ).float().to(device)
+        val_allele_device = torch.from_numpy(
+            validation_x_dict["allele"]
+        ).float().to(device)
+        val_y_device = torch.from_numpy(output.astype(numpy.float32)).to(device)
+
+        # Non-blocking H2D only helps when the source is pinned. For the
+        # training step's per-chunk tensors we allocate fresh each step
+        # from numpy — keep the transfer synchronous (pin_memory on a
+        # one-shot tensor is pure overhead). The prefetcher-style
+        # overlap is the bigger win but requires a DataLoader wrap over
+        # the generator — Phase 2 scope since it changes iteration
+        # semantics.
+
         mutable_generator_state = {
             "yielded_values": 0
         }
@@ -1824,16 +1849,16 @@ class Class1NeuralNetwork(object):
                 optimizer.step()
                 epoch_losses.append(loss.item())
 
-            # Compute validation loss
+            # Compute validation loss — reuse the device tensors hoisted
+            # before the epoch loop (val data is static).
             network.eval()
             with torch.no_grad():
-                val_peptide = torch.from_numpy(validation_x_dict["peptide"]).float().to(device)
-                val_allele = torch.from_numpy(validation_x_dict["allele"]).float().to(device)
-                val_y = torch.from_numpy(output.astype(numpy.float32)).to(device)
-
-                val_inputs = {"peptide": val_peptide, "allele": val_allele}
+                val_inputs = {
+                    "peptide": val_peptide_device,
+                    "allele": val_allele_device,
+                }
                 val_predictions = network(val_inputs)
-                val_loss = loss_obj(val_predictions, val_y)
+                val_loss = loss_obj(val_predictions, val_y_device)
                 regularization_penalty = self._regularization_penalty(
                     regularization_parameters,
                     l1=l1_reg,

--- a/mhcflurry/class1_neural_network.py
+++ b/mhcflurry/class1_neural_network.py
@@ -80,6 +80,50 @@ class _FitBatchDataset(torch.utils.data.Dataset):
         return sample
 
 
+def _build_epoch_input_arrays(
+    random_negative_peptides_encoding,
+    x_dict_without_random_negatives,
+    *,
+    random_negatives_allele_encoding,
+    allele_encoding_to_input,
+):
+    """Build the per-epoch ``(x_peptide, x_allele)`` arrays for fit().
+
+    Extracted from fit()'s epoch loop so that the previous epoch's
+    arrays go out of scope naturally on the caller's reassignment of
+    x_peptide / x_allele — no explicit ``del`` or ``= None`` needed
+    before the concat to keep peak RAM at 1× rather than 2×. For a
+    1.85M-row × 45-wide BLOSUM62 training set that's an extra ~7 GB
+    briefly held per worker per epoch; on A100-40GB it's the
+    difference between ``MAX_WORKERS_PER_GPU=1`` and 2.
+
+    When there are no random negatives, returns the un-concatenated
+    training arrays directly (no copy). When there are random
+    negatives but no allele encoding, returns x_allele=None.
+    """
+    no_random_negs = random_negatives_allele_encoding is None and len(
+        random_negative_peptides_encoding
+    ) == 0
+    if no_random_negs:
+        return (
+            x_dict_without_random_negatives["peptide"],
+            x_dict_without_random_negatives.get("allele"),
+        )
+
+    x_peptide = numpy.concatenate([
+        random_negative_peptides_encoding,
+        x_dict_without_random_negatives["peptide"],
+    ])
+    if "allele" in x_dict_without_random_negatives:
+        x_allele = numpy.concatenate([
+            allele_encoding_to_input(random_negatives_allele_encoding)[0],
+            x_dict_without_random_negatives["allele"],
+        ])
+    else:
+        x_allele = None
+    return x_peptide, x_allele
+
+
 def _effective_num_workers(num_workers):
     """Downgrade ``num_workers`` to 0 when running inside a daemon process.
 
@@ -124,7 +168,6 @@ def _make_fit_dataloader(
     batch_size,
     num_workers,
     use_pinned_memory,
-    persistent_workers=False,
 ):
     """Construct a DataLoader for fit()'s inner batch loop.
 
@@ -135,18 +178,17 @@ def _make_fit_dataloader(
     with GPU compute.
 
     If called from a daemon process (i.e. inside a
-    ``multiprocessing.Pool`` worker — the standard mhcflurry training
-    path), ``num_workers`` is forced to 0 and ``pin_memory`` to False
-    because daemon processes cannot spawn their own children. See
+    ``multiprocessing.Pool`` worker without the NonDaemonPool override),
+    ``num_workers`` is forced to 0 and ``pin_memory`` to False because
+    daemon processes cannot spawn their own children. See
     ``_effective_num_workers``.
 
-    ``persistent_workers=True`` avoids respawning the worker processes
-    between epochs. Currently only useful in narrow cases — ``fit()``
-    constructs a new DataLoader per epoch (the x_peptide arrays change
-    with each epoch's random negatives), so PyTorch's persistent-worker
-    optimization has nothing to persist across DataLoader instances.
-    Exposing the knob keeps the API forward-compatible with a Phase-2
-    refactor that hoists DataLoader construction out of the epoch loop.
+    Note: PyTorch's ``persistent_workers`` flag isn't exposed here
+    because ``fit()`` rebuilds the DataLoader per epoch (the x_peptide
+    arrays change with each epoch's random negatives) — persistent
+    workers have no DataLoader instance to persist across. If a future
+    refactor hoists DataLoader construction out of the epoch loop, add
+    the flag back then.
     """
     effective_workers = _effective_num_workers(num_workers)
     # pin_memory + non_blocking H2D only makes sense when prefetch workers
@@ -167,9 +209,6 @@ def _make_fit_dataloader(
         kwargs["multiprocessing_context"] = "spawn"
         # prefetch_factor is only valid when num_workers > 0.
         kwargs["prefetch_factor"] = 2
-        # PyTorch emits a warning if persistent_workers is set with
-        # num_workers=0; only pass it when it's meaningful.
-        kwargs["persistent_workers"] = persistent_workers
     return torch.utils.data.DataLoader(**kwargs)
 
 
@@ -883,14 +922,6 @@ class Class1NeuralNetwork(object):
         # each adds one Python process holding ~100-500 MB RSS. Don't
         # exceed (num_cpu_cores - num_training_workers).
         dataloader_num_workers=0,
-        # If True and ``dataloader_num_workers > 0``, DataLoader worker
-        # processes are not respawned between DataLoader instances. Only
-        # meaningful when the same DataLoader is iterated repeatedly — in
-        # the current ``fit()`` flow the DataLoader is rebuilt per epoch
-        # so this is effectively a no-op, but the flag is threaded through
-        # so a future hoisting of DataLoader construction can opt in. Has
-        # no effect when ``dataloader_num_workers == 0``.
-        dataloader_persistent_workers=False,
     ).extend(RandomNegativePeptides.hyperparameter_defaults)
     """
     Hyperparameters for neural network training.
@@ -2216,37 +2247,23 @@ class Class1NeuralNetwork(object):
                 random_negative_peptides
             )
 
-            # Build x_dict with random negatives.
-            #
-            # Drop the previous epoch's x_peptide / x_allele arrays BEFORE
-            # allocating the new concatenated buffers. Without this,
-            # both old and new live simultaneously through the
-            # ``numpy.concatenate`` call — peak RAM doubles on each
-            # epoch boundary. For a 1.85M-row 45-wide BLOSUM62 training
-            # set that's an extra ~7 GB briefly held per worker. On
-            # A100-40GB this is the difference between ``MAX_WORKERS_PER_GPU=1``
-            # and 2. Semantically a no-op: Python would have GC'd the
-            # old array eventually, but not before the concat allocates
-            # the new one.
-            x_peptide = None
-            x_allele = None
-            if len(random_negative_peptides) > 0:
-                x_peptide = numpy.concatenate([
-                    random_negative_peptides_encoding,
-                    x_dict_without_random_negatives["peptide"],
-                ])
-                if "allele" in x_dict_without_random_negatives:
-                    x_allele = numpy.concatenate([
-                        self.allele_encoding_to_network_input(
-                            random_negatives_allele_encoding
-                        )[0],
-                        x_dict_without_random_negatives["allele"],
-                    ])
-                else:
-                    x_allele = None
-            else:
-                x_peptide = x_dict_without_random_negatives["peptide"]
-                x_allele = x_dict_without_random_negatives.get("allele")
+            # Build the per-epoch x arrays. The previous epoch's
+            # x_peptide / x_allele go out of scope on the reassignment
+            # below — Python's refcount-based GC drops them before the
+            # concat inside the helper allocates the new buffers, so
+            # peak RAM is 1× the array size, not 2×. Encapsulating the
+            # concat in a function (rather than an inline block) makes
+            # this reliance on scope-based cleanup explicit.
+            x_peptide, x_allele = _build_epoch_input_arrays(
+                random_negative_peptides_encoding,
+                x_dict_without_random_negatives,
+                random_negatives_allele_encoding=(
+                    random_negatives_allele_encoding
+                    if len(random_negative_peptides) > 0
+                    else None
+                ),
+                allele_encoding_to_input=self.allele_encoding_to_network_input,
+            )
 
             if needs_initialization:
                 x_init = {"peptide": x_peptide}
@@ -2278,9 +2295,6 @@ class Class1NeuralNetwork(object):
             dataloader_num_workers = self.hyperparameters.get(
                 "dataloader_num_workers", 0
             )
-            dataloader_persistent_workers = self.hyperparameters.get(
-                "dataloader_persistent_workers", False
-            )
             use_pinned_memory = (
                 dataloader_num_workers > 0 and device.type == "cuda"
             )
@@ -2299,7 +2313,6 @@ class Class1NeuralNetwork(object):
                 batch_size=batch_size,
                 num_workers=dataloader_num_workers,
                 use_pinned_memory=use_pinned_memory,
-                persistent_workers=dataloader_persistent_workers,
             )
 
             for batch in loader:

--- a/mhcflurry/class1_neural_network.py
+++ b/mhcflurry/class1_neural_network.py
@@ -2216,7 +2216,20 @@ class Class1NeuralNetwork(object):
                 random_negative_peptides
             )
 
-            # Build x_dict with random negatives
+            # Build x_dict with random negatives.
+            #
+            # Drop the previous epoch's x_peptide / x_allele arrays BEFORE
+            # allocating the new concatenated buffers. Without this,
+            # both old and new live simultaneously through the
+            # ``numpy.concatenate`` call — peak RAM doubles on each
+            # epoch boundary. For a 1.85M-row 45-wide BLOSUM62 training
+            # set that's an extra ~7 GB briefly held per worker. On
+            # A100-40GB this is the difference between ``MAX_WORKERS_PER_GPU=1``
+            # and 2. Semantically a no-op: Python would have GC'd the
+            # old array eventually, but not before the concat allocates
+            # the new one.
+            x_peptide = None
+            x_allele = None
             if len(random_negative_peptides) > 0:
                 x_peptide = numpy.concatenate([
                     random_negative_peptides_encoding,

--- a/mhcflurry/class1_neural_network.py
+++ b/mhcflurry/class1_neural_network.py
@@ -7,7 +7,6 @@ import time
 import collections
 import json
 import multiprocessing
-import sys
 import weakref
 import itertools
 import os
@@ -81,39 +80,41 @@ class _FitBatchDataset(torch.utils.data.Dataset):
         return sample
 
 
-_DAEMON_DOWNGRADE_WARNED = False
-
-
 def _effective_num_workers(num_workers):
     """Downgrade ``num_workers`` to 0 when running inside a daemon process.
 
-    Python's ``multiprocessing`` disallows daemon processes from spawning
-    children — enforced by an ``AssertionError`` deep inside
-    ``DataLoader._MultiProcessingDataLoaderIter``. mhcflurry's training
-    orchestrator runs workers via ``multiprocessing.Pool``, whose workers
-    are daemonic by default. With ``dataloader_num_workers > 0`` that
-    detonates the whole training run at the first epoch's ``for batch
-    in loader`` line.
+    Safety net for DataLoader's ``num_workers>0`` path, which requires
+    spawning child processes — forbidden from daemon parents. mhcflurry's
+    training orchestrator switched to ``NonDaemonPool`` (see
+    ``local_parallelism.py``) so in production Pool workers are now
+    non-daemonic and this downgrade does NOT fire. It remains as
+    defense-in-depth for:
 
-    The right behavior under that constraint: silently fall back to
-    ``num_workers=0`` so the worker runs correctly (just without prefetch).
-    Orchestrator-level runs (e.g. tests, single-process CLI) keep the
-    configured value.
+      - External callers that wrap ``Class1NeuralNetwork.fit`` in a
+        daemonic process of their own (e.g. ``ProcessPoolExecutor`` is
+        non-daemon by default but ``multiprocessing.Pool`` without the
+        NonDaemonPool subclass is daemonic).
+      - Test suites that explicitly construct daemon subprocesses (our
+        own ``test_dataloader_num_workers_downgrades_in_daemon_context``
+        exercises this path).
 
-    See ``test_dataloader_num_workers_downgrades_in_daemon_context`` for
-    the regression test that locks this behavior.
+    Emits a ``DeprecationWarning`` — it's worth knowing if this fires,
+    since it means the caller is running in a daemon context and
+    DataLoader prefetch is silently disabled. Use ``warnings.filterwarnings``
+    to silence if intentional.
     """
-    global _DAEMON_DOWNGRADE_WARNED
     if num_workers > 0 and multiprocessing.current_process().daemon:
-        if not _DAEMON_DOWNGRADE_WARNED:
-            print(
-                f"[warn] dataloader_num_workers={num_workers} requested from a "
-                f"daemon process (mhcflurry Pool worker); downgrading to 0 to "
-                f"avoid 'daemonic processes are not allowed to have children'. "
-                f"Prefetch disabled inside this worker.",
-                file=sys.stderr,
-            )
-            _DAEMON_DOWNGRADE_WARNED = True
+        import warnings
+        warnings.warn(
+            f"dataloader_num_workers={num_workers} requested from a daemon "
+            f"process; downgrading to 0 because daemon processes cannot "
+            f"spawn children. If this is mhcflurry's Pool worker, switch "
+            f"to NonDaemonPool (mhcflurry/local_parallelism.py); if it's "
+            f"your own caller, use a non-daemonic executor or accept the "
+            f"downgrade (set dataloader_num_workers=0 explicitly to silence).",
+            DeprecationWarning,
+            stacklevel=3,
+        )
         return 0
     return num_workers
 

--- a/mhcflurry/class1_neural_network.py
+++ b/mhcflurry/class1_neural_network.py
@@ -41,6 +41,87 @@ KERAS_BATCH_NORM_EPSILON = 1e-3
 KERAS_BATCH_NORM_MOMENTUM = 0.01
 
 
+class _FitBatchDataset(torch.utils.data.Dataset):
+    """Map-style Dataset backing fit()'s inner batch loop.
+
+    Wraps the already-built per-epoch arrays (x_peptide, x_allele,
+    y_encoded, sample_weights_with_negatives) and the shuffled
+    train_indices. __getitem__ does a single-row fancy-index into each
+    array. With ``shuffle=False`` on the DataLoader, iteration order
+    matches the current (non-DataLoader) code path exactly, which is
+    what the bit-identical integration test requires.
+
+    See issue openvax/mhcflurry#268 for motivation and semantic-
+    preservation rationale.
+    """
+
+    def __init__(self, x_peptide, x_allele, y_encoded,
+                 sample_weights_with_negatives, train_indices):
+        self.x_peptide = x_peptide
+        self.x_allele = x_allele
+        self.y_encoded = y_encoded
+        self.sample_weights = sample_weights_with_negatives
+        self.train_indices = train_indices
+
+    def __len__(self):
+        return len(self.train_indices)
+
+    def __getitem__(self, i):
+        idx = self.train_indices[i]
+        sample = {
+            "peptide": self.x_peptide[idx],
+            "y": self.y_encoded[idx].astype(numpy.float32),
+        }
+        if self.x_allele is not None:
+            sample["allele"] = self.x_allele[idx]
+        if self.sample_weights is not None:
+            sample["weight"] = self.sample_weights[idx]
+        return sample
+
+
+def _make_fit_dataloader(
+    dataset,
+    batch_size,
+    num_workers,
+    use_pinned_memory,
+    persistent_workers=False,
+):
+    """Construct a DataLoader for fit()'s inner batch loop.
+
+    ``num_workers=0`` path runs everything in the main process — bit-
+    identical to pre-issue-#268 behavior. ``num_workers>0`` spawns worker
+    processes (via 'spawn' to avoid CUDA-context-fork hazards) that
+    prefetch minibatches into pinned host memory, overlapping CPU work
+    with GPU compute.
+
+    ``persistent_workers=True`` avoids respawning the worker processes
+    between epochs. Currently only useful in narrow cases — ``fit()``
+    constructs a new DataLoader per epoch (the x_peptide arrays change
+    with each epoch's random negatives), so PyTorch's persistent-worker
+    optimization has nothing to persist across DataLoader instances.
+    Exposing the knob keeps the API forward-compatible with a Phase-2
+    refactor that hoists DataLoader construction out of the epoch loop.
+    """
+    kwargs = dict(
+        dataset=dataset,
+        batch_size=batch_size,
+        shuffle=False,  # Dataset already reflects shuffled train_indices.
+        num_workers=num_workers,
+        pin_memory=use_pinned_memory,
+    )
+    if num_workers > 0:
+        # CUDA contexts aren't fork-safe. Using 'spawn' avoids copying the
+        # training process's CUDA state into workers, at a ~200-500 ms
+        # per-worker startup cost. Safe default.
+        kwargs["multiprocessing_context"] = "spawn"
+        # prefetch_factor is only valid when num_workers > 0.
+        kwargs["prefetch_factor"] = 2
+        # PyTorch emits a warning if persistent_workers is set with
+        # num_workers=0; only pass it when it's meaningful.
+        kwargs["persistent_workers"] = persistent_workers
+    return torch.utils.data.DataLoader(**kwargs)
+
+
 class Class1NeuralNetworkModel(nn.Module):
     """
     PyTorch module for Class1 neural network.
@@ -743,6 +824,22 @@ class Class1NeuralNetwork(object):
         random_negative_affinity_min=20000.0,
         random_negative_affinity_max=50000.0,
         random_negative_output_indices=None,
+        # Number of DataLoader worker processes for the fit() inner batch
+        # loop. 0 (default) runs everything in the training process —
+        # bit-identical to pre-issue-#268 behavior. >0 spawns worker procs
+        # that prefetch minibatches into pinned host memory, overlapping
+        # CPU data-prep with GPU compute. Per-worker memory + CPU budget:
+        # each adds one Python process holding ~100-500 MB RSS. Don't
+        # exceed (num_cpu_cores - num_training_workers).
+        dataloader_num_workers=0,
+        # If True and ``dataloader_num_workers > 0``, DataLoader worker
+        # processes are not respawned between DataLoader instances. Only
+        # meaningful when the same DataLoader is iterated repeatedly — in
+        # the current ``fit()`` flow the DataLoader is rebuilt per epoch
+        # so this is effectively a no-op, but the flag is threaded through
+        # so a future hoisting of DataLoader construction can opt in. Has
+        # no effect when ``dataloader_num_workers == 0``.
+        dataloader_persistent_workers=False,
     ).extend(RandomNegativePeptides.hyperparameter_defaults)
     """
     Hyperparameters for neural network training.
@@ -1991,6 +2088,50 @@ class Class1NeuralNetwork(object):
         l1_reg = self.hyperparameters["dense_layer_l1_regularization"]
         l2_reg = self.hyperparameters["dense_layer_l2_regularization"]
 
+        # --- Validation tensors cached on device (issue openvax/mhcflurry#268) ---
+        # The validation set indexes into the concatenated
+        # [random_negs | training] array via val_indices. The training portion
+        # is static across epochs; the random-negative portion changes.
+        # When val_indices points entirely into the training portion (the
+        # common case — with default val_split=0.1 and random_negative_rate=1,
+        # val set is the tail 10% of the ~2x-size concatenated array, all in
+        # training portion), x_peptide[val_indices] and x_allele[val_indices]
+        # are stable across epochs. Materialize them on device once to save
+        # ~60 MB+ H2D per epoch.
+        #
+        # When overlap IS possible (unusual hyperparameter combos), skip the
+        # cache and fall back to per-epoch copy (preserved behavior).
+        _val_cache_safe = (
+            val_indices is not None
+            and len(val_indices) > 0
+            and val_indices[0] >= num_random_negatives
+        )
+        _val_device_tensors = None
+        if _val_cache_safe:
+            val_training_indices = val_indices - num_random_negatives
+            _val_peptide_device = torch.from_numpy(
+                x_dict_without_random_negatives["peptide"][val_training_indices]
+            ).float().to(device)
+            _val_y_device = torch.from_numpy(
+                y_encoded[val_indices].astype(numpy.float32)
+            ).to(device)
+            _val_allele_device = None
+            if "allele" in x_dict_without_random_negatives:
+                _val_allele_device = torch.from_numpy(
+                    x_dict_without_random_negatives["allele"][val_training_indices]
+                ).float().to(device)
+            _val_weights_device = None
+            if sample_weights_with_negatives is not None:
+                _val_weights_device = torch.from_numpy(
+                    sample_weights_with_negatives[val_indices]
+                ).float().to(device)
+            _val_device_tensors = (
+                _val_peptide_device,
+                _val_y_device,
+                _val_allele_device,
+                _val_weights_device,
+            )
+
         for epoch in range(self.hyperparameters["max_epochs"]):
             random_negative_peptides = EncodableSequences.create(
                 random_negatives_planner.get_peptides()
@@ -2038,28 +2179,61 @@ class Class1NeuralNetwork(object):
             network.train()
             epoch_start = time.time()
 
-            # Create batches
+            # Create batches via DataLoader — with num_workers=0 this is
+            # bit-identical to the old single-process inline-iteration path
+            # (DataLoader wraps the same fancy-indexing logic with no
+            # reordering). With num_workers>0, prefetcher processes build
+            # the next batch while the GPU crunches the current one.
+            # See issue openvax/mhcflurry#268.
             batch_size = self.hyperparameters["minibatch_size"]
+            dataloader_num_workers = self.hyperparameters.get(
+                "dataloader_num_workers", 0
+            )
+            dataloader_persistent_workers = self.hyperparameters.get(
+                "dataloader_persistent_workers", False
+            )
+            use_pinned_memory = (
+                dataloader_num_workers > 0 and device.type == "cuda"
+            )
+            non_blocking_h2d = use_pinned_memory
+
             train_losses = []
+            dataset = _FitBatchDataset(
+                x_peptide=x_peptide,
+                x_allele=x_allele,
+                y_encoded=y_encoded,
+                sample_weights_with_negatives=sample_weights_with_negatives,
+                train_indices=train_indices,
+            )
+            loader = _make_fit_dataloader(
+                dataset=dataset,
+                batch_size=batch_size,
+                num_workers=dataloader_num_workers,
+                use_pinned_memory=use_pinned_memory,
+                persistent_workers=dataloader_persistent_workers,
+            )
 
-            for batch_start in range(0, n_train, batch_size):
-                batch_idx = train_indices[batch_start:batch_start + batch_size]
-
-                peptide_batch = torch.from_numpy(x_peptide[batch_idx]).float().to(device)
-                y_batch = torch.from_numpy(y_encoded[batch_idx].astype(numpy.float32)).to(device)
+            for batch in loader:
+                peptide_batch = batch["peptide"].float().to(
+                    device, non_blocking=non_blocking_h2d
+                )
+                y_batch = batch["y"].to(
+                    device, non_blocking=non_blocking_h2d
+                )
 
                 inputs = {"peptide": peptide_batch}
-                if x_allele is not None:
-                    allele_batch = torch.from_numpy(x_allele[batch_idx]).float().to(device)
-                    inputs["allele"] = allele_batch
+                if "allele" in batch:
+                    inputs["allele"] = batch["allele"].float().to(
+                        device, non_blocking=non_blocking_h2d
+                    )
 
                 optimizer.zero_grad()
                 predictions = network(inputs)
                 weights_batch = None
-                if sample_weights_with_negatives is not None:
-                    weights_batch = torch.from_numpy(
-                        sample_weights_with_negatives[batch_idx]
-                    ).float().to(device)
+                if "weight" in batch:
+                    weights_batch = batch["weight"].float().to(
+                        device, non_blocking=non_blocking_h2d
+                    )
                 loss = loss_obj(predictions, y_batch, sample_weights=weights_batch)
                 regularization_penalty = self._regularization_penalty(
                     regularization_parameters,
@@ -2080,18 +2254,38 @@ class Class1NeuralNetwork(object):
             if val_split > 0:
                 network.eval()
                 with torch.no_grad():
-                    val_peptide = torch.from_numpy(x_peptide[val_indices]).float().to(device)
-                    val_y = torch.from_numpy(y_encoded[val_indices].astype(numpy.float32)).to(device)
+                    if _val_device_tensors is not None:
+                        # Fast path: reuse tensors materialized once before the
+                        # epoch loop. Saves ~60 MB+ H2D copy per epoch. Bit-
+                        # identical because val_indices points entirely into
+                        # the static training portion of x_peptide/x_allele.
+                        (
+                            val_peptide,
+                            val_y,
+                            val_allele,
+                            val_weights,
+                        ) = _val_device_tensors
+                    else:
+                        val_peptide = torch.from_numpy(
+                            x_peptide[val_indices]
+                        ).float().to(device)
+                        val_y = torch.from_numpy(
+                            y_encoded[val_indices].astype(numpy.float32)
+                        ).to(device)
+                        val_allele = None
+                        if x_allele is not None:
+                            val_allele = torch.from_numpy(
+                                x_allele[val_indices]
+                            ).float().to(device)
+                        val_weights = None
+                        if sample_weights_with_negatives is not None:
+                            val_weights = torch.from_numpy(
+                                sample_weights_with_negatives[val_indices]
+                            ).float().to(device)
                     val_inputs = {"peptide": val_peptide}
-                    if x_allele is not None:
-                        val_allele = torch.from_numpy(x_allele[val_indices]).float().to(device)
+                    if val_allele is not None:
                         val_inputs["allele"] = val_allele
                     val_predictions = network(val_inputs)
-                    val_weights = None
-                    if sample_weights_with_negatives is not None:
-                        val_weights = torch.from_numpy(
-                            sample_weights_with_negatives[val_indices]
-                        ).float().to(device)
                     val_loss = loss_obj(
                         val_predictions,
                         val_y,

--- a/mhcflurry/encoding_cache.py
+++ b/mhcflurry/encoding_cache.py
@@ -269,7 +269,7 @@ def _as_peptide_list(peptides: list[str] | numpy.ndarray) -> list[str]:
 #
 # LOAD-BEARING COMPATIBILITY SURFACE:
 #
-# ``make_preencoded_encodable_sequences`` writes into the per-instance
+# ``make_prepopulated_encodable_sequences`` writes into the per-instance
 # ``EncodableSequences.encoding_cache`` dict at a key that must match the
 # tuple that ``EncodableSequences.variable_length_to_fixed_length_
 # vector_encoding`` builds internally (encodable_sequences.py around
@@ -337,7 +337,7 @@ def _verify_cache_key_shape() -> None:
 
     Runs once per process (guarded by ``_CACHE_KEY_SHAPE_VERIFIED``).
     Fast: one 8-mer encoded with a 15-length pad. Amortized across all
-    subsequent ``make_preencoded_encodable_sequences`` calls.
+    subsequent ``make_prepopulated_encodable_sequences`` calls.
     """
     global _CACHE_KEY_SHAPE_VERIFIED
     if _CACHE_KEY_SHAPE_VERIFIED:
@@ -375,7 +375,7 @@ def _verify_cache_key_shape() -> None:
     _CACHE_KEY_SHAPE_VERIFIED = True
 
 
-def make_preencoded_encodable_sequences(
+def make_prepopulated_encodable_sequences(
     peptides: list[str] | numpy.ndarray,
     encoded_rows: numpy.ndarray,
     params: EncodingParams,

--- a/mhcflurry/encoding_cache.py
+++ b/mhcflurry/encoding_cache.py
@@ -187,10 +187,19 @@ class EncodingCache:
             **self.params.to_kwargs()
         )
         encoded_row_shape = sample_encoded.shape[1:]
-        # Upstream sometimes returns float64. Pin to float32 to match what
-        # class1_neural_network's .float().to(device) cast would produce,
-        # and to halve memmap size on disk.
-        dtype = numpy.float32
+        # Preserve the encoder's native dtype. For BLOSUM62 (our only
+        # vector_encoding_name in practice) upstream returns int8 — the
+        # substitution-matrix values fit tightly in [-4, +6]. Storing as
+        # int8 is LOSSLESS for that encoding and cuts memmap size by 4×
+        # vs float32. At training-step time the batch is cast int8→fp32
+        # on the GPU, which is a free widening op and reduces H2D
+        # bandwidth by the same 4× factor (cold cache slices are int8
+        # from the memmap, not float32).
+        #
+        # If a future encoding returns float values, we preserve those
+        # too — only the storage width shrinks for integer-valued
+        # encoders.
+        dtype = sample_encoded.dtype
 
         n = len(peptides)
         out_path = entry_dir / "encoded.npy"

--- a/mhcflurry/encoding_cache.py
+++ b/mhcflurry/encoding_cache.py
@@ -1,0 +1,390 @@
+"""Memmap-backed BLOSUM62 peptide encoding cache.
+
+Training the pan-allele model re-encodes the same ~945K training peptides
+from scratch for every architecture×fold×replicate combination, and every
+epoch re-encodes the 256K pretrain peptides. The encoding is a pure
+function of (peptide_string, encoding_params); there's no reason to redo
+it 32+ times.
+
+This module pre-encodes a peptide list once, writes a memmap-compatible
+.npy file to disk, and hands out read-only mmap views. Multiple training
+workers on the same box share one physical copy via the OS page cache.
+
+Semantics
+---------
+The encoded bytes are identical to what
+``EncodableSequences.variable_length_to_fixed_length_vector_encoding``
+returns for the same peptides and params — this module does NOT define
+a new encoding, it only caches the existing one. A regression test
+(``test_cached_matches_direct_byte_for_byte``) asserts this.
+
+Cache layout
+------------
+Cache directory (default ``$MHCFLURRY_OUT/encoding_cache/`` or user-provided)
+contains one subdirectory per (params, peptides) pair::
+
+    <cache_dir>/<params_hash>_<peptides_hash>/
+        encoded.npy       # float32, shape (N, encoded_len, 21)
+        peptides.txt      # one peptide per line, order matches encoded.npy rows
+        params.json       # encoding params (human-readable)
+        .complete         # sentinel: present iff build finished atomically
+
+Reader invariant: only consume a cache entry if ``.complete`` exists.
+The build pass writes encoded.npy as ``encoded.npy.tmp`` first, renames,
+then touches ``.complete`` last; any crash before the sentinel leaves a
+half-written cache that the next reader will rebuild instead of using.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import numpy
+import numpy.lib.format
+
+from .encodable_sequences import EncodableSequences
+
+
+# Default chunk size for the encoding pass. Chunks amortize the overhead of
+# constructing an ``EncodableSequences`` instance over many peptides and
+# cap peak memory during build (one chunk's worth of encoded float32s).
+DEFAULT_CHUNK_SIZE = 100_000
+
+
+@dataclass(frozen=True)
+class EncodingParams:
+    """The tuple of knobs that determines encoded output bytes.
+
+    Matches the kwargs accepted by
+    ``EncodableSequences.variable_length_to_fixed_length_vector_encoding``.
+    All fields participate in the cache key.
+    """
+    vector_encoding_name: str = "BLOSUM62"
+    alignment_method: str = "pad_middle"
+    left_edge: int = 4
+    right_edge: int = 4
+    max_length: int = 15
+    trim: bool = False
+    allow_unsupported_amino_acids: bool = False
+
+    def to_kwargs(self) -> dict[str, Any]:
+        return {
+            "vector_encoding_name": self.vector_encoding_name,
+            "alignment_method": self.alignment_method,
+            "left_edge": self.left_edge,
+            "right_edge": self.right_edge,
+            "max_length": self.max_length,
+            "trim": self.trim,
+            "allow_unsupported_amino_acids": self.allow_unsupported_amino_acids,
+        }
+
+    def hash_key(self) -> str:
+        payload = json.dumps(self.to_kwargs(), sort_keys=True).encode("utf-8")
+        return hashlib.sha256(payload).hexdigest()[:16]
+
+
+def _hash_peptides(peptides: list[str]) -> str:
+    """Stream-hash the peptide list preserving order.
+
+    Order matters: peptide at row i maps to training row i in the caller.
+    Same peptides in different order is intentionally a cache miss.
+    """
+    h = hashlib.sha256()
+    # Hash count first so ["A", "B"] and ["AB"] produce different hashes.
+    h.update(str(len(peptides)).encode("utf-8"))
+    h.update(b"\0")
+    for peptide in peptides:
+        h.update(peptide.encode("utf-8"))
+        h.update(b"\0")
+    return h.hexdigest()[:16]
+
+
+@dataclass
+class EncodingCache:
+    """Memmap-backed cache of BLOSUM62-encoded peptides.
+
+    Typical usage from the orchestrator process::
+
+        cache = EncodingCache(cache_dir=Path("out/encoding_cache"),
+                              params=EncodingParams(**hyperparams["peptide_encoding"]))
+        encoded, peptide_to_idx = cache.get_or_build(train_data.peptide.values)
+        # encoded is a read-only mmap'd array of shape (N, encoded_len, 21)
+        # peptide_to_idx is a dict; use encoded[peptide_to_idx[pep]] to look up.
+
+    Workers subsequently open the same cache_dir+params+peptides; they
+    hit the existing cache and get mmap views with zero extra encoding cost.
+    """
+
+    cache_dir: Path
+    params: EncodingParams = field(default_factory=EncodingParams)
+    chunk_size: int = DEFAULT_CHUNK_SIZE
+
+    def __post_init__(self) -> None:
+        self.cache_dir = Path(self.cache_dir)
+
+    # ---- public API ----
+
+    def get_or_build(
+        self, peptides: list[str] | numpy.ndarray
+    ) -> tuple[numpy.ndarray, dict[str, int]]:
+        """Return (encoded_memmap_array, peptide_to_row_idx).
+
+        Builds the cache if not present. Safe to call from multiple processes;
+        the atomic-rename + sentinel-file pattern makes concurrent readers
+        never see a partial write (they just rebuild into a separate tmp
+        path, and the last writer wins the rename; both produce identical
+        bytes).
+        """
+        peptides = _as_peptide_list(peptides)
+        entry_dir = self._entry_dir(peptides)
+        if not self._is_complete(entry_dir):
+            self._build(peptides, entry_dir)
+        return self._load(entry_dir)
+
+    def entry_path(self, peptides: list[str] | numpy.ndarray) -> Path:
+        """Return the directory path for the cache entry for these peptides."""
+        return self._entry_dir(_as_peptide_list(peptides))
+
+    def is_complete_for(self, peptides: list[str] | numpy.ndarray) -> bool:
+        """Return True iff this (params, peptides) entry is fully built on disk.
+
+        Public callers (orchestrators, diagnostic tooling) use this to
+        avoid calling ``get_or_build`` just to check cache state. Workers
+        typically just call ``get_or_build`` directly — the atomic sentinel
+        check happens inside.
+        """
+        return self._is_complete(self._entry_dir(_as_peptide_list(peptides)))
+
+    # ---- internals ----
+
+    def _entry_dir(self, peptides: list[str]) -> Path:
+        params_hash = self.params.hash_key()
+        peptides_hash = _hash_peptides(peptides)
+        return self.cache_dir / f"{params_hash}_{peptides_hash}"
+
+    @staticmethod
+    def _is_complete(entry_dir: Path) -> bool:
+        return (entry_dir / ".complete").exists()
+
+    def _build(self, peptides: list[str], entry_dir: Path) -> None:
+        entry_dir.mkdir(parents=True, exist_ok=True)
+
+        # Dry-run one peptide to learn the encoded shape and dtype.
+        sample_encoder = EncodableSequences([peptides[0]])
+        sample_encoded = sample_encoder.variable_length_to_fixed_length_vector_encoding(
+            **self.params.to_kwargs()
+        )
+        encoded_row_shape = sample_encoded.shape[1:]
+        # Upstream sometimes returns float64. Pin to float32 to match what
+        # class1_neural_network's .float().to(device) cast would produce,
+        # and to halve memmap size on disk.
+        dtype = numpy.float32
+
+        n = len(peptides)
+        out_path = entry_dir / "encoded.npy"
+        tmp_path = entry_dir / "encoded.npy.tmp"
+        # open_memmap writes a .npy header plus raw bytes that np.load(mmap_mode='r')
+        # can consume.
+        mm = numpy.lib.format.open_memmap(
+            tmp_path,
+            mode="w+",
+            dtype=dtype,
+            shape=(n, *encoded_row_shape),
+        )
+        try:
+            for start in range(0, n, self.chunk_size):
+                chunk = peptides[start : start + self.chunk_size]
+                encoded = (
+                    EncodableSequences(chunk)
+                    .variable_length_to_fixed_length_vector_encoding(
+                        **self.params.to_kwargs()
+                    )
+                    .astype(dtype, copy=False)
+                )
+                mm[start : start + len(chunk)] = encoded
+            mm.flush()
+        finally:
+            # Release the memmap so the rename below isn't blocked on Windows
+            # and so the OS can coalesce dirty pages. `del` is the conventional
+            # way to close a np.memmap.
+            del mm
+        os.replace(tmp_path, out_path)
+
+        # Write peptide list and params in parallel (both small).
+        (entry_dir / "peptides.txt").write_text("\n".join(peptides) + "\n")
+        (entry_dir / "params.json").write_text(
+            json.dumps(self.params.to_kwargs(), indent=2, sort_keys=True) + "\n"
+        )
+
+        # Sentinel last. Presence of `.complete` is the atomic signal that the
+        # cache entry is fully written and safe to consume.
+        (entry_dir / ".complete").touch()
+
+    @staticmethod
+    def _load(entry_dir: Path) -> tuple[numpy.ndarray, dict[str, int]]:
+        encoded = numpy.load(entry_dir / "encoded.npy", mmap_mode="r")
+        peptides_text = (entry_dir / "peptides.txt").read_text()
+        # The trailing newline in peptides.txt produces an empty final token
+        # after splitlines+split on newline; strip empties.
+        peptide_list = [p for p in peptides_text.splitlines() if p != ""]
+        # Build the lookup dict lazily-ish (caller often needs it).
+        peptide_to_idx = {p: i for i, p in enumerate(peptide_list)}
+        return encoded, peptide_to_idx
+
+
+def _as_peptide_list(peptides: list[str] | numpy.ndarray) -> list[str]:
+    if isinstance(peptides, numpy.ndarray):
+        return peptides.tolist()
+    return list(peptides)
+
+
+# ---- Integration helper ---------------------------------------------------
+#
+# LOAD-BEARING COMPATIBILITY SURFACE:
+#
+# ``make_preencoded_encodable_sequences`` writes into the per-instance
+# ``EncodableSequences.encoding_cache`` dict at a key that must match the
+# tuple that ``EncodableSequences.variable_length_to_fixed_length_
+# vector_encoding`` builds internally (encodable_sequences.py around
+# line 160). If upstream rearranges that tuple in a future refactor,
+# prepopulation silently misses and the "cache hit" path degrades to a
+# full re-encode + memmap read — silent perf regression, correct output.
+#
+# We protect against this two ways:
+#
+#  1. A module-level self-test (``_verify_cache_key_shape``, run once per
+#     process on first use) that builds a prepopulated ``EncodableSequences``
+#     and confirms the prepopulated tensor IS returned by a subsequent
+#     ``variable_length_to_fixed_length_vector_encoding`` call. If it
+#     isn't, we raise ``EncodingCacheKeyMismatchError`` loudly at first
+#     use with a pointer to this module — no silent degradation.
+#
+#  2. A regression test (``test_prepopulated_hits_existing_cache_path``)
+#     that asserts the same invariant at CI time.
+
+
+class EncodingCacheKeyMismatchError(RuntimeError):
+    """Raised when our cache-key tuple shape no longer matches EncodableSequences.
+
+    Indicates a breaking upstream change: the internal cache key in
+    ``EncodableSequences.variable_length_to_fixed_length_vector_encoding``
+    has been refactored in a way that ``_vector_encoding_cache_key``
+    didn't keep up with. Fix by reading the updated upstream code and
+    mirroring the new tuple layout here.
+    """
+
+
+def _vector_encoding_cache_key(params: EncodingParams) -> tuple:
+    """Construct the cache key tuple EncodableSequences uses internally.
+
+    Must exactly match the tuple built inside
+    ``EncodableSequences.variable_length_to_fixed_length_vector_encoding``.
+    Protected by a module-level self-test — see the block comment above.
+    """
+    return (
+        "fixed_length_vector_encoding",
+        params.vector_encoding_name,
+        params.alignment_method,
+        params.left_edge,
+        params.right_edge,
+        params.max_length,
+        params.trim,
+        params.allow_unsupported_amino_acids,
+    )
+
+
+# Guard flag so ``_verify_cache_key_shape`` runs exactly once per process.
+# Module-level mutable so ``reset`` helpers in tests can re-exercise it.
+_CACHE_KEY_SHAPE_VERIFIED = False
+
+
+def _verify_cache_key_shape() -> None:
+    """Assert that our prepopulation key round-trips through EncodableSequences.
+
+    Build a tiny EncodableSequences, prepopulate its instance cache using
+    ``_vector_encoding_cache_key``, then call
+    ``variable_length_to_fixed_length_vector_encoding`` and assert the
+    returned array IS (object identity) the one we stored. If it isn't,
+    the upstream key layout has drifted and we raise a clear error up
+    front — no silent perf regression.
+
+    Runs once per process (guarded by ``_CACHE_KEY_SHAPE_VERIFIED``).
+    Fast: one 8-mer encoded with a 15-length pad. Amortized across all
+    subsequent ``make_preencoded_encodable_sequences`` calls.
+    """
+    global _CACHE_KEY_SHAPE_VERIFIED
+    if _CACHE_KEY_SHAPE_VERIFIED:
+        return
+
+    # Use the default params for the self-test; the real check is the
+    # tuple shape matching, which is param-value-independent.
+    params = EncodingParams()
+    # Minimal peptide set that works with default params
+    # (max_length=15, pad_middle handles 8-15 without trim).
+    probe_peptides = ["SIINFEKL"]
+    probe_tensor = (
+        EncodableSequences(probe_peptides)
+        .variable_length_to_fixed_length_vector_encoding(**params.to_kwargs())
+        .astype(numpy.float32)
+    )
+
+    sentinel = probe_tensor.copy() + 777.0  # distinguishable bytes
+    es = EncodableSequences(probe_peptides)
+    es.encoding_cache[_vector_encoding_cache_key(params)] = sentinel
+    returned = es.variable_length_to_fixed_length_vector_encoding(
+        **params.to_kwargs()
+    )
+    if returned is not sentinel:
+        raise EncodingCacheKeyMismatchError(
+            "The per-instance EncodableSequences.encoding_cache key tuple no "
+            "longer matches what `_vector_encoding_cache_key` in "
+            "mhcflurry/encoding_cache.py produces. Prepopulation silently "
+            "missed. Update `_vector_encoding_cache_key` to match the key "
+            "constructed inside "
+            "`EncodableSequences.variable_length_to_fixed_length_vector_"
+            "encoding` (see encodable_sequences.py)."
+        )
+
+    _CACHE_KEY_SHAPE_VERIFIED = True
+
+
+def make_preencoded_encodable_sequences(
+    peptides: list[str] | numpy.ndarray,
+    encoded_rows: numpy.ndarray,
+    params: EncodingParams,
+) -> EncodableSequences:
+    """Return an EncodableSequences whose per-instance encoding_cache is
+    prepopulated with ``encoded_rows``.
+
+    When downstream code (``Class1NeuralNetwork.peptides_to_network_input``)
+    calls ``.variable_length_to_fixed_length_vector_encoding(**params)`` on
+    the returned instance, it will hit the cache and return ``encoded_rows``
+    directly without re-encoding — the whole point of the exercise.
+
+    On first call in the process, runs a self-test
+    (``_verify_cache_key_shape``) that raises
+    ``EncodingCacheKeyMismatchError`` if the upstream cache-key layout has
+    drifted. See the block comment above for rationale.
+
+    ``encoded_rows`` must be shape-compatible with what the encoder would
+    have produced (N_peptides, encoded_len, alphabet_size). Caller's
+    responsibility. For safety the length is checked against len(peptides).
+    """
+    # Verify once — converts a silent upstream break into a loud error
+    # on the first cache-integration call the orchestrator makes.
+    _verify_cache_key_shape()
+
+    peptides = _as_peptide_list(peptides)
+    if len(peptides) != len(encoded_rows):
+        raise ValueError(
+            f"encoded_rows length {len(encoded_rows)} does not match "
+            f"peptide count {len(peptides)}"
+        )
+    es = EncodableSequences(peptides)
+    es.encoding_cache[_vector_encoding_cache_key(params)] = encoded_rows
+    return es

--- a/mhcflurry/encoding_cache.py
+++ b/mhcflurry/encoding_cache.py
@@ -174,6 +174,13 @@ class EncodingCache:
     def _build(self, peptides: list[str], entry_dir: Path) -> None:
         entry_dir.mkdir(parents=True, exist_ok=True)
 
+        # Re-check the sentinel now that entry_dir exists: another process
+        # may have finished building while we were on the is_complete path.
+        # Catches the common race where two workers simultaneously decide
+        # to build; the second wakes up to find the build is done.
+        if self._is_complete(entry_dir):
+            return
+
         # Dry-run one peptide to learn the encoded shape and dtype.
         sample_encoder = EncodableSequences([peptides[0]])
         sample_encoded = sample_encoder.variable_length_to_fixed_length_vector_encoding(
@@ -187,7 +194,16 @@ class EncodingCache:
 
         n = len(peptides)
         out_path = entry_dir / "encoded.npy"
-        tmp_path = entry_dir / "encoded.npy.tmp"
+        # Per-process tmp path. Two workers that simultaneously build the
+        # same cache entry (the orchestrator's single-threaded pre-build
+        # is preferred, but Pool workers can race for entries the
+        # orchestrator didn't pre-build — e.g. the pretrain cache) each
+        # have their own tmp file, so their final ``os.replace`` moves
+        # never compete for the same source file. The writers produce
+        # byte-identical content (the encoding is a pure function of
+        # params+peptides), so whichever rename lands last determines
+        # out_path's content safely.
+        tmp_path = entry_dir / f"encoded.npy.tmp.{os.getpid()}"
         # open_memmap writes a .npy header plus raw bytes that np.load(mmap_mode='r')
         # can consume.
         mm = numpy.lib.format.open_memmap(
@@ -213,9 +229,15 @@ class EncodingCache:
             # and so the OS can coalesce dirty pages. `del` is the conventional
             # way to close a np.memmap.
             del mm
+        # Atomic move of our unique tmp file into place. POSIX ``os.replace``
+        # is atomic — a concurrent reader either sees the old inode or the
+        # new one, never a partial write. If another writer raced us to
+        # produce out_path, our os.replace quietly overwrites their
+        # (identical) bytes.
         os.replace(tmp_path, out_path)
 
-        # Write peptide list and params in parallel (both small).
+        # Write peptide list and params — writes are idempotent across
+        # racing writers since both write the same content.
         (entry_dir / "peptides.txt").write_text("\n".join(peptides) + "\n")
         (entry_dir / "params.json").write_text(
             json.dumps(self.params.to_kwargs(), indent=2, sort_keys=True) + "\n"

--- a/mhcflurry/local_parallelism.py
+++ b/mhcflurry/local_parallelism.py
@@ -4,12 +4,14 @@ compute node.
 """
 
 import itertools
+import multiprocessing
+import multiprocessing.pool
 import traceback
 import sys
 import os
 import time
 import queue
-from multiprocessing import Pool, Queue, cpu_count
+from multiprocessing import Queue, cpu_count
 from multiprocessing.util import Finalize
 from pprint import pprint
 import random
@@ -17,6 +19,75 @@ import random
 import numpy
 
 from .common import configure_pytorch, normalize_pytorch_backend
+
+
+# ---- Non-daemonic worker pool --------------------------------------------
+#
+# By default ``multiprocessing.Pool`` spawns daemon workers, and daemon
+# processes cannot fork their own children. That's incompatible with the
+# Phase 1 (#268) PyTorch DataLoader wrap in ``Class1NeuralNetwork.fit``,
+# which uses ``num_workers>0`` to prefetch minibatches via per-DataLoader
+# worker processes. Under the default Pool, the DataLoader init call
+# raises ``AssertionError: daemonic processes are not allowed to have
+# children`` the first time a training epoch tries to iterate.
+#
+# Phase 1 shipped a runtime downgrade (``_effective_num_workers`` in
+# class1_neural_network.py) that silently forces ``num_workers=0`` when
+# called from a daemon process — safe, but it effectively disables
+# DataLoader prefetch in production training. The real fix is here:
+# run Pool workers as NON-daemonic so they can spawn their own children.
+#
+# Non-daemon workers have one behavioral difference worth naming: if the
+# parent process dies ungracefully (e.g. SIGKILL), the workers may
+# linger as zombies rather than being auto-reaped by init. The
+# training orchestrator's ``try/finally`` closes and joins the pool on
+# clean exit, so this only matters under unusual fault modes.
+class NonDaemonProcess(multiprocessing.Process):
+    """A ``multiprocessing.Process`` whose ``daemon`` flag cannot be set.
+
+    Reading ``.daemon`` always returns False; writes are no-ops. This
+    lets us instantiate ``multiprocessing.pool.Pool`` with a worker
+    class that declines to be a daemon, so the DataLoader inside each
+    worker can spawn its own prefetch children.
+    """
+
+    @property
+    def daemon(self) -> bool:
+        return False
+
+    @daemon.setter
+    def daemon(self, value) -> None:
+        # Silently ignore; ``multiprocessing.Pool._repopulate_pool`` sets
+        # daemon=True on every fresh worker, so we must tolerate the
+        # assignment without raising.
+        pass
+
+
+class NonDaemonContext(type(multiprocessing.get_context())):
+    """A multiprocessing context that hands out ``NonDaemonProcess`` workers.
+
+    Subclasses the current default context so the start method (fork on
+    Linux, spawn on macOS) is preserved — we only swap the Process
+    class. The Pool uses ``self._ctx.Process(...)`` to create workers
+    and will now get our non-daemonic variant.
+    """
+
+    Process = NonDaemonProcess
+
+
+class NonDaemonPool(multiprocessing.pool.Pool):
+    """A ``multiprocessing.Pool`` that runs non-daemonic workers.
+
+    Pool's constructor takes a ``context`` kwarg — we thread a
+    ``NonDaemonContext`` through so each worker is a
+    ``NonDaemonProcess``. Everything else (apply_async, imap, etc.)
+    inherits unchanged.
+    """
+
+    def __init__(self, *args, **kwargs):
+        # Callers may pass their own context; if not, use our non-daemon one.
+        kwargs.setdefault("context", NonDaemonContext())
+        super().__init__(*args, **kwargs)
 
 
 def add_local_parallelism_args(parser):
@@ -300,7 +371,10 @@ def make_worker_pool(
         else:
             pool_kwargs["initializer"] = initializer
 
-    worker_pool = Pool(**pool_kwargs)
+    # Use a non-daemonic pool so workers can spawn DataLoader children.
+    # See NonDaemonPool for the rationale and the Phase 1 (#268) crash
+    # it unblocks.
+    worker_pool = NonDaemonPool(**pool_kwargs)
     print("Started pool: %s" % str(worker_pool))
     pprint(pool_kwargs)
     return worker_pool

--- a/mhcflurry/train_pan_allele_models_command.py
+++ b/mhcflurry/train_pan_allele_models_command.py
@@ -4,7 +4,6 @@ Train Class1 pan-allele models.
 import argparse
 import os
 from os.path import join
-from pathlib import Path
 import signal
 import sys
 import time
@@ -36,7 +35,7 @@ from .encodable_sequences import EncodableSequences
 from .encoding_cache import (
     EncodingCache,
     EncodingParams,
-    make_preencoded_encodable_sequences,
+    make_prepopulated_encodable_sequences,
 )
 
 tqdm.monitor_interval = 0  # see https://github.com/tqdm/tqdm/issues/481
@@ -343,7 +342,7 @@ def pretrain_data_iterator(
                 chunk_encoded = numpy.repeat(
                     pretrain_encoded_mmap[indices], len(usable_alleles), axis=0
                 )
-                encodable_peptides = make_preencoded_encodable_sequences(
+                encodable_peptides = make_prepopulated_encodable_sequences(
                     repeated_peptides, chunk_encoded, encoding_params
                 )
 
@@ -576,11 +575,8 @@ def _initialize_encoding_cache(args, all_work_items):
     # that's ~15 min aggregate across 32 work items (the race fix in
     # EncodingCache._build makes this safe but not cheap). Pre-building
     # here amortizes the encoding to a single orchestrator-side pass.
-    #
-    # Guard with isinstance(str): test Mocks return Mock objects for
-    # unset attrs, which are truthy; require a real str/pathlib path.
     pretrain_data_path = getattr(args, "pretrain_data", None)
-    if isinstance(pretrain_data_path, (str, Path)) and pretrain_data_path:
+    if pretrain_data_path:
         pretrain_peptides = _read_pretrain_peptide_list(pretrain_data_path)
         for cfg in configs_seen.values():
             params = EncodingParams(**cfg)
@@ -782,7 +778,7 @@ def _build_train_peptides(peptide_values, hyperparameters, constant_data):
         count=len(peptide_values),
     )
     fold_encoded = encoded_all[fold_indices]
-    return make_preencoded_encodable_sequences(peptide_values, fold_encoded, params)
+    return make_prepopulated_encodable_sequences(peptide_values, fold_encoded, params)
 
 
 def train_model(

--- a/mhcflurry/train_pan_allele_models_command.py
+++ b/mhcflurry/train_pan_allele_models_command.py
@@ -4,6 +4,7 @@ Train Class1 pan-allele models.
 import argparse
 import os
 from os.path import join
+from pathlib import Path
 import signal
 import sys
 import time
@@ -568,6 +569,33 @@ def _initialize_encoding_cache(args, all_work_items):
     # (~20 MB for 1M 12-mers) — fine for a single-box Pool. Revisit if this
     # ever ships to a distributed scheduler.
     GLOBAL_DATA["encoding_cache_unique_peptides"] = unique_peptides
+
+    # Pre-build the pretrain cache too if a pretrain file is configured.
+    # Without this, each worker racing to build the pretrain cache on
+    # first use pays a redundant encoding pass — on an A100 subset run
+    # that's ~15 min aggregate across 32 work items (the race fix in
+    # EncodingCache._build makes this safe but not cheap). Pre-building
+    # here amortizes the encoding to a single orchestrator-side pass.
+    #
+    # Guard with isinstance(str): test Mocks return Mock objects for
+    # unset attrs, which are truthy; require a real str/pathlib path.
+    pretrain_data_path = getattr(args, "pretrain_data", None)
+    if isinstance(pretrain_data_path, (str, Path)) and pretrain_data_path:
+        pretrain_peptides = _read_pretrain_peptide_list(pretrain_data_path)
+        for cfg in configs_seen.values():
+            params = EncodingParams(**cfg)
+            cache = EncodingCache(cache_dir=cache_dir, params=params)
+            if cache.is_complete_for(pretrain_peptides):
+                print(f"Pretrain encoding cache hit: "
+                      f"{cache.entry_path(pretrain_peptides)} "
+                      f"({len(pretrain_peptides)} peptides)")
+                continue
+            print(f"Building pretrain encoding cache for params "
+                  f"{params.to_kwargs()} ({len(pretrain_peptides)} peptides) "
+                  f"at {cache.entry_path(pretrain_peptides)}...")
+            t0 = time.time()
+            cache.get_or_build(pretrain_peptides)
+            print(f"Pretrain encoding cache built in {time.time() - t0:.1f}s.")
 
 
 def _deterministic_unique_peptide_list(peptide_values):

--- a/mhcflurry/train_pan_allele_models_command.py
+++ b/mhcflurry/train_pan_allele_models_command.py
@@ -32,6 +32,11 @@ from .cluster_parallelism import (
     cluster_results_from_args)
 from .allele_encoding import AlleleEncoding
 from .encodable_sequences import EncodableSequences
+from .encoding_cache import (
+    EncodingCache,
+    EncodingParams,
+    make_preencoded_encodable_sequences,
+)
 
 tqdm.monitor_interval = 0  # see https://github.com/tqdm/tqdm/issues/481
 
@@ -126,6 +131,22 @@ parser.add_argument(
     default=False,
     help="Do not actually train models. The initialized run can be continued "
     "later with --continue-incomplete.")
+parser.add_argument(
+    "--use-encoding-cache",
+    action="store_true",
+    default=False,
+    help="Precompute BLOSUM62 peptide encodings once per training run and "
+    "share the result across all worker processes via mmap. Preserves bit-"
+    "identical semantics; the cache output matches EncodableSequences."
+    "variable_length_to_fixed_length_vector_encoding exactly. Saves 30-50x "
+    "per-epoch wall-time on the CPU-bound pan-allele training path. See "
+    "mhcflurry/encoding_cache.py.")
+parser.add_argument(
+    "--encoding-cache-dir",
+    metavar="DIR",
+    default=None,
+    help="Directory for the encoding cache. Default: <out-models-dir>/"
+    "encoding_cache/. Only used when --use-encoding-cache is set.")
 
 add_local_parallelism_args(parser)
 add_cluster_parallelism_args(parser)
@@ -210,7 +231,9 @@ def assign_folds(df, num_folds, held_out_fraction, held_out_max):
 def pretrain_data_iterator(
         filename,
         master_allele_encoding,
-        peptides_per_chunk=1024):
+        peptides_per_chunk=1024,
+        encoding_cache_dir=None,
+        encoding_params=None):
     """
     Step through a CSV file giving predictions for a large number of peptides
     (rows) and alleles (columns).
@@ -220,6 +243,20 @@ def pretrain_data_iterator(
     filename : string
     master_allele_encoding : AlleleEncoding
     peptides_per_chunk : int
+    encoding_cache_dir : string, optional
+        When set together with ``encoding_params``, the iterator pre-reads
+        the CSV's peptide column, pre-encodes all peptides via
+        ``EncodingCache``, and yields ``EncodableSequences`` instances whose
+        per-instance ``encoding_cache`` is prepopulated with the memmap
+        slice for each chunk's peptides. Downstream
+        ``peptides_to_network_input`` calls hit the prepopulated cache and
+        return the stored array without re-encoding. Bit-identical output
+        to the uncached path (verified in
+        ``test_pretrain_iterator_bit_identical`` in
+        test_train_pan_allele_encoding_cache.py).
+    encoding_params : EncodingParams, optional
+        Required when ``encoding_cache_dir`` is set. Determines which
+        entry in the cache to use / build.
 
     Returns
     -------
@@ -243,6 +280,27 @@ def pretrain_data_iterator(
         numpy.tile(usable_alleles, peptides_per_chunk),
         borrow_from=master_allele_encoding)
 
+    # Optionally pre-encode the full CSV's peptides into a shared memmap.
+    # Workers all hit the same mmap via the OS page cache; the physical
+    # encoded bytes live on disk once regardless of how many training
+    # workers ran. See mhcflurry/encoding_cache.py.
+    pretrain_cache = None
+    pretrain_peptide_to_idx = None
+    pretrain_encoded_mmap = None
+    if encoding_cache_dir is not None and encoding_params is not None:
+        pretrain_peptides = _read_pretrain_peptide_list(filename)
+        pretrain_cache = EncodingCache(
+            cache_dir=encoding_cache_dir, params=encoding_params
+        )
+        t0 = time.time()
+        pretrain_encoded_mmap, pretrain_peptide_to_idx = (
+            pretrain_cache.get_or_build(pretrain_peptides)
+        )
+        print(
+            f"Pretrain encoding cache ready ({len(pretrain_peptides)} peptides, "
+            f"{time.time() - t0:.1f}s)."
+        )
+
     while True:
         synthetic_iter = pandas.read_csv(
             filename, index_col=0, chunksize=peptides_per_chunk)
@@ -252,10 +310,41 @@ def pretrain_data_iterator(
 
             df.columns = empty.columns
             df = df[usable_alleles]
-            encodable_peptides = EncodableSequences(
-                numpy.repeat(
-                    df.index.values,
-                    len(usable_alleles)))
+            repeated_peptides = numpy.repeat(df.index.values, len(usable_alleles))
+
+            if pretrain_encoded_mmap is None:
+                encodable_peptides = EncodableSequences(repeated_peptides)
+            else:
+                # Index into the shared memmap and construct an
+                # EncodableSequences with its cache prepopulated. Semantics
+                # are identical to the fresh-encode path.
+                try:
+                    indices = numpy.fromiter(
+                        (pretrain_peptide_to_idx[p] for p in df.index.values),
+                        dtype=numpy.int64,
+                        count=len(df.index),
+                    )
+                except KeyError as missing:
+                    # Actionable error: the cache was built from a different
+                    # file than the one we're now iterating. Point the user
+                    # at the likely remediation (blow away the cache dir or
+                    # pass a fresh --encoding-cache-dir).
+                    raise KeyError(
+                        f"Peptide {missing.args[0]!r} was not in the encoding "
+                        f"cache built from {filename}. The cache at "
+                        f"{encoding_cache_dir} likely corresponds to a "
+                        f"different pretrain CSV. Delete the cache directory "
+                        f"or pass a fresh --encoding-cache-dir and rerun."
+                    ) from missing
+                # Each unique peptide appears len(usable_alleles) times in
+                # the repeated_peptides array; mirror that with a repeat on
+                # the encoded rows.
+                chunk_encoded = numpy.repeat(
+                    pretrain_encoded_mmap[indices], len(usable_alleles), axis=0
+                )
+                encodable_peptides = make_preencoded_encodable_sequences(
+                    repeated_peptides, chunk_encoded, encoding_params
+                )
 
             yield (allele_encoding, encodable_peptides, df.stack().values)
 
@@ -421,6 +510,88 @@ def initialize_training(args):
     print("Done initializing training.")
 
 
+def _initialize_encoding_cache(args, all_work_items):
+    """Pre-build BLOSUM62 encoding caches used by training workers.
+
+    Run once in the orchestrator. Distinct ``peptide_encoding`` configs
+    across the hyperparameters sweep each get their own cache keyed by
+    params hash. Workers subsequently call ``EncodingCache.get_or_build``
+    with the same params + peptides and hit the already-built cache.
+
+    Stores the cache_dir plus the orchestrator-computed unique-peptide
+    list in ``GLOBAL_DATA``. The peptide list is small (a ~20 MB Python
+    list of strings for a 1M-peptide training set) compared to the
+    encoded tensor (~1+ GB), and stashing it means workers skip the
+    `drop_duplicates` + `sha256` pass that would otherwise run 140+ times
+    across a full sweep.
+
+    Safe to call repeatedly; cache hits short-circuit.
+    """
+    cache_dir = args.encoding_cache_dir or join(
+        args.out_models_dir, "encoding_cache"
+    )
+    # Group hyperparameters by their peptide_encoding config so we build one
+    # cache per unique config. Most sweeps share the same config, in which
+    # case this loop runs once.
+    configs_seen = {}
+    for work_item in all_work_items:
+        cfg = work_item["hyperparameters"].get("peptide_encoding", {})
+        # dict isn't hashable; use a sorted-kv string key. The config dict
+        # itself is small and we just need de-duplication.
+        key = tuple(sorted(cfg.items()))
+        configs_seen[key] = cfg
+
+    df = GLOBAL_DATA["train_data"]
+    unique_peptides = _deterministic_unique_peptide_list(df.peptide.values)
+
+    for cfg in configs_seen.values():
+        params = EncodingParams(**cfg)
+        cache = EncodingCache(cache_dir=cache_dir, params=params)
+        if cache.is_complete_for(unique_peptides):
+            print(f"Encoding cache hit: {cache.entry_path(unique_peptides)} "
+                  f"({len(unique_peptides)} peptides)")
+            continue
+        print(f"Building encoding cache for params "
+              f"{params.to_kwargs()} ({len(unique_peptides)} peptides) "
+              f"at {cache.entry_path(unique_peptides)}...")
+        t0 = time.time()
+        cache.get_or_build(unique_peptides)
+        print(f"Encoding cache built in {time.time() - t0:.1f}s.")
+
+    GLOBAL_DATA["encoding_cache_dir"] = str(cache_dir)
+    # Per-arch params lookup: hyperparameters dict doesn't change pickle size
+    # meaningfully, so just stash it. Workers use it to pick the right cache.
+    GLOBAL_DATA["encoding_cache_configs"] = list(configs_seen.values())
+    # Stash the orchestrator-built peptide list + its index map so workers
+    # don't re-run drop_duplicates + sha256 over ~1M peptides on every fold.
+    # The list pickles at roughly (8 bytes + avg peptide length) per entry
+    # (~20 MB for 1M 12-mers) — fine for a single-box Pool. Revisit if this
+    # ever ships to a distributed scheduler.
+    GLOBAL_DATA["encoding_cache_unique_peptides"] = unique_peptides
+
+
+def _deterministic_unique_peptide_list(peptide_values):
+    """Return unique peptides in first-seen order.
+
+    Must be stable: orchestrator's list must match what workers compute, or
+    the cache key (which hashes the list) won't match. pandas.Series
+    .drop_duplicates() preserves first-seen order — use it consistently.
+    """
+    return list(pandas.Series(peptide_values).drop_duplicates())
+
+
+def _read_pretrain_peptide_list(filename):
+    """Read only the peptide column (index) from the pretrain CSV.
+
+    The cache build pass needs the full peptide list up front. Reading
+    just the index column avoids parsing the much-wider affinity matrix.
+    For a 1M-row file this takes a few seconds vs minutes for a full read.
+    """
+    # Reading only usecols=[0] makes pandas parse just the peptide column.
+    peptide_series = pandas.read_csv(filename, index_col=0, usecols=[0]).index
+    return list(peptide_series)
+
+
 def train_models(args):
     global GLOBAL_DATA
 
@@ -434,6 +605,12 @@ def train_models(args):
     print("Loaded training init info.")
 
     all_work_items = GLOBAL_DATA["work_items"]
+
+    # Optionally pre-build the shared BLOSUM62 encoding cache. Orchestrator
+    # does the (single-threaded) encoding pass once; workers mmap the result.
+    # See mhcflurry/encoding_cache.py and issue openvax/mhcflurry#268.
+    if getattr(args, "use_encoding_cache", False):
+        _initialize_encoding_cache(args, all_work_items)
     complete_work_item_names = [
         network.fit_info[-1]["training_info"]["work_item_name"] for network in
         predictor.neural_networks
@@ -534,6 +711,52 @@ def train_models(args):
     print("Predictor written to: %s" % args.out_models_dir)
 
 
+def _build_train_peptides(peptide_values, hyperparameters, constant_data):
+    """Construct an EncodableSequences for the fold's training peptides.
+
+    When the encoding cache is enabled (orchestrator set
+    ``encoding_cache_dir`` in constant_data), we look up each peptide in
+    the pre-built memmap and return an EncodableSequences with its
+    ``encoding_cache`` prepopulated — so the subsequent
+    ``peptides_to_network_input`` call inside ``fit()`` is a memmap slice
+    instead of a fresh BLOSUM62 pass.
+
+    When disabled (default), falls through to the old behavior — a plain
+    ``EncodableSequences(peptides)`` whose first
+    ``variable_length_to_fixed_length_vector_encoding`` call does the
+    encoding work inline. Bit-identical to pre-change behavior.
+    """
+    cache_dir = constant_data.get("encoding_cache_dir")
+    if cache_dir is None:
+        return EncodableSequences(peptide_values)
+
+    cfg = hyperparameters.get("peptide_encoding", {})
+    params = EncodingParams(**cfg)
+    cache = EncodingCache(cache_dir=cache_dir, params=params)
+
+    # Prefer the orchestrator-stashed unique-peptide list so every worker
+    # skips the drop_duplicates + sha256 pass over the ~1M-peptide training
+    # set. Fall back to recomputation if the key is absent (older pickle,
+    # manually-constructed constant_data in tests).
+    unique_peptides = constant_data.get("encoding_cache_unique_peptides")
+    if unique_peptides is None:
+        df = constant_data["train_data"]
+        unique_peptides = _deterministic_unique_peptide_list(df.peptide.values)
+    encoded_all, peptide_to_idx = cache.get_or_build(unique_peptides)
+
+    # Lookup each fold-peptide's row in the memmap. Fancy indexing produces
+    # a contiguous in-memory copy sized (len(fold), enc_len, alphabet); that's
+    # the same materialized tensor the old path would have produced on first
+    # encode call.
+    fold_indices = numpy.fromiter(
+        (peptide_to_idx[p] for p in peptide_values),
+        dtype=numpy.int64,
+        count=len(peptide_values),
+    )
+    fold_encoded = encoded_all[fold_indices]
+    return make_preencoded_encodable_sequences(peptide_values, fold_encoded, params)
+
+
 def train_model(
         work_item_name,
         work_item_num,
@@ -566,7 +789,9 @@ def train_model(
         folds_df["fold_%d" % fold_num]
     ].sample(frac=1.0)
 
-    train_peptides = EncodableSequences(train_data.peptide.values)
+    train_peptides = _build_train_peptides(
+        train_data.peptide.values, hyperparameters, constant_data
+    )
     train_alleles = AlleleEncoding(
         train_data.allele.values, borrow_from=allele_encoding)
 
@@ -634,7 +859,14 @@ def train_model(
             generator = pretrain_data_iterator(
                 pretrain_data_filename,
                 allele_encoding,
-                peptides_per_chunk=pretrain_peptides_per_step)
+                peptides_per_chunk=pretrain_peptides_per_step,
+                encoding_cache_dir=constant_data.get("encoding_cache_dir"),
+                encoding_params=(
+                    EncodingParams(**hyperparameters["peptide_encoding"])
+                    if constant_data.get("encoding_cache_dir")
+                    else None
+                ),
+            )
 
             model.fit_generator(
                 generator,

--- a/scripts/training/pan_allele_ensemble.sh
+++ b/scripts/training/pan_allele_ensemble.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+#
+# Train a full 4 fold × 4 replicate = 16-network pan-allele MHCflurry
+# ensemble on the curated_training_data. Matches the structure of the
+# public release so we can compare predictions head-to-head.
+#
+# Env:
+#   MHCFLURRY_OUT              required — where artifacts are written
+#   ENSEMBLE_MAX_EPOCHS=N      cap epochs per network (default: 500;
+#                              early stopping usually ends long before)
+#   ENSEMBLE_PATIENCE=N        early-stopping patience (default: 20)
+#   ENSEMBLE_NUM_FOLDS=N       override fold count (default: 4)
+#   ENSEMBLE_NUM_REPLICATES=N  override replicate count (default: 4)
+#   ENSEMBLE_NUM_JOBS=N        mhcflurry --num-jobs value (default: 0 =
+#                              inline; >=1 forks a Pool, which has hit
+#                              CUDA-fork interactions — only use when
+#                              you know GPU-per-worker is sane).
+set -euo pipefail
+set -x
+
+: "${MHCFLURRY_OUT:?MHCFLURRY_OUT must be set}"
+MAX_EPOCHS="${ENSEMBLE_MAX_EPOCHS:-500}"
+PATIENCE="${ENSEMBLE_PATIENCE:-20}"
+NUM_FOLDS="${ENSEMBLE_NUM_FOLDS:-4}"
+NUM_REPLICATES="${ENSEMBLE_NUM_REPLICATES:-4}"
+NUM_JOBS="${ENSEMBLE_NUM_JOBS:-0}"
+
+mkdir -p "$MHCFLURRY_OUT"
+cd "$MHCFLURRY_OUT"
+
+mhcflurry-downloads fetch data_curated allele_sequences
+
+TRAINING_DATA="$(mhcflurry-downloads path data_curated)/curated_training_data.csv.bz2"
+ALLELE_SEQUENCES="$(mhcflurry-downloads path allele_sequences)/allele_sequences.csv"
+
+python - <<PY > hyperparameters.yaml
+from yaml import dump
+hp = [{
+    'activation': 'tanh',
+    'allele_dense_layer_sizes': [],
+    'batch_normalization': False,
+    'dense_layer_l1_regularization': 0.0,
+    'dense_layer_l2_regularization': 0.0,
+    'dropout_probability': 0.5,
+    'early_stopping': True,
+    'init': 'glorot_uniform',
+    'layer_sizes': [1024, 512],
+    'learning_rate': 0.001,
+    'locally_connected_layers': [],
+    'topology': 'feedforward',
+    'loss': 'custom:mse_with_inequalities',
+    'max_epochs': ${MAX_EPOCHS},
+    'minibatch_size': 128,
+    'optimizer': 'rmsprop',
+    'output_activation': 'sigmoid',
+    'patience': ${PATIENCE},
+    'min_delta': 0.0,
+    'peptide_encoding': {
+        'vector_encoding_name': 'BLOSUM62',
+        'alignment_method': 'left_pad_centered_right_pad',
+        'max_length': 15,
+    },
+    'peptide_allele_merge_activation': '',
+    'peptide_allele_merge_method': 'concatenate',
+    'peptide_amino_acid_encoding': 'BLOSUM62',
+    'peptide_dense_layer_sizes': [],
+    'random_negative_affinity_max': 50000.0,
+    'random_negative_affinity_min': 30000.0,
+    'random_negative_constant': 1,
+    'random_negative_distribution_smoothing': 0.0,
+    'random_negative_match_distribution': True,
+    'random_negative_rate': 1.0,
+    'random_negative_method': 'by_allele_equalize_nonbinders',
+    'random_negative_binder_threshold': 500.0,
+    'train_data': {'pretrain': False},
+    'validation_split': 0.1,
+    'data_dependent_initialization_method': 'lsuv',
+}]
+print(dump(hp))
+PY
+
+if command -v nvidia-smi >/dev/null 2>&1; then
+    GPUS=$(nvidia-smi -L | wc -l | tr -d ' ')
+else
+    GPUS=0
+fi
+echo "Detected GPUs: $GPUS"
+
+mhcflurry-class1-train-pan-allele-models \
+    --data "$TRAINING_DATA" \
+    --allele-sequences "$ALLELE_SEQUENCES" \
+    --held-out-measurements-per-allele-fraction-and-max 0.25 100 \
+    --num-folds "$NUM_FOLDS" \
+    --num-replicates "$NUM_REPLICATES" \
+    --max-epochs "$MAX_EPOCHS" \
+    --hyperparameters hyperparameters.yaml \
+    --out-models-dir "$MHCFLURRY_OUT/models.ensemble" \
+    --num-jobs "$NUM_JOBS" \
+    --gpus "$GPUS"
+
+echo "Ensemble training completed. Artifacts in: $MHCFLURRY_OUT/models.ensemble"
+ls -la "$MHCFLURRY_OUT/models.ensemble"

--- a/scripts/training/pan_allele_omp_smoketest.sh
+++ b/scripts/training/pan_allele_omp_smoketest.sh
@@ -17,6 +17,8 @@ set -x
 : "${MHCFLURRY_OUT:?MHCFLURRY_OUT must be set}"
 
 export OMP_NUM_THREADS=1
+export MKL_NUM_THREADS=1
+export OPENBLAS_NUM_THREADS=1
 export PYTHONUNBUFFERED=1
 
 SCRIPT_ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"

--- a/scripts/training/pan_allele_omp_smoketest.sh
+++ b/scripts/training/pan_allele_omp_smoketest.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+#
+# Quickly measure per-epoch wall time with OMP_NUM_THREADS=1. Same
+# pipeline as pan_allele_release_exact.sh but caps work:
+#   - 1 fold (not 4)
+#   - 2 architectures (not 35 from generate_hyperparameters.py)
+#   - no percentile-rank calibration
+#   - no model selection step
+#   - cap epochs at 20 per network to bound wall time
+#
+# Target signal: per-epoch time drops from the 200-450s seen without
+# OMP_NUM_THREADS=1 to <20s. If we see <20s on an A100 with OMP=1, the
+# full release-exact run is worth launching.
+set -euo pipefail
+set -x
+
+: "${MHCFLURRY_OUT:?MHCFLURRY_OUT must be set}"
+
+export OMP_NUM_THREADS=1
+export PYTHONUNBUFFERED=1
+
+SCRIPT_ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+SCRIPT_DIR="$(dirname "$SCRIPT_ABSOLUTE_PATH")"
+RECIPE_DIR="$SCRIPT_DIR/release_exact"
+
+mkdir -p "$MHCFLURRY_OUT"
+cd "$MHCFLURRY_OUT"
+
+if command -v nvidia-smi >/dev/null 2>&1; then
+    GPUS=$(nvidia-smi -L 2>/dev/null | wc -l | tr -d ' ')
+else
+    GPUS=0
+fi
+echo "Detected GPUS: $GPUS"
+PARALLELISM_ARGS="--num-jobs $GPUS --max-tasks-per-worker 1 --gpus $GPUS --max-workers-per-gpu 1"
+
+# ---- data (same as public recipe) -----------------------------------
+mhcflurry-downloads fetch data_curated allele_sequences random_peptide_predictions
+
+cp "$RECIPE_DIR/reassign_mass_spec_training_data.py" .
+cp "$RECIPE_DIR/additional_alleles.txt" .
+
+python reassign_mass_spec_training_data.py \
+    "$(mhcflurry-downloads path data_curated)/curated_training_data.csv.bz2" \
+    --set-measurement-value 100 \
+    --out-csv "$(pwd)/train_data.csv"
+bzip2 -f "$(pwd)/train_data.csv"
+TRAINING_DATA="$(pwd)/train_data.csv.bz2"
+
+# ---- sub-sampled hyperparameters (2 arches, capped epochs) ----------
+cp "$RECIPE_DIR/generate_hyperparameters.py" .
+python - <<'PY' > hyperparameters.yaml
+import yaml, sys, importlib.util
+spec = importlib.util.spec_from_file_location("genhp", "generate_hyperparameters.py")
+mod  = importlib.util.module_from_spec(spec); spec.loader.exec_module(mod)
+# generate_hyperparameters.py prints yaml to stdout when run as __main__.
+# Capture via exec to get the in-memory hyperparameters list.
+import io, contextlib
+buf = io.StringIO()
+with contextlib.redirect_stdout(buf):
+    # The script's __name__ == "__main__" path is not reentrant-friendly;
+    # re-exec with __name__ swapped.
+    src = open("generate_hyperparameters.py").read()
+    ns  = {"__name__": "__main__"}
+    exec(compile(src, "generate_hyperparameters.py", "exec"), ns)
+raw = buf.getvalue()
+all_hp = yaml.safe_load(raw)
+sub = all_hp[:2]  # first 2 architectures
+for hp in sub:
+    hp["max_epochs"] = 20  # cap to measure per-epoch time cheaply
+    if "train_data" in hp and isinstance(hp["train_data"], dict):
+        if "pretrain_max_epochs" in hp["train_data"]:
+            hp["train_data"]["pretrain_max_epochs"] = 5
+print(yaml.dump(sub))
+PY
+
+ARCH_COUNT=$(python -c "import yaml; print(len(yaml.safe_load(open('hyperparameters.yaml'))))")
+echo "Architectures in smoketest sweep: $ARCH_COUNT"
+
+ALLELE_SEQUENCES="$(mhcflurry-downloads path allele_sequences)/allele_sequences.csv"
+PRETRAIN_DATA="$(mhcflurry-downloads path random_peptide_predictions)/predictions.csv.bz2"
+
+mhcflurry-class1-train-pan-allele-models \
+    --data "$TRAINING_DATA" \
+    --allele-sequences "$ALLELE_SEQUENCES" \
+    --pretrain-data "$PRETRAIN_DATA" \
+    --held-out-measurements-per-allele-fraction-and-max 0.25 100 \
+    --num-folds 1 \
+    --hyperparameters hyperparameters.yaml \
+    --out-models-dir "$(pwd)/models.smoketest" \
+    --worker-log-dir "$MHCFLURRY_OUT" \
+    $PARALLELISM_ARGS
+
+echo "Smoketest training completed."
+echo "Per-epoch timing summary (look for [53 sec] or similar in brackets):"
+for f in "$MHCFLURRY_OUT"/LOG-worker.*.txt; do
+    [ -f "$f" ] || continue
+    grep -E "Epoch  +[0-9]+ / +[0-9]+ \[" "$f" | head -5
+done
+echo "--- done ---"

--- a/scripts/training/pan_allele_omp_smoketest.sh
+++ b/scripts/training/pan_allele_omp_smoketest.sh
@@ -49,29 +49,20 @@ TRAINING_DATA="$(pwd)/train_data.csv.bz2"
 
 # ---- sub-sampled hyperparameters (2 arches, capped epochs) ----------
 cp "$RECIPE_DIR/generate_hyperparameters.py" .
-python - <<'PY' > hyperparameters.yaml
-import yaml, sys, importlib.util
-spec = importlib.util.spec_from_file_location("genhp", "generate_hyperparameters.py")
-mod  = importlib.util.module_from_spec(spec); spec.loader.exec_module(mod)
-# generate_hyperparameters.py prints yaml to stdout when run as __main__.
-# Capture via exec to get the in-memory hyperparameters list.
-import io, contextlib
-buf = io.StringIO()
-with contextlib.redirect_stdout(buf):
-    # The script's __name__ == "__main__" path is not reentrant-friendly;
-    # re-exec with __name__ swapped.
-    src = open("generate_hyperparameters.py").read()
-    ns  = {"__name__": "__main__"}
-    exec(compile(src, "generate_hyperparameters.py", "exec"), ns)
-raw = buf.getvalue()
-all_hp = yaml.safe_load(raw)
-sub = all_hp[:2]  # first 2 architectures
+# Generate full sweep, then subset to 2 architectures with capped epochs.
+python generate_hyperparameters.py > hyperparameters.full.yaml
+python - <<'PY'
+import yaml
+with open("hyperparameters.full.yaml") as f:
+    all_hp = yaml.safe_load(f)
+sub = all_hp[:2]
 for hp in sub:
-    hp["max_epochs"] = 20  # cap to measure per-epoch time cheaply
+    hp["max_epochs"] = 20
     if "train_data" in hp and isinstance(hp["train_data"], dict):
         if "pretrain_max_epochs" in hp["train_data"]:
             hp["train_data"]["pretrain_max_epochs"] = 5
-print(yaml.dump(sub))
+with open("hyperparameters.yaml", "w") as f:
+    yaml.safe_dump(sub, f)
 PY
 
 ARCH_COUNT=$(python -c "import yaml; print(len(yaml.safe_load(open('hyperparameters.yaml'))))")

--- a/scripts/training/pan_allele_presentation_subset.sh
+++ b/scripts/training/pan_allele_presentation_subset.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+#
+# Subset of the full release-exact pipeline: affinity → processing →
+# presentation end-to-end with a small architecture sweep per variant.
+# Produces a usable Class1PresentationPredictor for Phase D comparison
+# against the public release, and gives us timing / cost signal for
+# extrapolating the full-run budget.
+#
+# Default subset:
+#   Affinity:    4 folds × 8 architectures = 32 networks
+#   Processing:  4 folds × 8 architectures × 2 variants (no_flank,
+#                short_flanks) = 64 networks
+#   Presentation: 1 logistic-regression on top of the above (cheap)
+#
+# Environment:
+#   MHCFLURRY_OUT              required — directory for all artifacts
+#   SUBSET_ARCHS=N             architectures per variant (default 8)
+#   REPO                       path to the rsynced mhcflurry repo (used
+#                              to find downloads-generation recipe files)
+#                              Defaults to $HOME/runplz-repo.
+set -euo pipefail
+set -x
+
+: "${MHCFLURRY_OUT:?MHCFLURRY_OUT must be set}"
+
+export OMP_NUM_THREADS=1
+export PYTHONUNBUFFERED=1
+
+SUBSET_ARCHS="${SUBSET_ARCHS:-8}"
+REPO="${REPO:-$HOME/runplz-repo}"
+
+if command -v nvidia-smi >/dev/null 2>&1; then
+    GPUS=$(nvidia-smi -L 2>/dev/null | wc -l | tr -d ' ')
+else
+    GPUS=0
+fi
+echo "Detected GPUS: $GPUS"
+if [ "$GPUS" -eq 0 ]; then
+    NUM_JOBS=1
+else
+    NUM_JOBS="$GPUS"
+fi
+PARALLELISM_ARGS="--num-jobs $NUM_JOBS --max-tasks-per-worker 1 --gpus $GPUS --max-workers-per-gpu 1"
+
+mkdir -p "$MHCFLURRY_OUT/affinity" "$MHCFLURRY_OUT/processing" "$MHCFLURRY_OUT/presentation"
+
+# ============================================================
+# STAGE 1 — AFFINITY (Class1AffinityPredictor)
+# ============================================================
+echo "=== STAGE 1: AFFINITY ==="
+STAGE1_START=$(date +%s)
+
+cd "$MHCFLURRY_OUT/affinity"
+mhcflurry-downloads fetch data_curated allele_sequences random_peptide_predictions
+
+cp "$REPO/downloads-generation/models_class1_pan/reassign_mass_spec_training_data.py" .
+cp "$REPO/downloads-generation/models_class1_pan/additional_alleles.txt" .
+python reassign_mass_spec_training_data.py \
+    "$(mhcflurry-downloads path data_curated)/curated_training_data.csv.bz2" \
+    --set-measurement-value 100 \
+    --out-csv "$(pwd)/train_data.csv"
+bzip2 -f "$(pwd)/train_data.csv"
+
+cp "$REPO/downloads-generation/models_class1_pan/generate_hyperparameters.py" .
+python generate_hyperparameters.py > hyperparameters.full.yaml
+python - <<PY
+import yaml
+hp = yaml.safe_load(open("hyperparameters.full.yaml"))[:${SUBSET_ARCHS}]
+with open("hyperparameters.yaml", "w") as f:
+    yaml.safe_dump(hp, f)
+print(f"affinity: using {len(hp)} architectures")
+PY
+
+mhcflurry-class1-train-pan-allele-models \
+    --data "$(pwd)/train_data.csv.bz2" \
+    --allele-sequences "$(mhcflurry-downloads path allele_sequences)/allele_sequences.csv" \
+    --pretrain-data "$(mhcflurry-downloads path random_peptide_predictions)/predictions.csv.bz2" \
+    --held-out-measurements-per-allele-fraction-and-max 0.25 100 \
+    --num-folds 4 \
+    --hyperparameters hyperparameters.yaml \
+    --out-models-dir "$(pwd)/models.unselected" \
+    --worker-log-dir "$MHCFLURRY_OUT/affinity" \
+    $PARALLELISM_ARGS
+
+mhcflurry-class1-select-pan-allele-models \
+    --data "$(pwd)/models.unselected/train_data.csv.bz2" \
+    --models-dir "$(pwd)/models.unselected" \
+    --out-models-dir "$(pwd)/models.combined" \
+    --min-models 1 \
+    --max-models 4 \
+    $PARALLELISM_ARGS
+cp "$(pwd)/models.unselected/train_data.csv.bz2" "$(pwd)/models.combined/train_data.csv.bz2"
+
+AFFINITY_PREDICTOR="$MHCFLURRY_OUT/affinity/models.combined"
+echo "affinity predictor at: $AFFINITY_PREDICTOR"
+echo "STAGE 1 duration: $(( $(date +%s) - STAGE1_START )) sec"
+
+# ============================================================
+# STAGE 2 — PROCESSING (no_flank + short_flanks)
+# Only those two variants are consumed by the presentation predictor.
+# ============================================================
+echo "=== STAGE 2: PROCESSING ==="
+STAGE2_START=$(date +%s)
+
+cd "$MHCFLURRY_OUT/processing"
+mhcflurry-downloads fetch data_mass_spec_annotated data_references
+
+cp "$REPO/downloads-generation/models_class1_processing/annotate_hits_with_expression.py" .
+cp "$REPO/downloads-generation/models_class1_processing/write_proteome_peptides.py" .
+cp "$REPO/downloads-generation/models_class1_processing/make_train_data.py" make_train_data.processing.py
+cp "$REPO/downloads-generation/models_class1_processing/generate_hyperparameters.base.py" .
+cp "$REPO/downloads-generation/models_class1_processing/generate_hyperparameters.variants.py" .
+
+python annotate_hits_with_expression.py \
+    --hits "$(mhcflurry-downloads path data_mass_spec_annotated)/annotated_ms.csv.bz2" \
+    --expression "$(mhcflurry-downloads path data_curated)/rna_expression.csv.bz2" \
+    --out "$(pwd)/hits_with_tpm.csv"
+bzip2 -f "$(pwd)/hits_with_tpm.csv"
+
+python write_proteome_peptides.py \
+    "$(mhcflurry-downloads path data_mass_spec_annotated)/annotated_ms.csv.bz2" \
+    "$(mhcflurry-downloads path data_references)/uniprot_proteins.csv.bz2" \
+    --out "$(pwd)/proteome_peptides.csv"
+bzip2 -f "$(pwd)/proteome_peptides.csv"
+
+python make_train_data.processing.py \
+    --hits "$(pwd)/hits_with_tpm.csv.bz2" \
+    --affinity-predictor "$AFFINITY_PREDICTOR" \
+    --proteome-peptides "$(pwd)/proteome_peptides.csv.bz2" \
+    --ppv-multiplier 100 \
+    --hit-multiplier-to-take 2 \
+    --out "$(pwd)/train_data.csv" \
+    $PARALLELISM_ARGS
+bzip2 -f "$(pwd)/train_data.csv"
+
+python generate_hyperparameters.base.py > hyperparameters.base.yaml
+
+for kind in no_flank short_flanks; do
+    python generate_hyperparameters.variants.py hyperparameters.base.yaml $kind \
+        > hyperparameters.$kind.full.yaml
+    python - <<PY
+import yaml
+hp = yaml.unsafe_load(open("hyperparameters.$kind.full.yaml"))[:${SUBSET_ARCHS}]
+# Avoid python/tuple tags on write so downstream readers can safe_load.
+for d in hp:
+    def _detuple(x):
+        if isinstance(x, tuple): return list(x)
+        if isinstance(x, list):  return [_detuple(e) for e in x]
+        if isinstance(x, dict):  return {k: _detuple(v) for k, v in x.items()}
+        return x
+    hp_list_safe = [_detuple(d) for d in hp]
+with open("hyperparameters.$kind.yaml", "w") as f:
+    yaml.safe_dump([_detuple(d) for d in hp], f)
+print(f"processing.$kind: using {len(hp)} architectures")
+PY
+
+    mhcflurry-class1-train-processing-models \
+        --data "$(pwd)/train_data.csv.bz2" \
+        --held-out-samples 10 \
+        --num-folds 4 \
+        --hyperparameters hyperparameters.$kind.yaml \
+        --out-models-dir "$(pwd)/models.unselected.$kind" \
+        --worker-log-dir "$MHCFLURRY_OUT/processing" \
+        $PARALLELISM_ARGS
+
+    mhcflurry-class1-select-processing-models \
+        --data "$(pwd)/models.unselected.$kind/train_data.csv.bz2" \
+        --models-dir "$(pwd)/models.unselected.$kind" \
+        --out-models-dir "$(pwd)/models.selected.$kind" \
+        --min-models 1 \
+        --max-models 2 \
+        $PARALLELISM_ARGS
+    cp "$(pwd)/models.unselected.$kind/train_data.csv.bz2" \
+        "$(pwd)/models.selected.$kind/train_data.csv.bz2"
+done
+
+echo "STAGE 2 duration: $(( $(date +%s) - STAGE2_START )) sec"
+
+# ============================================================
+# STAGE 3 — PRESENTATION (Class1PresentationPredictor)
+# ============================================================
+echo "=== STAGE 3: PRESENTATION ==="
+STAGE3_START=$(date +%s)
+
+cd "$MHCFLURRY_OUT/presentation"
+cp "$REPO/downloads-generation/models_class1_presentation/make_train_data.py" \
+    make_train_data.presentation.py
+
+python make_train_data.presentation.py \
+    --hits "$MHCFLURRY_OUT/processing/hits_with_tpm.csv.bz2" \
+    --proteome-peptides "$MHCFLURRY_OUT/processing/proteome_peptides.csv.bz2" \
+    --decoys-per-hit 2 \
+    --exclude-pmid 31844290 31495665 31154438 \
+    --only-format MULTIALLELIC \
+    --sample-fraction 0.1 \
+    --out "$(pwd)/train_data.csv"
+bzip2 -f "$(pwd)/train_data.csv"
+
+time mhcflurry-class1-train-presentation-models \
+    --data "$(pwd)/train_data.csv.bz2" \
+    --affinity-predictor "$AFFINITY_PREDICTOR" \
+    --processing-predictor-with-flanks "$MHCFLURRY_OUT/processing/models.selected.short_flanks" \
+    --processing-predictor-without-flanks "$MHCFLURRY_OUT/processing/models.selected.no_flank" \
+    --out-models-dir "$(pwd)/models"
+
+time mhcflurry-calibrate-percentile-ranks \
+    --models-dir "$(pwd)/models" \
+    --match-amino-acid-distribution-data "$AFFINITY_PREDICTOR/train_data.csv.bz2" \
+    --alleles-file "$AFFINITY_PREDICTOR/train_data.csv.bz2" \
+    --predictor-kind class1_presentation \
+    --num-peptides-per-length 10000 \
+    --alleles-per-genotype 1 \
+    --num-genotypes 50 \
+    --verbosity 1 \
+    $PARALLELISM_ARGS
+
+# Convenience: copy training data into the final bundle like the
+# release does.
+cp "$AFFINITY_PREDICTOR/train_data.csv.bz2" \
+    "$(pwd)/models/affinity_predictor_train_data.csv.bz2"
+cp "$MHCFLURRY_OUT/processing/models.selected.short_flanks/train_data.csv.bz2" \
+    "$(pwd)/models/processing_predictor_with_flanks_train_data.csv.bz2"
+cp "$MHCFLURRY_OUT/processing/models.selected.no_flank/train_data.csv.bz2" \
+    "$(pwd)/models/processing_predictor_no_flank_train_data.csv.bz2"
+
+echo "STAGE 3 duration: $(( $(date +%s) - STAGE3_START )) sec"
+
+echo "=== DONE ==="
+echo "Final presentation predictor: $MHCFLURRY_OUT/presentation/models/"
+ls -la "$MHCFLURRY_OUT/presentation/models" | head -20

--- a/scripts/training/pan_allele_presentation_subset.sh
+++ b/scripts/training/pan_allele_presentation_subset.sh
@@ -77,11 +77,26 @@ mkdir -p "$MHCFLURRY_OUT/affinity" "$MHCFLURRY_OUT/processing" "$MHCFLURRY_OUT/p
 # ---- optional Nsight Systems profiling wrapper ----------------------
 # Profile only stage 1 (affinity), for a bounded duration. Everything
 # else runs bare so the 4-6 hr full run isn't slowed/ballooned.
+#
+# The pytorch/pytorch:2.4.0-cuda12.1-cudnn9-devel image installs nsys at
+# /usr/local/cuda/bin/nsys but does NOT add that dir to the default PATH,
+# so a plain `command -v nsys` misses it (this bit us on the 2026-04-21
+# A100 subset run — profiling silently skipped). Probe both the default
+# PATH and the canonical CUDA bin path before giving up.
 NSYS_WRAP=()
 if [ "${NSYS_PROFILE:-0}" = "1" ]; then
+    NSYS_BIN=""
     if command -v nsys >/dev/null 2>&1; then
+        NSYS_BIN="$(command -v nsys)"
+    elif [ -x /usr/local/cuda/bin/nsys ]; then
+        NSYS_BIN="/usr/local/cuda/bin/nsys"
+    elif [ -x /opt/nvidia/nsight-systems/bin/nsys ]; then
+        NSYS_BIN="/opt/nvidia/nsight-systems/bin/nsys"
+    fi
+
+    if [ -n "$NSYS_BIN" ]; then
         NSYS_WRAP=(
-            nsys profile
+            "$NSYS_BIN" profile
             --duration=180        # 3 min capture window
             --trace=cuda,nvtx,osrt
             --follow-fork=true    # mhcflurry uses multiprocessing.Pool
@@ -91,7 +106,7 @@ if [ "${NSYS_PROFILE:-0}" = "1" ]; then
         )
         echo "NSYS_PROFILE=1: will wrap stage 1 affinity training with: ${NSYS_WRAP[*]}"
     else
-        echo "WARNING: NSYS_PROFILE=1 but 'nsys' not found in PATH; continuing without profiling."
+        echo "WARNING: NSYS_PROFILE=1 but no nsys found in PATH, /usr/local/cuda/bin, or /opt/nvidia/nsight-systems/bin; continuing without profiling. Install with 'apt-get install -y nsight-systems-cli' on Ubuntu images."
     fi
 fi
 

--- a/scripts/training/pan_allele_presentation_subset.sh
+++ b/scripts/training/pan_allele_presentation_subset.sh
@@ -24,9 +24,16 @@ set -x
 : "${MHCFLURRY_OUT:?MHCFLURRY_OUT must be set}"
 
 export OMP_NUM_THREADS=1
+export MKL_NUM_THREADS=1
+export OPENBLAS_NUM_THREADS=1
 export PYTHONUNBUFFERED=1
 
 SUBSET_ARCHS="${SUBSET_ARCHS:-8}"
+# Per-worker GPU memory during mhcflurry training + validation inference
+# peaks at 16-22 GB (activation tensors, not weights). On A100-80GB, 2
+# workers fit comfortably (~44 GB); 4 workers OOMs deterministically.
+# On A100-40GB, 1 worker is the safe ceiling.
+MAX_WORKERS_PER_GPU="${MAX_WORKERS_PER_GPU:-2}"
 REPO="${REPO:-$HOME/runplz-repo}"
 
 if command -v nvidia-smi >/dev/null 2>&1; then
@@ -38,11 +45,32 @@ echo "Detected GPUS: $GPUS"
 if [ "$GPUS" -eq 0 ]; then
     NUM_JOBS=1
 else
-    NUM_JOBS="$GPUS"
+    NUM_JOBS="$(( GPUS * MAX_WORKERS_PER_GPU ))"
 fi
-PARALLELISM_ARGS="--num-jobs $NUM_JOBS --max-tasks-per-worker 1 --gpus $GPUS --max-workers-per-gpu 1"
+PARALLELISM_ARGS="--num-jobs $NUM_JOBS --max-tasks-per-worker 1 --gpus $GPUS --max-workers-per-gpu $MAX_WORKERS_PER_GPU"
 
 mkdir -p "$MHCFLURRY_OUT/affinity" "$MHCFLURRY_OUT/processing" "$MHCFLURRY_OUT/presentation"
+
+# ---- optional Nsight Systems profiling wrapper ----------------------
+# Profile only stage 1 (affinity), for a bounded duration. Everything
+# else runs bare so the 4-6 hr full run isn't slowed/ballooned.
+NSYS_WRAP=()
+if [ "${NSYS_PROFILE:-0}" = "1" ]; then
+    if command -v nsys >/dev/null 2>&1; then
+        NSYS_WRAP=(
+            nsys profile
+            --duration=180        # 3 min capture window
+            --trace=cuda,nvtx,osrt
+            --follow-fork=true    # mhcflurry uses multiprocessing.Pool
+            --sample=none         # cheaper; we care about GPU vs CPU not PC
+            --output="$MHCFLURRY_OUT/nsys_profile_stage1_affinity"
+            --force-overwrite=true
+        )
+        echo "NSYS_PROFILE=1: will wrap stage 1 affinity training with: ${NSYS_WRAP[*]}"
+    else
+        echo "WARNING: NSYS_PROFILE=1 but 'nsys' not found in PATH; continuing without profiling."
+    fi
+fi
 
 # ============================================================
 # STAGE 1 — AFFINITY (Class1AffinityPredictor)
@@ -71,7 +99,7 @@ with open("hyperparameters.yaml", "w") as f:
 print(f"affinity: using {len(hp)} architectures")
 PY
 
-mhcflurry-class1-train-pan-allele-models \
+"${NSYS_WRAP[@]}" mhcflurry-class1-train-pan-allele-models \
     --data "$(pwd)/train_data.csv.bz2" \
     --allele-sequences "$(mhcflurry-downloads path allele_sequences)/allele_sequences.csv" \
     --pretrain-data "$(mhcflurry-downloads path random_peptide_predictions)/predictions.csv.bz2" \

--- a/scripts/training/pan_allele_presentation_subset.sh
+++ b/scripts/training/pan_allele_presentation_subset.sh
@@ -34,7 +34,30 @@ SUBSET_ARCHS="${SUBSET_ARCHS:-8}"
 # workers fit comfortably (~44 GB); 4 workers OOMs deterministically.
 # On A100-40GB, 1 worker is the safe ceiling.
 MAX_WORKERS_PER_GPU="${MAX_WORKERS_PER_GPU:-2}"
+# Phase 1 (#268) encoding cache: pre-encode BLOSUM62 peptide vectors
+# once and share across workers via mmap. Opt-in for safety; set
+# USE_ENCODING_CACHE=0 to run the legacy path. Cache materializes under
+# $MHCFLURRY_OUT/affinity/encoding_cache.
+USE_ENCODING_CACHE="${USE_ENCODING_CACHE:-1}"
+# DataLoader prefetch workers per training process. 0 = no prefetch
+# (bit-identical to pre-#268). 4 overlaps CPU data-prep with GPU
+# compute; each adds ~100-500 MB RSS.
+DATALOADER_NUM_WORKERS="${DATALOADER_NUM_WORKERS:-4}"
 REPO="${REPO:-$HOME/runplz-repo}"
+
+# Inject dataloader_num_workers into hyperparameters for all training
+# stages. Applied post-YAML-generation so we don't need to edit
+# generate_hyperparameters.py upstream.
+HYPERPARAMETER_INJECT=(
+    "dataloader_num_workers=$DATALOADER_NUM_WORKERS"
+)
+
+# Extra flags for mhcflurry-class1-train-pan-allele-models to enable the
+# encoding cache.
+CACHE_ARGS=()
+if [ "$USE_ENCODING_CACHE" = "1" ]; then
+    CACHE_ARGS=(--use-encoding-cache)
+fi
 
 if command -v nvidia-smi >/dev/null 2>&1; then
     GPUS=$(nvidia-smi -L 2>/dev/null | wc -l | tr -d ' ')
@@ -94,9 +117,24 @@ python generate_hyperparameters.py > hyperparameters.full.yaml
 python - <<PY
 import yaml
 hp = yaml.safe_load(open("hyperparameters.full.yaml"))[:${SUBSET_ARCHS}]
+# Inject per-run overrides (e.g. dataloader_num_workers from issue #268)
+# without having to edit generate_hyperparameters.py upstream.
+overrides = dict(kv.split("=", 1) for kv in """${HYPERPARAMETER_INJECT[@]}""".split() if "=" in kv)
+for k, v in overrides.items():
+    # Int-typed overrides (dataloader_num_workers) must parse as int;
+    # fall back to string if not numeric.
+    try:
+        parsed = int(v)
+    except ValueError:
+        try:
+            parsed = float(v)
+        except ValueError:
+            parsed = v
+    for d in hp:
+        d[k] = parsed
 with open("hyperparameters.yaml", "w") as f:
     yaml.safe_dump(hp, f)
-print(f"affinity: using {len(hp)} architectures")
+print(f"affinity: using {len(hp)} architectures; overrides={overrides}")
 PY
 
 "${NSYS_WRAP[@]}" mhcflurry-class1-train-pan-allele-models \
@@ -108,6 +146,7 @@ PY
     --hyperparameters hyperparameters.yaml \
     --out-models-dir "$(pwd)/models.unselected" \
     --worker-log-dir "$MHCFLURRY_OUT/affinity" \
+    "${CACHE_ARGS[@]}" \
     $PARALLELISM_ARGS
 
 mhcflurry-class1-select-pan-allele-models \

--- a/scripts/training/pan_allele_release_exact.sh
+++ b/scripts/training/pan_allele_release_exact.sh
@@ -59,6 +59,16 @@ fi
 echo "Num jobs: $NUM_JOBS (max-workers-per-gpu=$MAX_WORKERS_PER_GPU)"
 PARALLELISM_ARGS="--num-jobs $NUM_JOBS --max-tasks-per-worker 1 --gpus $GPUS --max-workers-per-gpu $MAX_WORKERS_PER_GPU"
 
+# Phase 1 (#268): enable the BLOSUM62 encoding cache + DataLoader prefetch
+# by default. USE_ENCODING_CACHE=0 or DATALOADER_NUM_WORKERS=0 restores
+# the pre-#268 legacy path (bit-identical; verified by Phase 1 tests).
+USE_ENCODING_CACHE="${USE_ENCODING_CACHE:-1}"
+DATALOADER_NUM_WORKERS="${DATALOADER_NUM_WORKERS:-4}"
+CACHE_ARGS=()
+if [ "$USE_ENCODING_CACHE" = "1" ]; then
+    CACHE_ARGS=(--use-encoding-cache)
+fi
+
 # ---- data ------------------------------------------------------------
 mhcflurry-downloads fetch data_curated allele_sequences random_peptide_predictions
 
@@ -75,7 +85,17 @@ TRAINING_DATA="$(pwd)/train_data.csv.bz2"
 
 # ---- hyperparameters -------------------------------------------------
 cp "$RECIPE_DIR/generate_hyperparameters.py" .
-python generate_hyperparameters.py > hyperparameters.yaml
+python generate_hyperparameters.py > hyperparameters.full.yaml
+# Inject dataloader_num_workers into every arch entry (Phase 1 #268).
+python - <<PY
+import yaml
+hp = yaml.safe_load(open("hyperparameters.full.yaml"))
+for d in hp:
+    d["dataloader_num_workers"] = $DATALOADER_NUM_WORKERS
+with open("hyperparameters.yaml", "w") as f:
+    yaml.safe_dump(hp, f)
+print(f"release_exact: {len(hp)} archs with dataloader_num_workers=$DATALOADER_NUM_WORKERS")
+PY
 ARCH_COUNT=$(python -c "import yaml; print(len(yaml.safe_load(open('hyperparameters.yaml'))))")
 echo "Architectures in sweep: $ARCH_COUNT"
 
@@ -103,6 +123,7 @@ do
         --hyperparameters hyperparameters.yaml \
         --out-models-dir "$(pwd)/$UNSELECTED_DIR" \
         --worker-log-dir "$MHCFLURRY_OUT" \
+        "${CACHE_ARGS[@]}" \
         $PARALLELISM_ARGS $CONTINUE_ARGS
 done
 echo "Done training. Beginning model selection."

--- a/scripts/training/pan_allele_release_exact.sh
+++ b/scripts/training/pan_allele_release_exact.sh
@@ -37,6 +37,32 @@ RECIPE_DIR="$SCRIPT_DIR/release_exact"
 mkdir -p "$MHCFLURRY_OUT"
 cd "$MHCFLURRY_OUT"
 
+# ---- GPU occupancy sampler (background, for later analysis) ----------
+# Sample nvidia-smi every 30 s into a CSV that rsync-down can pull back.
+# Captures per-GPU util, memory, and timestamp so we can answer "what
+# was the steady-state occupancy?" without having to SSH live during
+# the run. Auto-exits when the training process ends (watches its pid).
+if command -v nvidia-smi >/dev/null 2>&1; then
+    GPU_LOG="$MHCFLURRY_OUT/gpu_occupancy.csv"
+    {
+        echo "timestamp,gpu_index,util_percent,mem_used_mib,mem_total_mib"
+        while :; do
+            ts=$(date +%s)
+            nvidia-smi \
+                --query-gpu=index,utilization.gpu,memory.used,memory.total \
+                --format=csv,noheader,nounits 2>/dev/null \
+              | while IFS=',' read -r idx util mem_used mem_total; do
+                  echo "$ts,${idx// /},${util// /},${mem_used// /},${mem_total// /}"
+              done
+            sleep 30
+        done
+    } > "$GPU_LOG" 2>/dev/null &
+    GPU_SAMPLER_PID=$!
+    echo "GPU occupancy sampler PID: $GPU_SAMPLER_PID → $GPU_LOG"
+    # Make sure the sampler dies when the script exits (clean or error).
+    trap "kill $GPU_SAMPLER_PID 2>/dev/null; wait $GPU_SAMPLER_PID 2>/dev/null" EXIT
+fi
+
 # ---- parallelism -----------------------------------------------------
 if command -v nvidia-smi >/dev/null 2>&1; then
     GPUS=$(nvidia-smi -L 2>/dev/null | wc -l | tr -d ' ')

--- a/scripts/training/pan_allele_release_exact.sh
+++ b/scripts/training/pan_allele_release_exact.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+#
+# Exact replication of the public mhcflurry pan-allele release training
+# recipe (models_class1_pan, 2.2.0's GENERATE.sh — local mode, not
+# cluster). Uses the same `generate_hyperparameters.py`,
+# `reassign_mass_spec_training_data.py`, `additional_alleles.txt`, the
+# same curated_training_data and pretrain data (random_peptide_predictions),
+# same 4 folds, same architecture sweep, same --min-models/--max-models
+# selection, and runs percentile-rank calibration on the final ensemble.
+#
+# Env:
+#   MHCFLURRY_OUT              required — where artifacts are written.
+#                              Final selected ensemble lives at
+#                              $MHCFLURRY_OUT/models.combined/.
+#   NUM_JOBS=N                 parallelism (default: $GPUS). Controls
+#                              how many networks train concurrently;
+#                              mhcflurry pairs jobs 1:1 with GPUs.
+set -euo pipefail
+set -x
+
+: "${MHCFLURRY_OUT:?MHCFLURRY_OUT must be set}"
+
+SCRIPT_ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+SCRIPT_DIR="$(dirname "$SCRIPT_ABSOLUTE_PATH")"
+RECIPE_DIR="$SCRIPT_DIR/release_exact"
+
+mkdir -p "$MHCFLURRY_OUT"
+cd "$MHCFLURRY_OUT"
+
+# ---- parallelism -----------------------------------------------------
+if command -v nvidia-smi >/dev/null 2>&1; then
+    GPUS=$(nvidia-smi -L 2>/dev/null | wc -l | tr -d ' ')
+else
+    GPUS=0
+fi
+echo "Detected GPUS: $GPUS"
+
+PROCESSORS=$(getconf _NPROCESSORS_ONLN)
+echo "Detected processors: $PROCESSORS"
+
+if [ "$GPUS" -eq "0" ]; then
+    NUM_JOBS="${NUM_JOBS-1}"
+else
+    NUM_JOBS="${NUM_JOBS-$GPUS}"
+fi
+echo "Num jobs: $NUM_JOBS"
+PARALLELISM_ARGS="--num-jobs $NUM_JOBS --max-tasks-per-worker 1 --gpus $GPUS --max-workers-per-gpu 1"
+
+# ---- data ------------------------------------------------------------
+mhcflurry-downloads fetch data_curated allele_sequences random_peptide_predictions
+
+# Reassign mass-spec training rows per release recipe.
+cp "$RECIPE_DIR/reassign_mass_spec_training_data.py" .
+cp "$RECIPE_DIR/additional_alleles.txt" .
+
+python reassign_mass_spec_training_data.py \
+    "$(mhcflurry-downloads path data_curated)/curated_training_data.csv.bz2" \
+    --set-measurement-value 100 \
+    --out-csv "$(pwd)/train_data.csv"
+bzip2 -f "$(pwd)/train_data.csv"
+TRAINING_DATA="$(pwd)/train_data.csv.bz2"
+
+# ---- hyperparameters -------------------------------------------------
+cp "$RECIPE_DIR/generate_hyperparameters.py" .
+python generate_hyperparameters.py > hyperparameters.yaml
+ARCH_COUNT=$(python -c "import yaml; print(len(yaml.safe_load(open('hyperparameters.yaml'))))")
+echo "Architectures in sweep: $ARCH_COUNT"
+
+ALLELE_SEQUENCES="$(mhcflurry-downloads path allele_sequences)/allele_sequences.csv"
+PRETRAIN_DATA="$(mhcflurry-downloads path random_peptide_predictions)/predictions.csv.bz2"
+
+# ---- train all candidates (4 folds × ARCH_COUNT architectures) ------
+# `combined` is the only kind the public release trains (see GENERATE.sh).
+for kind in combined
+do
+    UNSELECTED_DIR="models.unselected.${kind}"
+
+    CONTINUE_ARGS=""
+    if [ -d "$UNSELECTED_DIR" ]; then
+        echo "Found existing $UNSELECTED_DIR — continuing incomplete run"
+        CONTINUE_ARGS="--continue-incomplete"
+    fi
+
+    mhcflurry-class1-train-pan-allele-models \
+        --data "$TRAINING_DATA" \
+        --allele-sequences "$ALLELE_SEQUENCES" \
+        --pretrain-data "$PRETRAIN_DATA" \
+        --held-out-measurements-per-allele-fraction-and-max 0.25 100 \
+        --num-folds 4 \
+        --hyperparameters hyperparameters.yaml \
+        --out-models-dir "$(pwd)/$UNSELECTED_DIR" \
+        --worker-log-dir "$MHCFLURRY_OUT" \
+        $PARALLELISM_ARGS $CONTINUE_ARGS
+done
+echo "Done training. Beginning model selection."
+
+# ---- select ---------------------------------------------------------
+for kind in combined
+do
+    UNSELECTED_DIR="models.unselected.${kind}"
+    SELECTED_DIR="models.${kind}"
+
+    mhcflurry-class1-select-pan-allele-models \
+        --data "$UNSELECTED_DIR/train_data.csv.bz2" \
+        --models-dir "$UNSELECTED_DIR" \
+        --out-models-dir "$SELECTED_DIR" \
+        --min-models 2 \
+        --max-models 8 \
+        $PARALLELISM_ARGS
+    cp "$UNSELECTED_DIR/train_data.csv.bz2" "$SELECTED_DIR/train_data.csv.bz2"
+
+    # ---- percentile rank calibration (matches release) ---------------
+    time mhcflurry-calibrate-percentile-ranks \
+        --models-dir "$SELECTED_DIR" \
+        --match-amino-acid-distribution-data "$UNSELECTED_DIR/train_data.csv.bz2" \
+        --motif-summary \
+        --num-peptides-per-length 100000 \
+        --alleles-per-work-chunk 10 \
+        --verbosity 1 \
+        $PARALLELISM_ARGS
+done
+
+echo "Full release-exact training completed."
+echo "Final ensemble: $MHCFLURRY_OUT/models.combined/"
+ls -la "$MHCFLURRY_OUT/models.combined" | head -30

--- a/scripts/training/pan_allele_release_exact.sh
+++ b/scripts/training/pan_allele_release_exact.sh
@@ -26,6 +26,8 @@ set -x
 # (6x oversubscription), 20-40x slowdown, and near-idle GPUs. One thread
 # per worker lets the GPU actually be the limiting factor.
 export OMP_NUM_THREADS=1
+export MKL_NUM_THREADS=1
+export OPENBLAS_NUM_THREADS=1
 export PYTHONUNBUFFERED=1
 
 SCRIPT_ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
@@ -46,13 +48,16 @@ echo "Detected GPUS: $GPUS"
 PROCESSORS=$(getconf _NPROCESSORS_ONLN)
 echo "Detected processors: $PROCESSORS"
 
+# Per-worker peak is 16-22 GB on mhcflurry pan-allele training (observed on
+# A100-80GB). Safe: 2 on 80GB, 1 on 40GB. 4 OOMs on 80GB.
+MAX_WORKERS_PER_GPU="${MAX_WORKERS_PER_GPU:-2}"
 if [ "$GPUS" -eq "0" ]; then
     NUM_JOBS="${NUM_JOBS-1}"
 else
-    NUM_JOBS="${NUM_JOBS-$GPUS}"
+    NUM_JOBS="${NUM_JOBS-$(( GPUS * MAX_WORKERS_PER_GPU ))}"
 fi
-echo "Num jobs: $NUM_JOBS"
-PARALLELISM_ARGS="--num-jobs $NUM_JOBS --max-tasks-per-worker 1 --gpus $GPUS --max-workers-per-gpu 1"
+echo "Num jobs: $NUM_JOBS (max-workers-per-gpu=$MAX_WORKERS_PER_GPU)"
+PARALLELISM_ARGS="--num-jobs $NUM_JOBS --max-tasks-per-worker 1 --gpus $GPUS --max-workers-per-gpu $MAX_WORKERS_PER_GPU"
 
 # ---- data ------------------------------------------------------------
 mhcflurry-downloads fetch data_curated allele_sequences random_peptide_predictions

--- a/scripts/training/pan_allele_release_exact.sh
+++ b/scripts/training/pan_allele_release_exact.sh
@@ -20,6 +20,14 @@ set -x
 
 : "${MHCFLURRY_OUT:?MHCFLURRY_OUT must be set}"
 
+# CRITICAL: matches GENERATE.sh in the public release. Without this,
+# numpy/MKL in each worker multi-threads to all available cores. With
+# 8 parallel workers on a 120-vCPU box that gave us load avg ~713
+# (6x oversubscription), 20-40x slowdown, and near-idle GPUs. One thread
+# per worker lets the GPU actually be the limiting factor.
+export OMP_NUM_THREADS=1
+export PYTHONUNBUFFERED=1
+
 SCRIPT_ABSOLUTE_PATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
 SCRIPT_DIR="$(dirname "$SCRIPT_ABSOLUTE_PATH")"
 RECIPE_DIR="$SCRIPT_DIR/release_exact"

--- a/scripts/training/release_exact/additional_alleles.txt
+++ b/scripts/training/release_exact/additional_alleles.txt
@@ -1,0 +1,3 @@
+# Additional alleles besides those in the training data to include in percentile rank calibration
+HLA-C*02:10
+HLA-A*02:20

--- a/scripts/training/release_exact/generate_hyperparameters.base.py
+++ b/scripts/training/release_exact/generate_hyperparameters.base.py
@@ -1,0 +1,52 @@
+"""
+Generate grid of hyperparameters
+"""
+from __future__ import print_function
+from sys import stdout, stderr
+from copy import deepcopy
+from yaml import dump
+
+base_hyperparameters = dict(
+    convolutional_filters=64,
+    convolutional_kernel_size=8,
+    convolutional_kernel_l1_l2=(0.00, 0.0),
+    flanking_averages=True,
+    n_flank_length=15,
+    c_flank_length=15,
+    post_convolutional_dense_layer_sizes=[],
+    minibatch_size=512,
+    dropout_rate=0.5,
+    convolutional_activation="relu",
+    patience=20,
+    learning_rate=0.001)
+
+grid = []
+
+
+def hyperparrameters_grid():
+    for learning_rate in [0.001]:
+        for convolutional_activation in ["tanh", "relu"]:
+            for convolutional_filters in [256, 512]:
+                for flanking_averages in [True]:
+                    for convolutional_kernel_size in [11, 13, 15, 17]:
+                        for l1 in [0.0, 1e-6]:
+                            for s in [[8], [16]]:
+                                for d in [0.3, 0.5]:
+                                    new = deepcopy(base_hyperparameters)
+                                    new["learning_rate"] = learning_rate
+                                    new["convolutional_activation"] = convolutional_activation
+                                    new["convolutional_filters"] = convolutional_filters
+                                    new["flanking_averages"] = flanking_averages
+                                    new["convolutional_kernel_size"] = convolutional_kernel_size
+                                    new["convolutional_kernel_l1_l2"] = (l1, 0.0)
+                                    new["post_convolutional_dense_layer_sizes"] = s
+                                    new["dropout_rate"] = d
+                                    yield new
+
+
+for new in hyperparrameters_grid():
+    if new not in grid:
+        grid.append(new)
+
+print("Hyperparameters grid size: %d" % len(grid), file=stderr)
+dump(grid, stdout)

--- a/scripts/training/release_exact/generate_hyperparameters.py
+++ b/scripts/training/release_exact/generate_hyperparameters.py
@@ -1,0 +1,81 @@
+"""
+Generate grid of hyperparameters
+"""
+
+from sys import stdout
+from copy import deepcopy
+from yaml import dump
+
+base_hyperparameters = {
+    'activation': 'tanh',
+    'allele_dense_layer_sizes': [],
+    'batch_normalization': False,
+    'dense_layer_l1_regularization': 0.0,
+    'dense_layer_l2_regularization': 0.0,
+    'dropout_probability': 0.5,
+    'early_stopping': True,
+    'init': 'glorot_uniform',
+    'layer_sizes': [1024, 512],
+    'learning_rate': 0.001,
+    'locally_connected_layers': [],
+    'topology': 'feedfoward',
+    'loss': 'custom:mse_with_inequalities',
+    'max_epochs': 5000,
+    'minibatch_size': 128,
+    'optimizer': 'rmsprop',
+    'output_activation': 'sigmoid',
+    "patience": 20,
+    "min_delta": 0.0,
+    'peptide_encoding': {
+        'vector_encoding_name': 'BLOSUM62',
+        'alignment_method': 'left_pad_centered_right_pad',
+        'max_length': 15,
+    },
+    'peptide_allele_merge_activation': '',
+    'peptide_allele_merge_method': 'concatenate',
+    'peptide_amino_acid_encoding': 'BLOSUM62',
+    'peptide_dense_layer_sizes': [],
+    'random_negative_affinity_max': 50000.0,
+    'random_negative_affinity_min': 30000.0,
+    'random_negative_constant': 1,
+    'random_negative_distribution_smoothing': 0.0,
+    'random_negative_match_distribution': True,
+    'random_negative_rate': 1.0,
+    'random_negative_method': 'by_allele_equalize_nonbinders',
+    'random_negative_binder_threshold': 500.0,
+    'train_data': {
+        'pretrain': True,
+        'pretrain_peptides_per_epoch': 64,
+        'pretrain_steps_per_epoch': 256,
+        'pretrain_patience': 2,
+        'pretrain_min_delta': 0.0001,
+        'pretrain_max_val_loss': 0.10,
+        'pretrain_max_epochs': 50,
+        'pretrain_min_epochs': 5,
+    },
+    'validation_split': 0.1,
+    'data_dependent_initialization_method': "lsuv",
+}
+
+grid = []
+for layer_sizes in [[512, 256], [512, 512], [1024, 512], [1024, 1024]]:
+    l1_base = 0.0000001
+    for l1 in [l1_base, l1_base / 10, l1_base / 100, l1_base / 1000, 0.0]:
+        new = deepcopy(base_hyperparameters)
+        new["topology"] = 'feedforward'
+        new["layer_sizes"] = layer_sizes
+        new["dense_layer_l1_regularization"] = l1
+        if not grid or new not in grid:
+            grid.append(new)
+
+for layer_sizes in [[256, 512], [256, 256, 512], [256, 512, 512]]:
+    l1_base = 0.0000001
+    for l1 in [l1_base, l1_base / 10, l1_base / 100, l1_base / 1000, 0.0]:
+        new = deepcopy(base_hyperparameters)
+        new["topology"] = 'with-skip-connections'
+        new["layer_sizes"] = layer_sizes
+        new["dense_layer_l1_regularization"] = l1
+        if not grid or new not in grid:
+            grid.append(new)
+
+dump(grid, stdout)

--- a/scripts/training/release_exact/generate_hyperparameters.variants.py
+++ b/scripts/training/release_exact/generate_hyperparameters.variants.py
@@ -1,0 +1,45 @@
+"""
+Generate grid of hyperparameters
+"""
+
+from sys import stdout, argv
+from copy import deepcopy
+from yaml import dump, load
+import argparse
+
+parser = argparse.ArgumentParser(usage=__doc__)
+parser.add_argument(
+    "production_hyperparameters",
+    metavar="data.json",
+    help="Production (i.e. standard) hyperparameters grid.")
+parser.add_argument(
+    "kind",
+    choices=('with_flanks', 'no_n_flank', 'no_c_flank', 'no_flank', 'short_flanks'),
+    help="Hyperameters variant to output")
+
+args = parser.parse_args(argv[1:])
+
+with open(args.production_hyperparameters) as fd:
+    production_hyperparameters_list = load(fd)
+
+
+def transform(kind, hyperparameters):
+    new_hyperparameters = deepcopy(hyperparameters)
+    if kind == "no_n_flank" or kind == "no_flank":
+        new_hyperparameters["n_flank_length"] = 0
+    if kind == "no_c_flank" or kind == "no_flank":
+        new_hyperparameters["c_flank_length"] = 0
+    if kind == "short_flanks":
+        new_hyperparameters["c_flank_length"] = 5
+        new_hyperparameters["n_flank_length"] = 5
+    return [new_hyperparameters]
+
+
+result_list = []
+for item in production_hyperparameters_list:
+    results = transform(args.kind, item)
+    for result_item in results:
+        if result_item not in result_list:
+            result_list.append(result_item)
+
+dump(result_list, stdout)

--- a/scripts/training/release_exact/make_train_data.presentation.py
+++ b/scripts/training/release_exact/make_train_data.presentation.py
@@ -1,0 +1,224 @@
+"""
+Make training data by selecting decoys, etc.
+"""
+import sys
+import argparse
+import os
+import numpy
+import collections
+
+import pandas
+import tqdm
+
+import mhcflurry
+
+parser = argparse.ArgumentParser(usage=__doc__)
+
+parser.add_argument(
+    "--hits",
+    metavar="CSV",
+    required=True,
+    help="Multiallelic mass spec")
+parser.add_argument(
+    "--proteome-peptides",
+    metavar="CSV",
+    required=True,
+    help="Proteome peptides")
+parser.add_argument(
+    "--decoys-per-hit",
+    type=float,
+    metavar="N",
+    default=99,
+    help="Decoys per hit")
+parser.add_argument(
+    "--exclude-pmid",
+    nargs="+",
+    default=[],
+    help="Exclude given PMID")
+parser.add_argument(
+    "--only-pmid",
+    nargs="*",
+    default=[],
+    help="Include only the given PMID")
+parser.add_argument(
+    "--exclude-train-data",
+    nargs="+",
+    default=[],
+    help="Remove hits and decoys included in the given training data")
+parser.add_argument(
+    "--only-format",
+    choices=("MONOALLELIC", "MULTIALLELIC"),
+    help="Include only data of the given format")
+parser.add_argument(
+    "--sample-fraction",
+    type=float,
+    help="Subsample data by specified fraction (e.g. 0.1)")
+parser.add_argument(
+    "--out",
+    metavar="CSV",
+    required=True,
+    help="File to write")
+
+
+def run():
+    args = parser.parse_args(sys.argv[1:])
+    hit_df = pandas.read_csv(args.hits)
+    hit_df["pmid"] = hit_df["pmid"].astype(str)
+    original_samples_pmids = hit_df.pmid.unique()
+    numpy.testing.assert_equal(hit_df.hit_id.nunique(), len(hit_df))
+    hit_df = hit_df.loc[
+        (hit_df.mhc_class == "I") &
+        (hit_df.peptide.str.len() <= 11) &
+        (hit_df.peptide.str.len() >= 8) &
+        (~hit_df.protein_ensembl.isnull()) &
+        (hit_df.peptide.str.match("^[%s]+$" % "".join(
+            mhcflurry.amino_acid.COMMON_AMINO_ACIDS)))
+    ]
+    hit_df['alleles'] = hit_df.hla.str.split().map(tuple)
+    print("Loaded hits from %d samples" % hit_df.sample_id.nunique())
+    if args.only_format:
+        hit_df = hit_df.loc[hit_df.format == args.only_format].copy()
+        print("Subselected to %d %s samples" % (
+            hit_df.sample_id.nunique(), args.only_format))
+
+    if args.only_pmid or args.exclude_pmid:
+        assert not (args.only_pmid and args.exclude_pmid)
+
+        pmids = list(args.only_pmid) + list(args.exclude_pmid)
+        missing = [pmid for pmid in pmids if pmid not in original_samples_pmids]
+        assert not missing, (missing, original_samples_pmids)
+
+        mask = hit_df.pmid.isin(pmids)
+        if args.exclude_pmid:
+            mask = ~mask
+
+        new_hit_df = hit_df.loc[mask]
+        print(
+            "Selecting by pmids",
+            pmids,
+            "reduced dataset from",
+            len(hit_df),
+            "to",
+            len(new_hit_df))
+        hit_df = new_hit_df.copy()
+        print("Subselected by pmid to %d samples" % hit_df.sample_id.nunique())
+
+    allele_to_excluded_peptides = collections.defaultdict(set)
+    for train_dataset in args.exclude_train_data:
+        if not train_dataset:
+            continue
+        print("Excluding hits from", train_dataset)
+        train_df = pandas.read_csv(train_dataset)
+        for (allele, peptides) in train_df.groupby("allele").peptide.unique().iteritems():
+            allele_to_excluded_peptides[allele].update(peptides)
+        train_counts = train_df.groupby(
+            ["allele", "peptide"]).measurement_value.count().to_dict()
+        hit_no_train = hit_df.loc[
+            [
+                not any([
+                    train_counts.get((allele, row.peptide))
+                    for allele in row.alleles
+                ])
+            for _, row in tqdm.tqdm(hit_df.iterrows(), total=len(hit_df))]
+        ]
+        print(
+            "Excluding hits from",
+            train_dataset,
+            "reduced dataset from",
+            len(hit_df),
+            "to",
+            len(hit_no_train))
+        hit_df = hit_no_train
+
+    sample_table = hit_df.drop_duplicates("sample_id").set_index("sample_id")
+    grouped = hit_df.groupby("sample_id").nunique()
+    for col in sample_table.columns:
+        if (grouped[col] > 1).any():
+            del sample_table[col]
+
+    print("Loading proteome peptides")
+    all_peptides_df = pandas.read_csv(args.proteome_peptides)
+    print("Loaded: ", all_peptides_df.shape)
+
+    all_peptides_df = all_peptides_df.loc[
+        all_peptides_df.protein_accession.isin(hit_df.protein_accession.unique()) &
+        all_peptides_df.peptide.str.match("^[%s]+$" % "".join(
+            mhcflurry.amino_acid.COMMON_AMINO_ACIDS))
+    ].copy()
+    all_peptides_df["length"] = all_peptides_df.peptide.str.len()
+    print("Subselected proteome peptides by accession: ", all_peptides_df.shape)
+
+    all_peptides_by_length = dict(iter(all_peptides_df.groupby("length")))
+
+    print("Selecting decoys.")
+
+    lengths = [8, 9, 10, 11]
+    result_df = []
+
+    for sample_id, sub_df in tqdm.tqdm(
+            hit_df.groupby("sample_id"), total=hit_df.sample_id.nunique()):
+        result_df.append(
+            sub_df[[
+                "protein_accession",
+                "peptide",
+                "sample_id",
+                "n_flank",
+                "c_flank",
+            ]].copy())
+        result_df[-1]["hit"] = 1
+
+        excluded_peptides = set()
+        for allele in sample_table.loc[sample_id].alleles:
+            excluded_peptides.update(allele_to_excluded_peptides[allele])
+        print(
+            sample_id,
+            "will exclude",
+            len(excluded_peptides),
+            "peptides from decoy universe")
+
+        for length in lengths:
+            universe = all_peptides_by_length[length]
+            possible_universe = universe.loc[
+                (~universe.peptide.isin(sub_df.peptide.unique())) &
+                (~universe.peptide.isin(excluded_peptides)) &
+                (universe.protein_accession.isin(sub_df.protein_accession.unique()))
+            ]
+            selected_decoys = possible_universe.sample(
+                n=int(len(sub_df) * args.decoys_per_hit / len(lengths)))
+
+            result_df.append(selected_decoys[
+                ["protein_accession", "peptide", "n_flank", "c_flank"]
+            ].copy())
+            result_df[-1]["hit"] = 0
+            result_df[-1]["sample_id"] = sample_id
+
+    result_df = pandas.concat(result_df, ignore_index=True, sort=False)
+    result_df["hla"] = result_df.sample_id.map(sample_table.hla)
+
+    print(result_df)
+    print("Counts:")
+    print(result_df.groupby(["sample_id", "hit"]).peptide.nunique())
+
+    print("Hit counts:")
+    print(
+        result_df.loc[
+            result_df.hit == 1
+        ].groupby("sample_id").hit.count().sort_values())
+
+    print("Hit rates:")
+    print(result_df.groupby("sample_id").hit.mean().sort_values())
+
+    if args.sample_fraction:
+        print("Subsampling to ", args.sample_fraction)
+        result_df = result_df.sample(frac=args.sample_fraction)
+        print("Subsampled:")
+        print(result_df)
+        print("Hit rates:")
+        print(result_df.groupby("sample_id").hit.mean().sort_values())
+
+    result_df.to_csv(args.out, index=False)
+    print("Wrote: ", args.out)
+
+
+if __name__ == '__main__':
+    run()

--- a/scripts/training/release_exact/make_train_data.processing.py
+++ b/scripts/training/release_exact/make_train_data.processing.py
@@ -1,0 +1,319 @@
+"""
+Make training data by selecting decoys, etc.
+"""
+import sys
+import argparse
+import os
+import numpy
+import time
+from functools import partial
+
+import pandas
+import tqdm
+
+tqdm.monitor_interval = 0  # see https://github.com/tqdm/tqdm/issues/481
+
+from mhcflurry.common import configure_logging
+from mhcflurry.local_parallelism import (
+    add_local_parallelism_args,
+    worker_pool_with_gpu_assignments_from_args,
+    call_wrapped_kwargs)
+from mhcflurry.cluster_parallelism import (
+    add_cluster_parallelism_args,
+    cluster_results_from_args)
+
+
+# To avoid pickling large matrices to send to child processes when running in
+# parallel, we use this global variable as a place to store data. Data that is
+# stored here before creating the thread pool will be inherited to the child
+# processes upon fork() call, allowing us to share large data with the workers
+# via shared memory.
+GLOBAL_DATA = {}
+
+
+parser = argparse.ArgumentParser(usage=__doc__)
+
+parser.add_argument(
+    "--hits",
+    metavar="CSV",
+    required=True,
+    help="Multiallelic mass spec")
+parser.add_argument(
+    "--affinity-predictor",
+    required=True,
+    metavar="CSV",
+    help="Class 1 affinity predictor to use (exclusive with --predictions)")
+parser.add_argument(
+    "--proteome-peptides",
+    metavar="CSV",
+    required=True,
+    help="Proteome peptides")
+parser.add_argument(
+    "--hit-multiplier-to-take",
+    type=float,
+    default=1,
+    help="")
+parser.add_argument(
+    "--ppv-multiplier",
+    type=int,
+    metavar="N",
+    default=1000,
+    help="Take top 1/N predictions.")
+parser.add_argument(
+    "--exclude-contig",
+    help="Exclude entries annotated to the given contig")
+parser.add_argument(
+    "--out",
+    metavar="CSV",
+    required=True,
+    help="File to write")
+parser.add_argument(
+    "--alleles",
+    nargs="+",
+    help="Include only the specified alleles")
+
+add_local_parallelism_args(parser)
+add_cluster_parallelism_args(parser)
+
+
+def do_process_samples(samples, constant_data=None):
+    import mhcflurry
+    import pandas
+    import tqdm
+    tqdm.monitor_interval = 0  # see https://github.com/tqdm/tqdm/issues/481
+
+    columns_to_keep = [
+        "hit_id",
+        "protein_accession",
+        "n_flank",
+        "c_flank",
+        "peptide",
+        "sample_id",
+        "affinity_prediction",
+        "hit",
+    ]
+
+    if constant_data is None:
+        constant_data = GLOBAL_DATA
+
+    args = constant_data['args']
+    lengths = constant_data['lengths']
+    all_peptides_by_length = constant_data['all_peptides_by_length']
+    sample_table = constant_data['sample_table']
+
+    hit_df = constant_data['hit_df']
+    hit_df = hit_df.loc[
+        hit_df.sample_id.isin(samples)
+    ]
+
+    affinity_predictor = mhcflurry.Class1AffinityPredictor.load(
+        args.affinity_predictor)
+    print("Loaded", affinity_predictor)
+
+    result_df = []
+    for sample_id, sub_hit_df in tqdm.tqdm(
+            hit_df.groupby("sample_id"), total=hit_df.sample_id.nunique()):
+
+        sub_hit_df = sub_hit_df.copy()
+        sub_hit_df["hit"] = 1
+
+        decoys_df = []
+        for length in lengths:
+            universe = all_peptides_by_length[length]
+            decoys_df.append(
+                universe.loc[
+                    (~universe.peptide.isin(sub_hit_df.peptide.unique())) &
+                    (universe.protein_accession.isin(sub_hit_df.protein_accession.unique()))
+                ].sample(
+                    n=int(len(sub_hit_df) * args.ppv_multiplier / len(lengths)))[[
+                        "protein_accession", "peptide", "n_flank", "c_flank"
+                ]].drop_duplicates("peptide"))
+
+        merged_df = pandas.concat(
+            [sub_hit_df] + decoys_df, ignore_index=True, sort=False)
+
+        prediction_col = "%s affinity" % sample_table.loc[sample_id].hla
+        predictions_df = pandas.DataFrame(
+            index=merged_df.peptide.unique(),
+            columns=[prediction_col])
+
+        predictions_df[prediction_col] = affinity_predictor.predict(
+            predictions_df.index,
+            allele=sample_table.loc[sample_id].hla)
+
+        merged_df["affinity_prediction"] = merged_df.peptide.map(
+            predictions_df[prediction_col])
+        merged_df = merged_df.sort_values("affinity_prediction", ascending=True)
+
+        num_to_take = int(len(sub_hit_df) * args.hit_multiplier_to_take)
+        selected_df = merged_df.head(num_to_take)[
+                columns_to_keep
+        ].sample(frac=1.0).copy()
+        selected_df["hit"] = selected_df["hit"].fillna(0)
+        selected_df["sample_id"] = sample_id
+        result_df.append(selected_df)
+
+        print(
+            "Processed sample",
+            sample_id,
+            "with hit and decoys:\n",
+            selected_df.hit.value_counts())
+
+    result_df = pandas.concat(result_df, ignore_index=True, sort=False)
+    return result_df
+
+
+def run():
+    import mhcflurry
+
+    args = parser.parse_args(sys.argv[1:])
+
+    configure_logging()
+
+    serial_run = not args.cluster_parallelism and args.num_jobs == 0
+
+    hit_df = pandas.read_csv(args.hits)
+    numpy.testing.assert_equal(hit_df.hit_id.nunique(), len(hit_df))
+    hit_df = hit_df.loc[
+        (hit_df.mhc_class == "I") &
+        (hit_df.peptide.str.len() <= 11) &
+        (hit_df.peptide.str.len() >= 8) &
+        (~hit_df.protein_ensembl.isnull()) &
+        (hit_df.peptide.str.match("^[%s]+$" % "".join(
+            mhcflurry.amino_acid.COMMON_AMINO_ACIDS)))
+    ]
+    print("Loaded hits from %d samples" % hit_df.sample_id.nunique())
+    hit_df = hit_df.loc[hit_df.format == "MONOALLELIC"].copy()
+    print("Subselected to %d monoallelic samples" % hit_df.sample_id.nunique())
+    hit_df["allele"] = hit_df.hla
+
+    hit_df = hit_df.loc[hit_df.allele.str.match("^HLA-[ABC]")]
+    print("Subselected to %d HLA-A/B/C samples" % hit_df.sample_id.nunique())
+
+    if args.exclude_contig:
+        new_hit_df = hit_df.loc[
+            hit_df.protein_primary_ensembl_contig.astype(str) !=
+            args.exclude_contig
+        ]
+        print(
+            "Excluding contig",
+            args.exclude_contig,
+            "reduced dataset from",
+            len(hit_df),
+            "to",
+            len(new_hit_df))
+        hit_df = new_hit_df.copy()
+    if args.alleles:
+        filter_alleles = set(args.alleles)
+        new_hit_df = hit_df.loc[
+            hit_df.allele.isin(filter_alleles)
+        ]
+        print(
+            "Selecting alleles",
+            args.alleles,
+            "reduced dataset from",
+            len(hit_df),
+            "to",
+            len(new_hit_df))
+        hit_df = new_hit_df.copy()
+
+    sample_table = hit_df.drop_duplicates("sample_id").set_index("sample_id")
+    grouped = hit_df.groupby("sample_id").nunique()
+    for col in sample_table.columns:
+        if (grouped[col] > 1).any():
+            del sample_table[col]
+    sample_table["total_hits"] = hit_df.groupby("sample_id").peptide.nunique()
+
+    print("Loading proteome peptides")
+    all_peptides_df = pandas.read_csv(args.proteome_peptides)
+    print("Loaded: ", all_peptides_df.shape)
+
+    all_peptides_df = all_peptides_df.loc[
+        all_peptides_df.protein_accession.isin(hit_df.protein_accession.unique()) &
+        all_peptides_df.peptide.str.match("^[%s]+$" % "".join(
+            mhcflurry.amino_acid.COMMON_AMINO_ACIDS))
+    ].copy()
+    all_peptides_df["length"] = all_peptides_df.peptide.str.len()
+    print("Subselected proteome peptides by accession: ", all_peptides_df.shape)
+
+    all_peptides_by_length = dict(iter(all_peptides_df.groupby("length")))
+
+    print("Selecting decoys.")
+
+    GLOBAL_DATA['args'] = args
+    GLOBAL_DATA['lengths'] = [8, 9, 10, 11]
+    GLOBAL_DATA['all_peptides_by_length'] = all_peptides_by_length
+    GLOBAL_DATA['sample_table'] = sample_table
+    GLOBAL_DATA['hit_df'] = hit_df
+
+    worker_pool = None
+    start = time.time()
+
+    tasks = [
+        {"samples": [sample]} for sample in hit_df.sample_id.unique()
+    ]
+
+    if serial_run:
+        # Serial run
+        print("Running in serial.")
+        results = [do_process_samples(hit_df.sample_id.unique())]
+    elif args.cluster_parallelism:
+        # Run using separate processes HPC cluster.
+        print("Running on cluster.")
+        results = cluster_results_from_args(
+            args,
+            work_function=do_process_samples,
+            work_items=tasks,
+            constant_data=GLOBAL_DATA,
+            input_serialization_method="dill",
+            result_serialization_method="pickle",
+            clear_constant_data=False)
+    else:
+        worker_pool = worker_pool_with_gpu_assignments_from_args(args)
+        print("Worker pool", worker_pool)
+        assert worker_pool is not None
+        results = worker_pool.imap_unordered(
+            partial(call_wrapped_kwargs, do_process_samples),
+            tasks,
+            chunksize=1)
+
+    print("Reading results")
+
+    result_df = []
+    for worker_result in tqdm.tqdm(results, total=len(tasks)):
+        for sample_id, selected_df in worker_result.groupby("sample_id"):
+            print(
+                "Received result for sample",
+                sample_id,
+                "with hit and decoys:\n",
+                selected_df.hit.value_counts())
+        result_df.append(worker_result)
+
+    print("Received all results in %0.2f sec" % (time.time() - start))
+
+    result_df = pandas.concat(result_df, ignore_index=True, sort=False)
+    result_df["hla"] = result_df.sample_id.map(sample_table.hla)
+
+    print(result_df)
+    print("Counts:")
+    print(result_df.groupby(["sample_id", "hit"]).peptide.nunique())
+
+    print("Hit counts:")
+    print(
+        result_df.loc[
+            result_df.hit == 1
+        ].groupby("sample_id").hit.count().sort_values())
+
+    print("Hit rates:")
+    print(result_df.groupby("sample_id").hit.mean().sort_values())
+
+    result_df.to_csv(args.out, index=False)
+    print("Wrote: ", args.out)
+
+    if worker_pool:
+        worker_pool.close()
+        worker_pool.join()
+
+
+if __name__ == '__main__':
+    run()

--- a/scripts/training/release_exact/reassign_mass_spec_training_data.py
+++ b/scripts/training/release_exact/reassign_mass_spec_training_data.py
@@ -1,0 +1,53 @@
+"""
+Reassign affinity values for mass spec data
+"""
+import sys
+import os
+import argparse
+
+import pandas
+
+parser = argparse.ArgumentParser(usage=__doc__)
+
+parser.add_argument("data", metavar="CSV", help="Training data")
+parser.add_argument("--ms-only", action="store_true", default=False)
+parser.add_argument("--drop-negative-ms", action="store_true", default=False)
+parser.add_argument("--set-measurement-value", type=float)
+parser.add_argument("--out-csv")
+
+pandas.set_option('display.max_columns', 500)
+
+
+def go(args):
+    df = pandas.read_csv(args.data)
+    print(df)
+
+    if args.drop_negative_ms:
+        bad = df.loc[
+            (df.measurement_kind == "mass_spec") &
+            (df.measurement_inequality != "<")
+        ]
+        print("Dropping ", len(bad))
+        df = df.loc[~df.index.isin(bad.index)].copy()
+
+    if args.ms_only:
+        print("Filtering to MS only")
+        df = df.loc[df.measurement_kind == "mass_spec"].copy()
+
+    if args.set_measurement_value is not None:
+        indexer = df.measurement_kind == "mass_spec"
+        df.loc[
+            indexer,
+            "measurement_value"
+        ] = args.set_measurement_value
+        print("Reassigned:")
+        print(df.loc[indexer])
+
+    if args.out_csv:
+        out_csv = os.path.abspath(args.out_csv)
+        df.to_csv(out_csv, index=False)
+        print("Wrote", out_csv)
+
+
+if __name__ == "__main__":
+    go(parser.parse_args(sys.argv[1:]))

--- a/scripts/validate_against_public.py
+++ b/scripts/validate_against_public.py
@@ -87,25 +87,39 @@ def swap_affinity_into_presentation(public_presentation, new_affinity):
     )
 
 
-def predict_affinity(pred, peptides, alleles) -> pd.DataFrame:
-    """Tall DataFrame: peptide, allele, affinity_nM."""
+def predict_affinity(pred, peptides, alleles, encoding_cache_dir=None) -> pd.DataFrame:
+    """Tall DataFrame: peptide, allele, affinity_nM.
+
+    Batches by allele so the full peptide list goes through predict()
+    once per allele (letting the Phase 3 encoding cache, if configured,
+    prepopulate once and reuse across alleles).
+    """
     rows = []
-    for p in peptides:
-        for a in alleles:
-            try:
-                aff = float(pred.predict(peptides=[p], alleles=[a])[0])
-            except Exception as exc:
-                aff = float("nan")
-                print(f"  [warn] affinity {p}+{a}: {exc!r}", file=sys.stderr)
-            rows.append({"peptide": p, "allele": a, "affinity_nM": aff})
+    peptides = list(peptides)
+    for a in alleles:
+        try:
+            affs = pred.predict(
+                peptides=peptides, alleles=[a] * len(peptides),
+                encoding_cache_dir=encoding_cache_dir,
+            )
+        except Exception as exc:
+            print(f"  [warn] affinity allele={a}: {exc!r}", file=sys.stderr)
+            affs = [float("nan")] * len(peptides)
+        for p, aff in zip(peptides, affs):
+            rows.append({"peptide": p, "allele": a, "affinity_nM": float(aff)})
     return pd.DataFrame(rows)
 
 
-def predict_presentation(pred, peptides, alleles) -> pd.DataFrame:
+def predict_presentation(pred, peptides, alleles, encoding_cache_dir=None) -> pd.DataFrame:
     """Tall DataFrame: peptide, allele, presentation_score. Uses the
     without-flanks processing model since our canonical peptide list
     doesn't carry true source-protein context. Higher = more likely
     presented."""
+    # Note: Class1PresentationPredictor.predict doesn't accept
+    # encoding_cache_dir yet — the affinity sub-predictor inside does.
+    # When the presentation predictor's own signature picks up the
+    # param, propagate it here; for now it's ignored (we share the
+    # affinity-side speedup via the shared cache on disk anyway).
     rows = []
     for a in alleles:
         try:
@@ -224,6 +238,12 @@ def main():
     p.add_argument("--public-presentation", default=None,
                    help="dir with public models_class1_presentation/models/. "
                         "If given, presentation Spearman is also reported.")
+    p.add_argument("--encoding-cache-dir", default=None,
+                   help="Shared BLOSUM62 peptide encoding cache directory "
+                        "(Phase 3 of #268). Populated once on the first "
+                        "predict() call, reused by all subsequent predicts "
+                        "— so comparing N predictors on the same peptide "
+                        "list costs 1 encoding pass instead of N.")
     args = p.parse_args()
 
     peptides = [pep for pep, _, _ in KNOWN_BINDERS]
@@ -241,8 +261,12 @@ def main():
 
     print(f"[predict] affinity: {len(peptides)} peptides × {len(alleles)} alleles = "
           f"{len(peptides)*len(alleles)} pairs, both models")
-    df_aff_ours = predict_affinity(ours_aff, peptides, alleles)
-    df_aff_public = predict_affinity(public_aff, peptides, alleles)
+    df_aff_ours = predict_affinity(
+        ours_aff, peptides, alleles, encoding_cache_dir=args.encoding_cache_dir
+    )
+    df_aff_public = predict_affinity(
+        public_aff, peptides, alleles, encoding_cache_dir=args.encoding_cache_dir
+    )
 
     out = Path("out/validation")
     out.mkdir(parents=True, exist_ok=True)
@@ -260,8 +284,12 @@ def main():
         print(f"[predict] presentation: {len(peptides)} peptides × {len(alleles)} alleles, "
               f"both models (without flanks — canonical peptide list has no true "
               f"source-protein flanking context)")
-        df_pres_ours = predict_presentation(ours_pres, peptides, alleles)
-        df_pres_public = predict_presentation(public_pres, peptides, alleles)
+        df_pres_ours = predict_presentation(
+            ours_pres, peptides, alleles, encoding_cache_dir=args.encoding_cache_dir
+        )
+        df_pres_public = predict_presentation(
+            public_pres, peptides, alleles, encoding_cache_dir=args.encoding_cache_dir
+        )
 
         merged_pres = run_comparison(
             df_pres_ours, df_pres_public, "presentation_score", False, "PRESENTATION"

--- a/scripts/validate_against_public.py
+++ b/scripts/validate_against_public.py
@@ -1,21 +1,26 @@
 """Compare a freshly-trained pan-allele predictor against the public
 mhcflurry release on a peptide × allele grid.
 
-For each peptide we pick a canonical allele it's known to bind, then
-mix in "distractor" alleles known to bind different peptide motifs.
-Our trained predictor should:
-  1. Rank canonical peptide-allele pairs above distractor pairs
-     consistently with the public weights.
-  2. Produce affinities in similar range (IC50 nM).
+Two levels of comparison are reported:
 
-We also sample random per-peptide allele subsets (Alex's "per sample
-allele lists sampled at random") and compare the relative ranking of
-alleles our model vs the public one produces.
+  1. **Affinity** — load each model as a Class1AffinityPredictor and
+     predict IC50 for every (peptide, allele) pair. Spearman measures
+     rank agreement with the public affinity predictor.
+
+  2. **Presentation** — load the public Class1PresentationPredictor,
+     then swap its affinity predictor for ours while keeping the
+     public's processing predictors and logistic weights. This isolates
+     how much our affinity change propagates through the full
+     presentation stack.
+
+We also tally canonical-allele rank-1 hits and best-allele agreement
+across random per-peptide 4-subsets of the allele pool.
 
 Run:
     python scripts/validate_against_public.py \\
-        --ours out/models.single/    \\
-        --public $(mhcflurry-downloads path models_class1_pan)/models.combined/
+        --ours out/models.unselected.release/    \\
+        --public $(mhcflurry-downloads path models_class1_pan)/models.combined/ \\
+        --public-presentation $(mhcflurry-downloads path models_class1_presentation)/models/
 """
 
 from __future__ import annotations
@@ -27,23 +32,23 @@ from pathlib import Path
 
 import pandas as pd
 
-# Well-characterized peptide / allele binding pairs. Pulled from commonly
-# cited MHC I epitopes — the canonical allele is what the peptide is
-# known to bind; the distractor is a different canonical binder for a
-# different peptide.
+# Well-characterized peptide / allele binding pairs with source antigen.
+# SPRWYFYYL (SARS-CoV-2 N protein) dropped: both ours and public rank
+# B*07:02 over B*35:01 for that peptide (motif at C-term Leu fits B*07,
+# not B*35), so the canonical label is ambiguous and it penalized both
+# models equally.
 KNOWN_BINDERS = [
-    # peptide            canonical_allele        source / context
-    ("SLLQHLIGL",        "HLA-A*02:01"),      # classic A*02:01 test peptide (HCV NS3)
-    ("GILGFVFTL",        "HLA-A*02:01"),      # Flu M1 58-66, strong A*02 binder
-    ("SLYNTVATL",        "HLA-A*02:01"),      # HIV Gag p17
-    ("NLVPMVATV",        "HLA-A*02:01"),      # CMV pp65
-    ("NYNYLYRLF",        "HLA-A*24:02"),      # HIV Nef
-    ("RYPLTFGWCF",       "HLA-A*24:02"),      # classic A*24:02 binder
-    ("VYFFKTNKF",        "HLA-A*24:02"),      # SARS-CoV-2 S
-    ("TPRVTGGGAM",       "HLA-B*07:02"),      # CMV pp65
-    ("APRTVALTA",        "HLA-B*07:02"),      # P at P2 anchor (B*07 family)
-    ("SPRWYFYYL",        "HLA-B*35:01"),      # SARS-CoV-2
-    ("IPSINVHHY",        "HLA-B*35:01"),      # EBV EBNA-1
+    # peptide,      canonical_allele, source antigen
+    ("SLLQHLIGL",   "HLA-A*02:01",    "HCV NS3 1406-1414"),
+    ("GILGFVFTL",   "HLA-A*02:01",    "Influenza A M1 58-66"),
+    ("SLYNTVATL",   "HLA-A*02:01",    "HIV-1 Gag p17 77-85"),
+    ("NLVPMVATV",   "HLA-A*02:01",    "HCMV pp65 495-503"),
+    ("NYNYLYRLF",   "HLA-A*24:02",    "HIV-1 Nef 134-142"),
+    ("RYPLTFGWCF",  "HLA-A*24:02",    "synthetic A*24 probe"),
+    ("VYFFKTNKF",   "HLA-A*24:02",    "SARS-CoV-2 Spike"),
+    ("TPRVTGGGAM",  "HLA-B*07:02",    "HCMV pp65 265-274"),
+    ("APRTVALTA",   "HLA-B*07:02",    "synthetic B*07 probe"),
+    ("IPSINVHHY",   "HLA-B*35:01",    "EBV EBNA-1 407-417"),
 ]
 
 # All alleles we'll consider. Using each canonical + some distractors
@@ -57,13 +62,33 @@ ALLELE_POOL = sorted({
 })
 
 
-def load_predictor(path: Path):
+def load_affinity_predictor(path: Path):
     from mhcflurry import Class1AffinityPredictor
     return Class1AffinityPredictor.load(str(path))
 
 
-def predict(pred, peptides, alleles) -> pd.DataFrame:
-    """Return a tall DataFrame with columns peptide, allele, affinity_nM."""
+def load_presentation_predictor(path: Path):
+    from mhcflurry import Class1PresentationPredictor
+    return Class1PresentationPredictor.load(str(path))
+
+
+def swap_affinity_into_presentation(public_presentation, new_affinity):
+    """Build a Class1PresentationPredictor that uses our affinity but
+    keeps the public's processing predictors and logistic weights. This
+    isolates how much our affinity change propagates through the full
+    presentation stack."""
+    from mhcflurry import Class1PresentationPredictor
+    return Class1PresentationPredictor(
+        affinity_predictor=new_affinity,
+        processing_predictor_with_flanks=public_presentation.processing_predictor_with_flanks,
+        processing_predictor_without_flanks=public_presentation.processing_predictor_without_flanks,
+        weights_dataframe=public_presentation.weights_dataframe,
+        metadata_dataframes=getattr(public_presentation, "metadata_dataframes", None),
+    )
+
+
+def predict_affinity(pred, peptides, alleles) -> pd.DataFrame:
+    """Tall DataFrame: peptide, allele, affinity_nM."""
     rows = []
     for p in peptides:
         for a in alleles:
@@ -71,122 +96,181 @@ def predict(pred, peptides, alleles) -> pd.DataFrame:
                 aff = float(pred.predict(peptides=[p], alleles=[a])[0])
             except Exception as exc:
                 aff = float("nan")
-                print(f"  [warn] {p}+{a}: {exc!r}", file=sys.stderr)
+                print(f"  [warn] affinity {p}+{a}: {exc!r}", file=sys.stderr)
             rows.append({"peptide": p, "allele": a, "affinity_nM": aff})
     return pd.DataFrame(rows)
 
 
-def canonical_agreement(df: pd.DataFrame, label: str) -> int:
-    """For each peptide, check that its canonical allele is ranked at or
-    near the top (best affinity = lowest nM)."""
+def predict_presentation(pred, peptides, alleles) -> pd.DataFrame:
+    """Tall DataFrame: peptide, allele, presentation_score. Uses the
+    without-flanks processing model since our canonical peptide list
+    doesn't carry true source-protein context. Higher = more likely
+    presented."""
+    rows = []
+    for a in alleles:
+        try:
+            df = pred.predict(peptides=list(peptides), alleles=[a], verbose=0)
+        except Exception as exc:
+            print(f"  [warn] presentation allele={a}: {exc!r}", file=sys.stderr)
+            for p in peptides:
+                rows.append({"peptide": p, "allele": a, "presentation_score": float("nan")})
+            continue
+        for p in peptides:
+            row_ = df[df["peptide"] == p]
+            if row_.empty:
+                rows.append({"peptide": p, "allele": a, "presentation_score": float("nan")})
+            else:
+                rows.append({
+                    "peptide": p,
+                    "allele": a,
+                    "presentation_score": float(row_.iloc[0]["presentation_score"]),
+                })
+    return pd.DataFrame(rows)
+
+
+def canonical_agreement(df: pd.DataFrame, score_col: str, lower_is_better: bool, label: str) -> int:
+    """For each canonical peptide-allele pair, does the peptide's best
+    scoring allele (lowest affinity or highest presentation score) match
+    the canonical binder?"""
     wins = 0
-    total = 0
-    for peptide, canonical in KNOWN_BINDERS:
-        sub = df[df["peptide"] == peptide].sort_values("affinity_nM")
+    ascending = lower_is_better
+    unit_tag = "nM" if score_col == "affinity_nM" else ""
+    for peptide, canonical, antigen in KNOWN_BINDERS:
+        sub = df[df["peptide"] == peptide].sort_values(score_col, ascending=ascending)
         if sub.empty:
             continue
-        total += 1
-        rank = sub["allele"].tolist().index(canonical) + 1 if canonical in sub["allele"].values else -1
+        rank = (
+            sub["allele"].tolist().index(canonical) + 1
+            if canonical in sub["allele"].values
+            else -1
+        )
         top = sub.iloc[0]
         mark = "✓" if top["allele"] == canonical else " "
+        val = top[score_col]
+        val_str = f"{val:.2f} {unit_tag}".strip() if pd.notna(val) else "?"
         print(
-            f"  {mark} {label:8s} {peptide:12s} canonical={canonical:14s} "
-            f"rank={rank}/{len(sub):<2} top={top['allele']} ({top['affinity_nM']:.1f} nM)"
+            f"  {mark} {label:8s} {peptide:12s}  canonical={canonical:14s}  "
+            f"antigen={antigen:28s}  rank={rank}/{len(sub):<2}  top={top['allele']} ({val_str})"
         )
         if top["allele"] == canonical:
             wins += 1
     return wins
 
 
-def rank_correlation(df_ours: pd.DataFrame, df_public: pd.DataFrame) -> float:
+def spearman(df_ours: pd.DataFrame, df_public: pd.DataFrame, score_col: str) -> float:
     from scipy.stats import spearmanr
-    merged = df_ours.merge(df_public, on=["peptide", "allele"],
-                           suffixes=("_ours", "_public"))
+    merged = df_ours.merge(df_public, on=["peptide", "allele"], suffixes=("_ours", "_public"))
     if merged.empty:
         return float("nan")
-    rho, _ = spearmanr(merged["affinity_nM_ours"], merged["affinity_nM_public"])
+    rho, _ = spearmanr(
+        merged[f"{score_col}_ours"], merged[f"{score_col}_public"],
+        nan_policy="omit",
+    )
     return rho
 
 
-def per_sample_random(df: pd.DataFrame, *, k: int = 4,
-                      n_samples: int = 20, seed: int = 17) -> pd.DataFrame:
-    """For each peptide, N random k-subsets of alleles. Returns a per-
-    sample dataframe with peptide + allele_subset + predicted best."""
+def per_sample_random(df: pd.DataFrame, score_col: str, lower_is_better: bool,
+                      *, k: int = 4, n_samples: int = 20, seed: int = 17) -> pd.DataFrame:
     rng = random.Random(seed)
+    ascending = lower_is_better
     rows = []
     for p in df["peptide"].unique():
         pdf = df[df["peptide"] == p]
         alleles = pdf["allele"].tolist()
         for _ in range(n_samples):
             subset = rng.sample(alleles, k=min(k, len(alleles)))
-            sdf = pdf[pdf["allele"].isin(subset)].sort_values("affinity_nM")
+            sdf = pdf[pdf["allele"].isin(subset)].sort_values(score_col, ascending=ascending)
             top = sdf.iloc[0]
             rows.append({
                 "peptide": p,
                 "subset": ",".join(sorted(subset)),
                 "best_allele": top["allele"],
-                "best_affinity_nM": top["affinity_nM"],
+                "best_score": float(top[score_col]),
             })
     return pd.DataFrame(rows)
 
 
-def main():
-    p = argparse.ArgumentParser()
-    p.add_argument("--ours", required=True, help="dir with trained predictor")
-    p.add_argument("--public", required=True, help="dir with public models_class1_pan predictor")
-    args = p.parse_args()
-
-    peptides = [pep for pep, _ in KNOWN_BINDERS]
-    alleles = ALLELE_POOL
-
-    print(f"[load] ours <- {args.ours}")
-    ours = load_predictor(Path(args.ours))
-    print(f"[load] public <- {args.public}")
-    public = load_predictor(Path(args.public))
-
-    print(f"[predict] {len(peptides)} peptides × {len(alleles)} alleles = "
-          f"{len(peptides)*len(alleles)} pairs, both models")
-    df_ours = predict(ours, peptides, alleles)
-    df_public = predict(public, peptides, alleles)
-
-    print()
-    print("== Canonical allele at top of ranking? ==")
-    w_ours = canonical_agreement(df_ours, "ours")
-    print()
-    w_public = canonical_agreement(df_public, "public")
+def run_comparison(df_ours, df_public, score_col, lower_is_better, block_label):
     total = len(KNOWN_BINDERS)
     print()
-    print(f"[score] ours:   {w_ours}/{total} canonical peptides with canonical allele at rank 1")
-    print(f"[score] public: {w_public}/{total}")
+    print(f"== {block_label}: canonical allele at rank 1? ==")
+    w_ours = canonical_agreement(df_ours, score_col, lower_is_better, "ours")
+    print()
+    w_public = canonical_agreement(df_public, score_col, lower_is_better, "public")
+    print()
+    print(f"[{block_label}] ours:   {w_ours}/{total} canonical pairs with true allele at rank 1")
+    print(f"[{block_label}] public: {w_public}/{total}")
 
-    rho = rank_correlation(df_ours, df_public)
-    print(f"[score] Spearman rank correlation (all pairs): {rho:.3f}")
+    rho = spearman(df_ours, df_public, score_col)
+    n_pairs = len(df_ours.merge(df_public, on=["peptide", "allele"]))
+    print(f"[{block_label}] Spearman rank correlation over {n_pairs} (peptide,allele) pairs: {rho:.3f}")
 
     print()
-    print("== Random per-peptide 4-subset agreement ==")
-    rand_ours = per_sample_random(df_ours)
-    rand_public = per_sample_random(df_public)
-    merged = rand_ours.merge(
-        rand_public, on=["peptide", "subset"], suffixes=("_ours", "_public")
-    )
+    print(f"== {block_label}: random 4-subset best-allele agreement ==")
+    rand_ours = per_sample_random(df_ours, score_col, lower_is_better)
+    rand_public = per_sample_random(df_public, score_col, lower_is_better)
+    merged = rand_ours.merge(rand_public, on=["peptide", "subset"], suffixes=("_ours", "_public"))
     agree = (merged["best_allele_ours"] == merged["best_allele_public"]).sum()
-    print(f"[score] best-allele agreement on random 4-subsets: "
+    print(f"[{block_label}] best-allele agreement on random 4-subsets: "
           f"{agree}/{len(merged)} ({agree/len(merged)*100:.0f}%)")
+    return merged
 
-    print()
-    print("== Example disagreement (first 5) ==")
-    disagree = merged[merged["best_allele_ours"] != merged["best_allele_public"]]
-    if not disagree.empty:
-        print(disagree.head(5).to_string(index=False))
-    else:
-        print("(none)")
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--ours", required=True, help="dir with trained affinity predictor")
+    p.add_argument("--public", required=True,
+                   help="dir with public models_class1_pan predictor (models.combined)")
+    p.add_argument("--public-presentation", default=None,
+                   help="dir with public models_class1_presentation/models/. "
+                        "If given, presentation Spearman is also reported.")
+    args = p.parse_args()
+
+    peptides = [pep for pep, _, _ in KNOWN_BINDERS]
+    alleles = ALLELE_POOL
+
+    print(f"[peptides] ({len(peptides)})")
+    for pep, canon, antigen in KNOWN_BINDERS:
+        print(f"    {pep:12s}  canonical={canon:14s}  antigen={antigen}")
+    print(f"[alleles] ({len(alleles)}) {alleles}")
+
+    print(f"\n[load] ours affinity  <- {args.ours}")
+    ours_aff = load_affinity_predictor(Path(args.ours))
+    print(f"[load] public affinity <- {args.public}")
+    public_aff = load_affinity_predictor(Path(args.public))
+
+    print(f"[predict] affinity: {len(peptides)} peptides × {len(alleles)} alleles = "
+          f"{len(peptides)*len(alleles)} pairs, both models")
+    df_aff_ours = predict_affinity(ours_aff, peptides, alleles)
+    df_aff_public = predict_affinity(public_aff, peptides, alleles)
 
     out = Path("out/validation")
     out.mkdir(parents=True, exist_ok=True)
-    df_ours.to_csv(out / "preds_ours.csv", index=False)
-    df_public.to_csv(out / "preds_public.csv", index=False)
-    merged.to_csv(out / "random_subset_agreement.csv", index=False)
-    print(f"\n[saved] full predictions + agreement tables to {out}/")
+
+    merged_aff = run_comparison(df_aff_ours, df_aff_public, "affinity_nM", True, "AFFINITY")
+    df_aff_ours.to_csv(out / "preds_affinity_ours.csv", index=False)
+    df_aff_public.to_csv(out / "preds_affinity_public.csv", index=False)
+    merged_aff.to_csv(out / "subset_agreement_affinity.csv", index=False)
+
+    if args.public_presentation:
+        print(f"\n[load] public presentation <- {args.public_presentation}")
+        public_pres = load_presentation_predictor(Path(args.public_presentation))
+        ours_pres = swap_affinity_into_presentation(public_pres, ours_aff)
+
+        print(f"[predict] presentation: {len(peptides)} peptides × {len(alleles)} alleles, "
+              f"both models (without flanks — canonical peptide list has no true "
+              f"source-protein flanking context)")
+        df_pres_ours = predict_presentation(ours_pres, peptides, alleles)
+        df_pres_public = predict_presentation(public_pres, peptides, alleles)
+
+        merged_pres = run_comparison(
+            df_pres_ours, df_pres_public, "presentation_score", False, "PRESENTATION"
+        )
+        df_pres_ours.to_csv(out / "preds_presentation_ours.csv", index=False)
+        df_pres_public.to_csv(out / "preds_presentation_public.csv", index=False)
+        merged_pres.to_csv(out / "subset_agreement_presentation.csv", index=False)
+
+    print(f"\n[saved] prediction + agreement tables under {out}/")
 
 
 if __name__ == "__main__":

--- a/scripts/validate_presentation_with_flanks.py
+++ b/scripts/validate_presentation_with_flanks.py
@@ -1,0 +1,259 @@
+"""Compare trained ensemble vs public mhcflurry on 10 peptides with their
+real source-protein flanks.
+
+Per-user ask (phase-c-single-a100 run): "test the ensemble against the
+public weights for accuracy on our example set of 10 peptides hopefully
+including SLLQHLIGL (find its flanking region in PRAME), and random other
+peptides + flanks and alleles including A0201 and A2402. Summarize rank
+correlation of public mhcflurry with trained ensemble on all outputs."
+
+What this script does:
+
+  1. For each of 10 well-characterized epitopes (incl. SLLQHLIGL in PRAME,
+     A*02:01 + A*24:02 coverage), look up the peptide in uniprot_proteins
+     and extract real N- and C-terminal 10-AA flanks from the source
+     protein. Falls back to empty flanks when a peptide isn't found.
+  2. Predict presentation scores with both our ensemble and the public
+     ensemble, on (peptide, allele, n_flank, c_flank) tuples for a small
+     allele pool.
+  3. Report Spearman rank correlation overall, per peptide, and the
+     canonical-allele rank check (is the peptide's best-scoring allele
+     the one the literature says binds?).
+
+Run:
+    python scripts/validate_presentation_with_flanks.py \\
+        --ours /path/to/models.combined/ \\
+        --public $(mhcflurry-downloads path models_class1_presentation)/models/
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import pandas as pd
+from scipy.stats import spearmanr
+
+
+# 10 peptides: A*02:01 (4), A*24:02 (3), B*07:02/B*35:01 (3).
+# Canonical allele is the literature-cited binder; we still predict over
+# the full ALLELE_POOL to check ranking behavior.
+PEPTIDES = [
+    # peptide,      canonical_allele, source_antigen_comment
+    ("SLLQHLIGL",   "HLA-A*02:01",    "PRAME (melanoma preferentially expressed)"),
+    ("GILGFVFTL",   "HLA-A*02:01",    "Influenza A M1 58-66"),
+    ("SLYNTVATL",   "HLA-A*02:01",    "HIV-1 Gag p17 77-85"),
+    ("NLVPMVATV",   "HLA-A*02:01",    "HCMV pp65 495-503"),
+    ("NYNYLYRLF",   "HLA-A*24:02",    "HIV-1 Nef 134-142"),
+    ("VYFFKTNKF",   "HLA-A*24:02",    "SARS-CoV-2 Spike"),
+    ("RYPLTFGWCF",  "HLA-A*24:02",    "synthetic A*24 probe"),
+    ("TPRVTGGGAM",  "HLA-B*07:02",    "HCMV pp65 265-274"),
+    ("IPSINVHHY",   "HLA-B*35:01",    "EBV EBNA-1 407-417"),
+    ("KAFSPEVIPMF", "HLA-B*57:01",    "HIV-1 Gag KF11"),
+]
+
+ALLELE_POOL = [
+    "HLA-A*02:01", "HLA-A*24:02", "HLA-B*07:02", "HLA-B*35:01",
+    "HLA-B*57:01", "HLA-A*03:01", "HLA-C*07:01",
+]
+
+FLANK_SIZE = 10  # AAs on each side
+
+
+def lookup_flanks(peptides):
+    """Return dict peptide -> (n_flank, c_flank, source_id) for each peptide.
+
+    Uses mhcflurry's bundled uniprot_proteins.csv.bz2. Searches every
+    protein for the peptide; takes the first protein that contains it.
+    Returns empty flanks if not found.
+    """
+    try:
+        from mhcflurry.downloads import get_path
+        path = get_path("data_references", "uniprot_proteins.csv.bz2")
+    except Exception as exc:
+        print(f"[warn] uniprot_proteins reference not available: {exc}",
+              file=sys.stderr)
+        return {p: ("", "", "N/A") for p in peptides}
+
+    df = pd.read_csv(path)
+    seqs = df[["gene_name", "accession", "seq"]].dropna(subset=["seq"])
+    result = {}
+    for pep in peptides:
+        found = False
+        for _, row in seqs.iterrows():
+            seq = str(row["seq"])
+            idx = seq.find(pep)
+            if idx >= 0:
+                n = seq[max(0, idx - FLANK_SIZE):idx]
+                c = seq[idx + len(pep): idx + len(pep) + FLANK_SIZE]
+                source = f"{row['gene_name']}/{row['accession']}"
+                result[pep] = (n, c, source)
+                found = True
+                break
+        if not found:
+            result[pep] = ("", "", "NOT_FOUND")
+    return result
+
+
+def load_predictor(path):
+    from mhcflurry import Class1PresentationPredictor
+    return Class1PresentationPredictor.load(str(path))
+
+
+def predict_all(predictor, peptides, flanks, alleles):
+    """Predict presentation with flanks for each (peptide, allele) pair.
+
+    Uses Class1PresentationPredictor.predict with explicit n_flanks/c_flanks.
+    Returns tall DataFrame: peptide, allele, n_flank, c_flank, score.
+    """
+    rows = []
+    for allele in alleles:
+        peps = [p for p, _, _ in PEPTIDES]
+        n_flanks = [flanks[p][0] for p in peps]
+        c_flanks = [flanks[p][1] for p in peps]
+        try:
+            df = predictor.predict(
+                peptides=peps,
+                alleles=[allele],
+                n_flanks=n_flanks,
+                c_flanks=c_flanks,
+                verbose=0,
+            )
+        except Exception as exc:
+            print(f"  [warn] {allele}: {exc!r}", file=sys.stderr)
+            for p in peps:
+                rows.append({
+                    "peptide": p,
+                    "allele": allele,
+                    "n_flank": flanks[p][0],
+                    "c_flank": flanks[p][1],
+                    "score": float("nan"),
+                })
+            continue
+        for p in peps:
+            sub = df[df["peptide"] == p]
+            score = float(sub.iloc[0]["presentation_score"]) if not sub.empty else float("nan")
+            rows.append({
+                "peptide": p,
+                "allele": allele,
+                "n_flank": flanks[p][0],
+                "c_flank": flanks[p][1],
+                "score": score,
+            })
+    return pd.DataFrame(rows)
+
+
+def spearman_all(ours, public):
+    """Overall Spearman on (peptide, allele, score)."""
+    merged = ours.merge(
+        public, on=["peptide", "allele"], suffixes=("_ours", "_public")
+    )
+    if merged.empty:
+        return float("nan"), 0
+    rho, _ = spearmanr(
+        merged["score_ours"], merged["score_public"], nan_policy="omit"
+    )
+    return rho, len(merged)
+
+
+def spearman_per_peptide(ours, public):
+    """Spearman per peptide (across the 7 alleles). Captures within-peptide
+    ranking agreement — the signal most relevant for ranking likely
+    presenters of a given epitope."""
+    merged = ours.merge(
+        public, on=["peptide", "allele"], suffixes=("_ours", "_public")
+    )
+    rows = []
+    for p, grp in merged.groupby("peptide"):
+        if len(grp) < 3:
+            rows.append({"peptide": p, "n_alleles": len(grp), "spearman": float("nan")})
+            continue
+        rho, _ = spearmanr(
+            grp["score_ours"], grp["score_public"], nan_policy="omit"
+        )
+        rows.append({"peptide": p, "n_alleles": len(grp), "spearman": rho})
+    return pd.DataFrame(rows)
+
+
+def canonical_ranks(df, label):
+    """For each peptide, is the canonical allele ranked #1 by score?"""
+    wins = 0
+    for pep, canonical, antigen in PEPTIDES:
+        sub = df[df["peptide"] == pep].sort_values("score", ascending=False)
+        if sub.empty:
+            continue
+        top_allele = sub.iloc[0]["allele"]
+        rank = (
+            sub["allele"].tolist().index(canonical) + 1
+            if canonical in sub["allele"].values
+            else -1
+        )
+        ok = "✓" if top_allele == canonical else " "
+        score = sub.iloc[0]["score"]
+        print(f"  {ok} {label:6s} {pep:12s} canonical={canonical:14s}"
+              f"  top={top_allele:14s} (score={score:.3f})  rank={rank}"
+              f"  [{antigen}]")
+        if top_allele == canonical:
+            wins += 1
+    return wins
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--ours", required=True,
+                    help="Dir with trained Class1PresentationPredictor")
+    ap.add_argument("--public", required=True,
+                    help="Dir with public Class1PresentationPredictor")
+    ap.add_argument("--out-dir", default="out/validation_with_flanks")
+    args = ap.parse_args()
+
+    out = Path(args.out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    peptides = [p for p, _, _ in PEPTIDES]
+    print(f"[flanks] looking up source-protein flanks for {len(peptides)} peptides...")
+    flanks = lookup_flanks(peptides)
+    for p, canon, antigen in PEPTIDES:
+        n, c, src = flanks[p]
+        print(f"  {p:12s} N={n or '(empty)':10s}  C={c or '(empty)':10s}  src={src}")
+
+    print(f"\n[load] ours    <- {args.ours}")
+    ours = load_predictor(Path(args.ours))
+    print(f"[load] public  <- {args.public}")
+    public = load_predictor(Path(args.public))
+
+    print(f"\n[predict] {len(peptides)} peptides × {len(ALLELE_POOL)} alleles = "
+          f"{len(peptides) * len(ALLELE_POOL)} pairs, each model")
+    df_ours = predict_all(ours, peptides, flanks, ALLELE_POOL)
+    df_public = predict_all(public, peptides, flanks, ALLELE_POOL)
+
+    df_ours.to_csv(out / "preds_ours.csv", index=False)
+    df_public.to_csv(out / "preds_public.csv", index=False)
+
+    # Overall Spearman
+    rho, n = spearman_all(df_ours, df_public)
+    print(f"\n[overall] Spearman rank correlation (peptide×allele, n={n}): {rho:.3f}")
+
+    # Per-peptide Spearman
+    per_pep = spearman_per_peptide(df_ours, df_public)
+    per_pep.to_csv(out / "spearman_per_peptide.csv", index=False)
+    print("\n[per-peptide] within-peptide Spearman (across alleles):")
+    for _, row in per_pep.iterrows():
+        rho_str = f"{row['spearman']:.3f}" if pd.notna(row["spearman"]) else "NaN"
+        print(f"  {row['peptide']:12s}  n_alleles={row['n_alleles']}  rho={rho_str}")
+    print(f"\n[per-peptide] mean Spearman: {per_pep['spearman'].mean():.3f}")
+
+    # Canonical-allele ranking
+    print(f"\n[canonical] is the canonical allele the top-scoring one?")
+    w_ours = canonical_ranks(df_ours, "ours")
+    print()
+    w_public = canonical_ranks(df_public, "public")
+    print(f"\n[canonical] ours:   {w_ours}/{len(PEPTIDES)}")
+    print(f"[canonical] public: {w_public}/{len(PEPTIDES)}")
+
+    print(f"\n[saved] predictions + spearman under {out}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/test_encoding_cache.py
+++ b/test/test_encoding_cache.py
@@ -26,7 +26,7 @@ from mhcflurry.encoding_cache import (
     _hash_peptides,
     _vector_encoding_cache_key,
     _verify_cache_key_shape,
-    make_preencoded_encodable_sequences,
+    make_prepopulated_encodable_sequences,
 )
 
 
@@ -469,7 +469,7 @@ def test_default_chunk_size_is_reasonable():
 
 
 def test_prepopulated_hits_existing_cache_path(default_params):
-    """The preencoded EncodableSequences short-circuits the encode path.
+    """The prepopulated EncodableSequences short-circuits the encode path.
 
     This is the load-bearing test for the integration — if upstream
     EncodableSequences rearranges its internal cache key tuple in a
@@ -482,7 +482,7 @@ def test_prepopulated_hits_existing_cache_path(default_params):
         .variable_length_to_fixed_length_vector_encoding(**default_params.to_kwargs())
         .astype(numpy.float32)
     )
-    es = make_preencoded_encodable_sequences(peptides, expected, default_params)
+    es = make_prepopulated_encodable_sequences(peptides, expected, default_params)
 
     # Short-circuit check: if the cache is hit, this call should NOT do any
     # actual encoding work. We detect by snapshotting the cache and
@@ -513,7 +513,7 @@ def test_prepopulated_hits_existing_cache_path(default_params):
 def test_prepopulated_length_mismatch_raises():
     params = EncodingParams(max_length=15, alignment_method="pad_middle")
     with pytest.raises(ValueError, match="does not match peptide count"):
-        make_preencoded_encodable_sequences(
+        make_prepopulated_encodable_sequences(
             ["SIINFEKL", "GILGFVFTL"],
             numpy.zeros((5, 15, 21), dtype=numpy.float32),
             params,
@@ -549,7 +549,7 @@ def test_full_roundtrip_via_prepopulated(tmp_path, default_params):
     )
     encoded_rows, _ = cache.get_or_build(VALID_PEPTIDES)
 
-    es = make_preencoded_encodable_sequences(
+    es = make_prepopulated_encodable_sequences(
         VALID_PEPTIDES, encoded_rows, default_params
     )
     through_cache = es.variable_length_to_fixed_length_vector_encoding(
@@ -681,8 +681,8 @@ def test_verify_cache_key_shape_raises_when_key_wrong(monkeypatch):
     assert encoding_cache_module._CACHE_KEY_SHAPE_VERIFIED is False
 
 
-def test_make_preencoded_triggers_self_test_on_first_call():
-    """make_preencoded_encodable_sequences runs the self-test once.
+def test_make_prepopulated_triggers_self_test_on_first_call():
+    """make_prepopulated_encodable_sequences runs the self-test once.
 
     First call after a fresh process (or after resetting the guard flag)
     must invoke _verify_cache_key_shape. This is the behavior that turns
@@ -695,15 +695,15 @@ def test_make_preencoded_triggers_self_test_on_first_call():
         .variable_length_to_fixed_length_vector_encoding(**params.to_kwargs())
         .astype(numpy.float32)
     )
-    make_preencoded_encodable_sequences(["SIINFEKL"], expected, params)
+    make_prepopulated_encodable_sequences(["SIINFEKL"], expected, params)
     assert encoding_cache_module._CACHE_KEY_SHAPE_VERIFIED is True
 
 
-def test_make_preencoded_raises_if_key_drift_detected(monkeypatch):
+def test_make_prepopulated_raises_if_key_drift_detected(monkeypatch):
     """Orchestrator-level failure mode: key drift blocks cache construction.
 
     Ensures a broken upstream refactor fails fast at the first
-    make_preencoded call rather than silently producing a cache that
+    make_prepopulated call rather than silently producing a cache that
     never gets hit.
     """
     encoding_cache_module._CACHE_KEY_SHAPE_VERIFIED = False
@@ -715,4 +715,4 @@ def test_make_preencoded_raises_if_key_drift_detected(monkeypatch):
     params = EncodingParams()
     fake_encoded = numpy.zeros((1, 15, 21), dtype=numpy.float32)
     with pytest.raises(EncodingCacheKeyMismatchError):
-        make_preencoded_encodable_sequences(["SIINFEKL"], fake_encoded, params)
+        make_prepopulated_encodable_sequences(["SIINFEKL"], fake_encoded, params)

--- a/test/test_encoding_cache.py
+++ b/test/test_encoding_cache.py
@@ -1,0 +1,586 @@
+"""Tests for the memmap-backed BLOSUM62 encoding cache.
+
+The cache is semantics-preserving by design: encoded bytes must match
+``EncodableSequences.variable_length_to_fixed_length_vector_encoding``
+for the same peptides and params. That property is the most important
+thing to test — if it slips, downstream training loses determinism.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+
+import numpy
+import pytest
+from numpy.testing import assert_array_equal
+
+from mhcflurry import encoding_cache as encoding_cache_module
+from mhcflurry.encodable_sequences import EncodableSequences
+from mhcflurry.encoding_cache import (
+    DEFAULT_CHUNK_SIZE,
+    EncodingCache,
+    EncodingCacheKeyMismatchError,
+    EncodingParams,
+    _hash_peptides,
+    _vector_encoding_cache_key,
+    _verify_cache_key_shape,
+    make_preencoded_encodable_sequences,
+)
+
+
+# A small peptide set that covers 8-15mers (the lengths mhcflurry supports).
+SAMPLE_PEPTIDES = [
+    "SIINFEKL",       # 8mer
+    "AAAAAAAAA",      # 9mer, homopolymer edge case
+    "GILGFVFTL",      # 9mer, famous flu epitope
+    "YLQPRTFLL",      # 9mer
+    "ELAGIGILTV",     # 10mer
+    "IMDQVPFSV",      # 9mer
+    "NLVPMVATV",      # 9mer
+    "RMFPNAPYL",      # 9mer
+    "FLRGRAYGL",      # 9mer
+    "LLDFVRFMGV",     # 10mer
+    "QYDPVAALF",      # 9mer
+    "KLVALGINAV",     # 10mer
+    "FVLELEPEWTVK",   # 12mer
+    "KLIETYFSKK",     # 10mer
+    "AQYELGGGPGAGD",  # 13mer
+    "YVNVNMGLKIRQLLWFHISCLTFGRETVLEYLVS",  # will truncate with trim=True or err without
+]
+
+# The subset that matches mhcflurry's default 8-15mer window without
+# needing trim=True. Used for the bit-for-bit baseline tests.
+VALID_PEPTIDES = [p for p in SAMPLE_PEPTIDES if 8 <= len(p) <= 15]
+
+
+@pytest.fixture
+def default_params():
+    """Matches the peptide_encoding block in pan-allele hyperparameters."""
+    return EncodingParams(
+        vector_encoding_name="BLOSUM62",
+        alignment_method="left_pad_centered_right_pad",
+        max_length=15,
+    )
+
+
+@pytest.fixture
+def cache(tmp_path, default_params):
+    return EncodingCache(cache_dir=tmp_path / "encoding_cache", params=default_params)
+
+
+# ---- Category A: unit tests for the cache module ----
+
+
+def test_cached_matches_direct_byte_for_byte(cache, default_params):
+    """The cache MUST emit bytes identical to a direct EncodableSequences call.
+
+    This is the semantic-preservation gate. If this fails, downstream
+    training will diverge from the un-cached code path and we can no
+    longer claim determinism. Every other test below is secondary.
+    """
+    direct = (
+        EncodableSequences(VALID_PEPTIDES)
+        .variable_length_to_fixed_length_vector_encoding(**default_params.to_kwargs())
+        .astype(numpy.float32)
+    )
+    cached, _ = cache.get_or_build(VALID_PEPTIDES)
+    assert cached.shape == direct.shape
+    assert cached.dtype == direct.dtype
+    assert_array_equal(cached, direct)
+
+
+def test_peptide_to_idx_roundtrip(cache):
+    _, peptide_to_idx = cache.get_or_build(VALID_PEPTIDES)
+    assert len(peptide_to_idx) == len(VALID_PEPTIDES)
+    for i, p in enumerate(VALID_PEPTIDES):
+        assert peptide_to_idx[p] == i
+
+
+def test_cache_hit_second_call_does_not_reencode(cache, monkeypatch):
+    """Second call with same params+peptides should skip the encoding pass."""
+    cache.get_or_build(VALID_PEPTIDES)
+    calls = []
+    original = EncodableSequences.variable_length_to_fixed_length_vector_encoding
+
+    def spy(self, *args, **kwargs):
+        calls.append(1)
+        return original(self, *args, **kwargs)
+
+    monkeypatch.setattr(
+        EncodableSequences,
+        "variable_length_to_fixed_length_vector_encoding",
+        spy,
+    )
+    cache.get_or_build(VALID_PEPTIDES)
+    assert calls == [], "expected no re-encoding on cache hit"
+
+
+def test_different_params_invalidates_cache(tmp_path):
+    """Changing max_length creates a separate cache entry — no bleed-through."""
+    params_a = EncodingParams(max_length=15, alignment_method="pad_middle")
+    params_b = EncodingParams(max_length=17, alignment_method="pad_middle")
+    cache_a = EncodingCache(cache_dir=tmp_path / "cache", params=params_a)
+    cache_b = EncodingCache(cache_dir=tmp_path / "cache", params=params_b)
+
+    encoded_a, _ = cache_a.get_or_build(VALID_PEPTIDES)
+    encoded_b, _ = cache_b.get_or_build(VALID_PEPTIDES)
+    assert encoded_a.shape != encoded_b.shape
+    # They live in different subdirs keyed by params_hash.
+    assert cache_a.entry_path(VALID_PEPTIDES) != cache_b.entry_path(VALID_PEPTIDES)
+
+
+def test_different_peptides_invalidates_cache(cache):
+    """Same params, different peptide list → different cache entry."""
+    path_a = cache.entry_path(VALID_PEPTIDES)
+    path_b = cache.entry_path(VALID_PEPTIDES[::-1])  # reversed order
+    assert path_a != path_b, "cache key must be order-sensitive"
+
+
+def test_cache_is_order_sensitive(cache, default_params):
+    """Peptides in reverse order produce reverse-ordered encoded rows."""
+    forward, _ = cache.get_or_build(VALID_PEPTIDES)
+    reversed_list = VALID_PEPTIDES[::-1]
+    reversed_encoded, _ = cache.get_or_build(reversed_list)
+    assert_array_equal(reversed_encoded, forward[::-1])
+
+
+def test_partial_write_not_consumed(tmp_path, default_params):
+    """A half-written cache (no .complete sentinel) must not be consumed.
+
+    Simulates a crash mid-build: pre-create the entry_dir with a stale
+    (wrong-bytes) encoded.npy but no .complete file. The next call should
+    rebuild, producing correct bytes.
+    """
+    cache = EncodingCache(
+        cache_dir=tmp_path / "encoding_cache", params=default_params
+    )
+    entry_dir = cache.entry_path(VALID_PEPTIDES)
+    entry_dir.mkdir(parents=True)
+    # Write garbage encoded.npy — anything the reader would trip on.
+    numpy.save(
+        entry_dir / "encoded.npy",
+        numpy.full((len(VALID_PEPTIDES), 45, 21), 99.0, dtype=numpy.float32),
+    )
+    # .complete deliberately absent.
+
+    encoded, _ = cache.get_or_build(VALID_PEPTIDES)
+
+    # Should have been rebuilt, not the 99.0-filled garbage.
+    direct = (
+        EncodableSequences(VALID_PEPTIDES)
+        .variable_length_to_fixed_length_vector_encoding(**default_params.to_kwargs())
+        .astype(numpy.float32)
+    )
+    assert_array_equal(encoded, direct)
+    assert (entry_dir / ".complete").exists()
+
+
+def test_sidecar_files_written(cache):
+    cache.get_or_build(VALID_PEPTIDES)
+    entry_dir = cache.entry_path(VALID_PEPTIDES)
+    assert (entry_dir / "encoded.npy").exists()
+    assert (entry_dir / "peptides.txt").exists()
+    assert (entry_dir / "params.json").exists()
+    assert (entry_dir / ".complete").exists()
+    # peptides.txt preserves order
+    written_peptides = [
+        p for p in (entry_dir / "peptides.txt").read_text().splitlines() if p != ""
+    ]
+    assert written_peptides == VALID_PEPTIDES
+    # params.json is human-readable JSON
+    params_dict = json.loads((entry_dir / "params.json").read_text())
+    assert params_dict["vector_encoding_name"] == "BLOSUM62"
+
+
+def test_mmap_load_is_memory_mapped(cache):
+    """Confirm we're actually mmap'ing, not loading into RSS.
+
+    Two calls should return memmap-backed arrays (shared with the file on
+    disk), not independent copies in RAM. The specific check: the returned
+    ndarray's ``.filename`` attribute exists (numpy.memmap) OR the base
+    array is a ``numpy.memmap``.
+    """
+    arr, _ = cache.get_or_build(VALID_PEPTIDES)
+    # np.load(mmap_mode='r') returns a numpy.memmap or similar.
+    assert isinstance(arr, numpy.memmap) or isinstance(
+        getattr(arr, "base", None), numpy.memmap
+    ), f"expected mmap-backed array, got {type(arr).__name__}"
+
+
+def test_mmap_is_read_only_view(cache):
+    """Readers must get a read-only mmap; accidental writes should raise.
+
+    Guards against a caller mutating a cache entry and silently corrupting
+    shared state for other processes.
+    """
+    arr, _ = cache.get_or_build(VALID_PEPTIDES)
+    with pytest.raises((ValueError, RuntimeError)):
+        arr[0, 0, 0] = 999.0
+
+
+def test_concurrent_readers_see_identical_bytes(tmp_path, default_params):
+    """Multiple threads opening the same cache entry see the same bytes.
+
+    This is really exercising mmap+OS page cache — the invariant we rely on
+    for multi-worker sharing. If this fails, the whole shared-encoding
+    optimization is unsafe.
+    """
+    # Build once up front so threads only READ.
+    builder = EncodingCache(
+        cache_dir=tmp_path / "encoding_cache", params=default_params
+    )
+    expected, _ = builder.get_or_build(VALID_PEPTIDES)
+    expected_bytes = bytes(expected.tobytes())
+
+    results: list[bytes] = []
+    lock = threading.Lock()
+
+    def reader():
+        c = EncodingCache(
+            cache_dir=tmp_path / "encoding_cache", params=default_params
+        )
+        arr, _ = c.get_or_build(VALID_PEPTIDES)
+        data = bytes(arr.tobytes())
+        with lock:
+            results.append(data)
+
+    threads = [threading.Thread(target=reader) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(results) == 8
+    for data in results:
+        assert data == expected_bytes
+
+
+def test_encoding_error_propagates_at_build_time(tmp_path, default_params):
+    """Unsupported peptide content must raise during build, not silently succeed.
+
+    The old un-cached path would raise from inside fit_generator; the
+    cached path raises earlier (at cache-build time) which is if anything
+    friendlier — but it must still raise, not silently produce a wrong
+    encoding.
+    """
+    cache = EncodingCache(
+        cache_dir=tmp_path / "encoding_cache",
+        params=EncodingParams(
+            max_length=15,
+            alignment_method="pad_middle",
+            allow_unsupported_amino_acids=False,
+        ),
+    )
+    bad_peptides = ["SIINFEKL", "BADJUNK1"]  # digit '1' isn't a canonical AA
+    with pytest.raises(Exception):
+        cache.get_or_build(bad_peptides)
+
+
+def test_chunked_build_matches_single_pass(tmp_path, default_params):
+    """Build a cache in small chunks and in one go; bytes must match.
+
+    Chunks matter for large pretrain data (>>RAM); must be byte-identical
+    to the single-pass encoding.
+    """
+    single_pass = EncodingCache(
+        cache_dir=tmp_path / "cache_single",
+        params=default_params,
+        chunk_size=10_000,
+    )
+    chunked = EncodingCache(
+        cache_dir=tmp_path / "cache_chunked",
+        params=default_params,
+        chunk_size=3,  # force multiple chunks
+    )
+    a, _ = single_pass.get_or_build(VALID_PEPTIDES)
+    b, _ = chunked.get_or_build(VALID_PEPTIDES)
+    assert_array_equal(a, b)
+
+
+def test_empty_peptide_list_raises():
+    """Edge case: zero peptides should fail cleanly rather than build an empty cache.
+
+    Downstream callers would all crash dividing by zero somewhere; better
+    to fail fast at build.
+    """
+    with pytest.raises(Exception):
+        # An empty list makes the sample-encode dry-run fail; that's fine.
+        cache = EncodingCache(
+            cache_dir=Path("/tmp/this/should/not/matter"),
+            params=EncodingParams(max_length=15),
+        )
+        cache.get_or_build([])
+
+
+def test_hash_peptides_order_sensitive():
+    assert _hash_peptides(["A", "B"]) != _hash_peptides(["B", "A"])
+
+
+def test_hash_peptides_count_sensitive():
+    # These differ in count (1 vs 2 items); the count prefix guarantees a miss.
+    assert _hash_peptides(["AB"]) != _hash_peptides(["A", "B"])
+
+
+def test_hash_peptides_stable():
+    """Same inputs → same hash (sanity: no datetime/pid in the hash path)."""
+    assert _hash_peptides(VALID_PEPTIDES) == _hash_peptides(VALID_PEPTIDES)
+
+
+def test_default_chunk_size_is_reasonable():
+    """Catch accidental reduction to a tiny chunk size in future refactors."""
+    assert DEFAULT_CHUNK_SIZE >= 1000
+
+
+# ---- Integration with EncodableSequences ----
+
+
+def test_prepopulated_hits_existing_cache_path(default_params):
+    """The preencoded EncodableSequences short-circuits the encode path.
+
+    This is the load-bearing test for the integration — if upstream
+    EncodableSequences rearranges its internal cache key tuple in a
+    future refactor, this test fails loudly before a wrong-encoded
+    training run hits production.
+    """
+    peptides = VALID_PEPTIDES
+    expected = (
+        EncodableSequences(peptides)
+        .variable_length_to_fixed_length_vector_encoding(**default_params.to_kwargs())
+        .astype(numpy.float32)
+    )
+    es = make_preencoded_encodable_sequences(peptides, expected, default_params)
+
+    # Short-circuit check: if the cache is hit, this call should NOT do any
+    # actual encoding work. We detect by snapshotting the cache and
+    # monkey-patching the underlying conversion function to assert it's not
+    # called a second time.
+    calls = []
+    original = EncodableSequences.variable_length_to_fixed_length_vector_encoding
+
+    def spy(self, *args, **kwargs):
+        calls.append(1)
+        return original(self, *args, **kwargs)
+
+    EncodableSequences.variable_length_to_fixed_length_vector_encoding = spy
+    try:
+        out = es.variable_length_to_fixed_length_vector_encoding(
+            **default_params.to_kwargs()
+        )
+    finally:
+        EncodableSequences.variable_length_to_fixed_length_vector_encoding = original
+    # spy was installed AFTER prepopulation, so the spy's `calls` should
+    # still grow by 1 (the lookup call itself), but the expensive work
+    # inside is not re-done — the cache key matches and the stored array
+    # is returned. We verify that by checking the returned array IS the
+    # prepopulated one (same object, not a recomputed copy).
+    assert out is expected, "prepopulated cache entry was not reused"
+
+
+def test_prepopulated_length_mismatch_raises():
+    params = EncodingParams(max_length=15, alignment_method="pad_middle")
+    with pytest.raises(ValueError, match="does not match peptide count"):
+        make_preencoded_encodable_sequences(
+            ["SIINFEKL", "GILGFVFTL"],
+            numpy.zeros((5, 15, 21), dtype=numpy.float32),
+            params,
+        )
+
+
+def test_cache_key_matches_encodable_sequences_internal(default_params):
+    """Our cache key tuple must match what EncodableSequences constructs.
+
+    If the tuple layout upstream ever changes, this test catches it via
+    the downstream prepopulation no longer hitting the cache (which is
+    exercised indirectly by test_prepopulated_hits_existing_cache_path).
+    This one is a narrower, cheaper regression check on the tuple shape.
+    """
+    key = _vector_encoding_cache_key(default_params)
+    # First element is the discriminator tag used inside
+    # variable_length_to_fixed_length_vector_encoding.
+    assert key[0] == "fixed_length_vector_encoding"
+    assert default_params.vector_encoding_name in key
+    assert default_params.alignment_method in key
+    assert default_params.max_length in key
+
+
+def test_full_roundtrip_via_prepopulated(tmp_path, default_params):
+    """End-to-end: cache → prepopulated EncodableSequences → encoder output.
+
+    The final encoded tensor emitted by peptides_to_network_input (via the
+    prepopulated instance) must byte-match the direct un-cached call. This
+    is the load-bearing semantic test for the integration as a whole.
+    """
+    cache = EncodingCache(
+        cache_dir=tmp_path / "encoding_cache", params=default_params
+    )
+    encoded_rows, _ = cache.get_or_build(VALID_PEPTIDES)
+
+    es = make_preencoded_encodable_sequences(
+        VALID_PEPTIDES, encoded_rows, default_params
+    )
+    through_cache = es.variable_length_to_fixed_length_vector_encoding(
+        **default_params.to_kwargs()
+    )
+    direct = (
+        EncodableSequences(VALID_PEPTIDES)
+        .variable_length_to_fixed_length_vector_encoding(**default_params.to_kwargs())
+        .astype(numpy.float32)
+    )
+    assert_array_equal(through_cache, direct)
+
+
+# ---- is_complete_for (public API) -----------------------------------------
+
+
+def test_is_complete_for_returns_false_for_empty_cache(tmp_path, default_params):
+    cache = EncodingCache(cache_dir=tmp_path / "cache", params=default_params)
+    assert cache.is_complete_for(VALID_PEPTIDES) is False
+
+
+def test_is_complete_for_returns_true_after_build(tmp_path, default_params):
+    cache = EncodingCache(cache_dir=tmp_path / "cache", params=default_params)
+    cache.get_or_build(VALID_PEPTIDES)
+    assert cache.is_complete_for(VALID_PEPTIDES) is True
+
+
+def test_is_complete_for_is_peptide_specific(tmp_path, default_params):
+    """Cache built for peptides A is not 'complete' for peptides B."""
+    cache = EncodingCache(cache_dir=tmp_path / "cache", params=default_params)
+    cache.get_or_build(VALID_PEPTIDES)
+    other_peptides = ["SIINFEKL", "GILGFVFTL"]  # proper subset, still different hash
+    assert cache.is_complete_for(VALID_PEPTIDES) is True
+    assert cache.is_complete_for(other_peptides) is False
+
+
+def test_is_complete_for_is_params_specific(tmp_path):
+    """Cache built for params A is not 'complete' for params B."""
+    params_a = EncodingParams(max_length=15, alignment_method="pad_middle")
+    params_b = EncodingParams(max_length=17, alignment_method="pad_middle")
+    cache_a = EncodingCache(cache_dir=tmp_path / "cache", params=params_a)
+    cache_b = EncodingCache(cache_dir=tmp_path / "cache", params=params_b)
+    cache_a.get_or_build(VALID_PEPTIDES)
+    assert cache_a.is_complete_for(VALID_PEPTIDES) is True
+    assert cache_b.is_complete_for(VALID_PEPTIDES) is False
+
+
+def test_is_complete_for_returns_false_when_sentinel_missing(tmp_path, default_params):
+    """Half-written cache: entry_dir exists but .complete absent → not complete."""
+    cache = EncodingCache(cache_dir=tmp_path / "cache", params=default_params)
+    entry_dir = cache.entry_path(VALID_PEPTIDES)
+    entry_dir.mkdir(parents=True)
+    # Create some content but not the sentinel
+    (entry_dir / "encoded.npy").write_bytes(b"stale")
+    assert cache.is_complete_for(VALID_PEPTIDES) is False
+
+
+# ---- Runtime cache-key-shape self-test ------------------------------------
+
+
+def test_verify_cache_key_shape_passes_with_current_encodable_sequences():
+    """Sanity: the self-test succeeds against the current encoder.
+
+    If this ever fails on master, the prepopulation tuple is drifting
+    out of sync with EncodableSequences and the whole cache integration
+    degrades silently. This is the canary.
+    """
+    # Force re-verification regardless of prior test ordering.
+    encoding_cache_module._CACHE_KEY_SHAPE_VERIFIED = False
+    try:
+        _verify_cache_key_shape()
+    finally:
+        # Leave in verified state so later tests don't re-pay the cost.
+        encoding_cache_module._CACHE_KEY_SHAPE_VERIFIED = True
+
+
+def test_verify_cache_key_shape_runs_at_most_once_per_process(monkeypatch):
+    """The self-test caches its result via _CACHE_KEY_SHAPE_VERIFIED.
+
+    A second call should be a no-op (not re-run the probe). We detect that
+    by monkey-patching EncodableSequences.variable_length_to_fixed_length_
+    vector_encoding to count calls.
+    """
+    # Pretend the self-test hasn't run, then run it once.
+    encoding_cache_module._CACHE_KEY_SHAPE_VERIFIED = False
+    _verify_cache_key_shape()
+    assert encoding_cache_module._CACHE_KEY_SHAPE_VERIFIED is True
+
+    # Spy and re-call — should short-circuit.
+    calls = []
+    original = EncodableSequences.variable_length_to_fixed_length_vector_encoding
+
+    def spy(self, *a, **kw):
+        calls.append(1)
+        return original(self, *a, **kw)
+
+    monkeypatch.setattr(
+        EncodableSequences,
+        "variable_length_to_fixed_length_vector_encoding",
+        spy,
+    )
+    _verify_cache_key_shape()
+    assert calls == [], "self-test ran again despite guard flag being set"
+
+
+def test_verify_cache_key_shape_raises_when_key_wrong(monkeypatch):
+    """If _vector_encoding_cache_key drifts, self-test raises loudly.
+
+    Simulates upstream drift by monkey-patching our cache-key function
+    to produce a tuple that won't match what EncodableSequences looks up.
+    The self-test must then raise EncodingCacheKeyMismatchError with
+    guidance — not silently degrade.
+    """
+    encoding_cache_module._CACHE_KEY_SHAPE_VERIFIED = False
+
+    def bad_key(params):
+        return ("definitely-wrong-tag", params.vector_encoding_name)
+
+    monkeypatch.setattr(
+        encoding_cache_module,
+        "_vector_encoding_cache_key",
+        bad_key,
+    )
+    with pytest.raises(EncodingCacheKeyMismatchError, match="key tuple no longer matches"):
+        _verify_cache_key_shape()
+
+    # Guard should remain unset so a subsequent (correct) call still runs
+    # and succeeds.
+    assert encoding_cache_module._CACHE_KEY_SHAPE_VERIFIED is False
+
+
+def test_make_preencoded_triggers_self_test_on_first_call():
+    """make_preencoded_encodable_sequences runs the self-test once.
+
+    First call after a fresh process (or after resetting the guard flag)
+    must invoke _verify_cache_key_shape. This is the behavior that turns
+    a silent upstream break into a loud error at orchestrator-init time.
+    """
+    encoding_cache_module._CACHE_KEY_SHAPE_VERIFIED = False
+    params = EncodingParams()
+    expected = (
+        EncodableSequences(["SIINFEKL"])
+        .variable_length_to_fixed_length_vector_encoding(**params.to_kwargs())
+        .astype(numpy.float32)
+    )
+    make_preencoded_encodable_sequences(["SIINFEKL"], expected, params)
+    assert encoding_cache_module._CACHE_KEY_SHAPE_VERIFIED is True
+
+
+def test_make_preencoded_raises_if_key_drift_detected(monkeypatch):
+    """Orchestrator-level failure mode: key drift blocks cache construction.
+
+    Ensures a broken upstream refactor fails fast at the first
+    make_preencoded call rather than silently producing a cache that
+    never gets hit.
+    """
+    encoding_cache_module._CACHE_KEY_SHAPE_VERIFIED = False
+    monkeypatch.setattr(
+        encoding_cache_module,
+        "_vector_encoding_cache_key",
+        lambda params: ("wrong",),
+    )
+    params = EncodingParams()
+    fake_encoded = numpy.zeros((1, 15, 21), dtype=numpy.float32)
+    with pytest.raises(EncodingCacheKeyMismatchError):
+        make_preencoded_encodable_sequences(["SIINFEKL"], fake_encoded, params)

--- a/test/test_encoding_cache.py
+++ b/test/test_encoding_cache.py
@@ -30,6 +30,23 @@ from mhcflurry.encoding_cache import (
 )
 
 
+# Module-level function so multiprocessing's spawn context can pickle it.
+# Nested/inline worker functions fail with AttributeError under spawn.
+def _concurrent_build_worker(cache_dir_str, params_kwargs, peptide_list, queue):
+    try:
+        from mhcflurry.encoding_cache import (
+            EncodingCache as _EC,
+            EncodingParams as _EP,
+        )
+        import hashlib as _hashlib
+        cache = _EC(cache_dir=cache_dir_str, params=_EP(**params_kwargs))
+        encoded, _ = cache.get_or_build(peptide_list)
+        queue.put(("ok", _hashlib.sha256(encoded.tobytes()).hexdigest()))
+    except Exception as exc:
+        import traceback as _tb
+        queue.put(("error", f"{type(exc).__name__}: {exc}\n{_tb.format_exc()}"))
+
+
 # A small peptide set that covers 8-15mers (the lengths mhcflurry supports).
 SAMPLE_PEPTIDES = [
     "SIINFEKL",       # 8mer
@@ -255,6 +272,121 @@ def test_concurrent_readers_see_identical_bytes(tmp_path, default_params):
     assert len(results) == 8
     for data in results:
         assert data == expected_bytes
+
+
+def test_concurrent_builders_do_not_collide(tmp_path, default_params):
+    """Multiple processes building the SAME cache entry in parallel must not crash.
+
+    Reproduces the 2026-04-20 A100 training failure: two Pool workers
+    simultaneously calling get_or_build() for the pretrain cache (which
+    the orchestrator doesn't pre-build). The old code used a shared
+    ``encoded.npy.tmp`` path so the second worker's ``os.replace`` failed
+    with ``FileNotFoundError`` after the first worker's rename consumed
+    the tmp file.
+
+    Fix: per-process tmp path (PID-suffixed). Both builders write their
+    own tmp file and atomically rename to the shared out_path; the second
+    rename silently overwrites identical bytes, since the encoding is a
+    pure function of params+peptides.
+
+    Uses multiprocessing (not threading) because the GIL serializes
+    threads inside Python-level code paths and wouldn't reliably trigger
+    the race. Real Pool workers are separate processes.
+    """
+    import multiprocessing as mp
+
+    ctx = mp.get_context("spawn")
+    queue = ctx.Queue()
+
+    n_workers = 4
+    procs = [
+        ctx.Process(
+            target=_concurrent_build_worker,
+            args=(
+                str(tmp_path / "cache"),
+                default_params.to_kwargs(),
+                VALID_PEPTIDES,
+                queue,
+            ),
+        )
+        for _ in range(n_workers)
+    ]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=60)
+
+    # Collect results.
+    results = []
+    while not queue.empty():
+        results.append(queue.get(timeout=1))
+
+    assert len(results) == n_workers, (
+        f"expected {n_workers} worker results, got {len(results)}"
+    )
+    # Every worker must succeed (no FileNotFoundError from racing renames).
+    errors = [payload for status, payload in results if status != "ok"]
+    assert not errors, "concurrent builders hit errors:\n" + "\n\n".join(errors)
+
+    # Every worker must see identical encoded bytes.
+    hashes = {payload for _, payload in results}
+    assert len(hashes) == 1, f"concurrent builders produced divergent bytes: {hashes}"
+
+    # Final cache dir must be in a clean state: .complete exists, exactly
+    # one encoded.npy, no leftover tmp files.
+    entry_dir = EncodingCache(
+        cache_dir=tmp_path / "cache", params=default_params
+    ).entry_path(VALID_PEPTIDES)
+    assert (entry_dir / ".complete").exists()
+    assert (entry_dir / "encoded.npy").exists()
+    leftover_tmps = list(entry_dir.glob("encoded.npy.tmp*"))
+    assert not leftover_tmps, (
+        f"per-process tmp files should have been renamed away; got leftovers: "
+        f"{leftover_tmps}"
+    )
+
+
+def test_concurrent_builders_on_pristine_cache_dir(tmp_path, default_params):
+    """Same as above but with zero pre-existing state.
+
+    The orchestrator-builds-first flow in training means workers usually
+    see ``is_complete == True`` on arrival. Occasionally (e.g. the
+    pretrain cache that the orchestrator doesn't pre-build) they hit a
+    pristine entry_dir. This test explicitly exercises that path with
+    multiple concurrent builders starting from zero.
+    """
+    import multiprocessing as mp
+
+    # Don't pre-build anything — cache dir doesn't even exist yet.
+    assert not (tmp_path / "cache").exists()
+
+    ctx = mp.get_context("spawn")
+    queue = ctx.Queue()
+    procs = [
+        ctx.Process(
+            target=_concurrent_build_worker,
+            args=(
+                str(tmp_path / "cache"),
+                default_params.to_kwargs(),
+                VALID_PEPTIDES,
+                queue,
+            ),
+        )
+        for _ in range(3)
+    ]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(timeout=60)
+
+    results = []
+    while not queue.empty():
+        results.append(queue.get(timeout=1))
+    assert len(results) == 3
+    errors = [payload for status, payload in results if status != "ok"]
+    assert not errors, (
+        "pristine-dir concurrent build hit errors:\n" + "\n\n".join(errors)
+    )
 
 
 def test_encoding_error_propagates_at_build_time(tmp_path, default_params):

--- a/test/test_encoding_cache.py
+++ b/test/test_encoding_cache.py
@@ -91,21 +91,38 @@ def cache(tmp_path, default_params):
 
 
 def test_cached_matches_direct_byte_for_byte(cache, default_params):
-    """The cache MUST emit bytes identical to a direct EncodableSequences call.
+    """The cache MUST emit values identical to a direct EncodableSequences call.
 
     This is the semantic-preservation gate. If this fails, downstream
     training will diverge from the un-cached code path and we can no
     longer claim determinism. Every other test below is secondary.
+
+    Dtype note: Phase 4a of #268 stores the encoder's native dtype
+    (int8 for BLOSUM62 — values fit tightly in [-4, +6]) instead of
+    widening to float32 at the cache layer. The downstream GPU cast
+    int8→float32 is a free widening op that preserves values exactly.
+    This test compares values (``assert_array_equal`` across the
+    widened cast) rather than dtype.
     """
-    direct = (
-        EncodableSequences(VALID_PEPTIDES)
-        .variable_length_to_fixed_length_vector_encoding(**default_params.to_kwargs())
-        .astype(numpy.float32)
+    direct = EncodableSequences(VALID_PEPTIDES).variable_length_to_fixed_length_vector_encoding(
+        **default_params.to_kwargs()
     )
     cached, _ = cache.get_or_build(VALID_PEPTIDES)
     assert cached.shape == direct.shape
+    # Dtype preserved exactly: cache stores encoder's native dtype.
     assert cached.dtype == direct.dtype
+    # Values identical byte-for-byte.
     assert_array_equal(cached, direct)
+    # For BLOSUM62 (the public release's only vector_encoding_name)
+    # specifically: native dtype is int8. Guard against silent
+    # regression to fp32 storage (which would 4× the memmap size and
+    # double the H2D bandwidth for no gain).
+    if default_params.vector_encoding_name == "BLOSUM62":
+        assert cached.dtype == numpy.int8, (
+            f"BLOSUM62 cache should store int8 (lossless, 4× smaller); "
+            f"got {cached.dtype}. Check encoding_cache._build's dtype "
+            f"line."
+        )
 
 
 def test_peptide_to_idx_roundtrip(cache):

--- a/test/test_encoding_cache_training_integration.py
+++ b/test/test_encoding_cache_training_integration.py
@@ -1,0 +1,518 @@
+"""End-to-end integration test: training is bit-identical with cache on/off.
+
+This is THE gate for issue #268 Phase 1. Unit tests can prove that the
+cache produces encoded bytes matching ``variable_length_to_fixed_length_
+vector_encoding`` exactly — but that only tests the encoder's output. It
+doesn't test what happens when those bytes flow through multi-epoch
+training with stochastic operations (weight init, random negative
+sampling, minibatch shuffle, validation split).
+
+So: we run actual training on a tiny model, with fixed seeds, via both
+the original code path (fresh ``EncodableSequences``) and the new cached
+path (``make_preencoded_encodable_sequences``). We assert the per-epoch
+loss trajectories match bit-for-bit AND the final model weights match
+bit-for-bit.
+
+If this test passes, the semantic-preservation claim is proven end-to-end:
+the cache is a pure implementation-detail optimization, not a behavior
+change.
+
+On CPU only. GPU determinism requires extra flags and isn't necessary to
+prove the point — the cache doesn't know or care about the device.
+"""
+
+from __future__ import annotations
+
+import random
+
+import numpy
+import pandas
+import pytest
+import torch
+
+from mhcflurry.allele_encoding import AlleleEncoding
+from mhcflurry.class1_neural_network import Class1NeuralNetwork
+from mhcflurry.common import configure_pytorch
+from mhcflurry.encodable_sequences import EncodableSequences
+from mhcflurry.encoding_cache import (
+    EncodingCache,
+    EncodingParams,
+    make_preencoded_encodable_sequences,
+)
+
+
+# Tiny but real: enough rows for a minibatch, enough length variety to
+# exercise the encoder, small enough that 2 epochs finish in under a second.
+TRAIN_PEPTIDES = [
+    "SIINFEKL", "GILGFVFTL", "NLVPMVATV", "YLQPRTFLL", "KLVALGINAV",
+    "FLRGRAYGL", "ELAGIGILTV", "RMFPNAPYL", "AAAAAAAAA", "KLIETYFSKK",
+    "YVNVNMGLK", "ILKEPVHGV", "VLFRGGPRGSL", "FEDLRVLSF", "TPGPGVRYPL",
+    "QYDPVAALF", "RMPEAAPPV", "IMDQVPFSV", "LLDFVRFMGV", "VQMENKLTL",
+    "FVLELEPEWTV", "ELAGIGILT", "GLQDCTMLV", "WLSLLVPFV", "FLPSDFFPSV",
+    "KAFSPEVIPMF", "FLYGKLILAS", "VLSPFPPKV", "SLYNTVATL", "GPGHKARVL",
+]
+TRAIN_ALLELES_CYCLE = ["HLA-A*02:01", "HLA-B*07:02", "HLA-A*01:01"]
+ALLELE_TO_SEQUENCE = {
+    "HLA-A*02:01": "YFAMYQENMAHTDANTLYLNYHDYTWAVLAYTWYG",
+    "HLA-B*07:02": "YFSTSVSRPGRGEPRFIAVGYVDDTQFVRFDSDAA",
+    "HLA-A*01:01": "YFSTSISRPGRGEPRFIAVGYIDDTQFVRFDSDAA",
+}
+DEFAULT_PEPTIDE_ENCODING = {
+    "alignment_method": "left_pad_centered_right_pad",
+    "max_length": 15,
+    "vector_encoding_name": "BLOSUM62",
+}
+
+
+def _seed_everything(seed=12345):
+    """Seed every RNG the training code touches."""
+    random.seed(seed)
+    numpy.random.seed(seed)
+    torch.manual_seed(seed)
+    # Force deterministic algorithms on CPU paths. torch.use_deterministic_algorithms
+    # raises on ops that have no deterministic impl — we don't use any such ops
+    # here, so the flag is safe.
+    torch.use_deterministic_algorithms(True)
+
+
+def _build_training_data():
+    """Return a DataFrame with peptide, allele, measurement_value columns."""
+    rng = numpy.random.default_rng(0)
+    rows = []
+    for i, peptide in enumerate(TRAIN_PEPTIDES):
+        allele = TRAIN_ALLELES_CYCLE[i % len(TRAIN_ALLELES_CYCLE)]
+        # Affinities in nM; mix of binders and non-binders.
+        measurement = float(rng.choice([50.0, 500.0, 10000.0]))
+        rows.append(
+            {"peptide": peptide, "allele": allele, "measurement_value": measurement}
+        )
+    return pandas.DataFrame(rows)
+
+
+def _tiny_hyperparameters():
+    """Hyperparameters sized so 2 epochs run in <1 second.
+
+    Shaped to match the pan-allele defaults produced by
+    downloads-generation/models_class1_pan/generate_hyperparameters.py —
+    specifically peptide/allele merge via concatenate, small layer sizes,
+    dropout off (determinism), early stopping off (epoch count fixed).
+    """
+    return {
+        "peptide_encoding": DEFAULT_PEPTIDE_ENCODING,
+        "max_epochs": 2,
+        "minibatch_size": 8,
+        # Architecture — sized tiny for test speed.
+        "layer_sizes": [16],
+        "peptide_dense_layer_sizes": [],
+        "allele_dense_layer_sizes": [],
+        "locally_connected_layers": [],
+        "peptide_allele_merge_method": "concatenate",
+        "peptide_allele_merge_activation": "",
+        "peptide_amino_acid_encoding": "BLOSUM62",
+        "topology": "feedforward",
+        # Regularization off for determinism across runs.
+        "dropout_probability": 0.0,
+        "batch_normalization": False,
+        "dense_layer_l1_regularization": 0.0,
+        "dense_layer_l2_regularization": 0.0,
+        # Training control.
+        "validation_split": 0.2,
+        "early_stopping": False,
+        "patience": 100,
+        "min_delta": 0.0,
+        "learning_rate": 0.001,
+        "loss": "custom:mse_with_inequalities",
+        "optimizer": "rmsprop",
+        "activation": "tanh",
+        "output_activation": "sigmoid",
+        "init": "glorot_uniform",
+        "data_dependent_initialization_method": "lsuv",
+        # Random negatives — pan-allele path.
+        "random_negative_rate": 1.0,
+        "random_negative_method": "by_allele_equalize_nonbinders",
+        "random_negative_affinity_min": 30000.0,
+        "random_negative_affinity_max": 50000.0,
+        "random_negative_binder_threshold": 500.0,
+        "random_negative_constant": 1,
+        "random_negative_distribution_smoothing": 0.0,
+        "random_negative_match_distribution": True,
+    }
+
+
+def _train_one_run(peptides_arg, training_df, allele_encoding):
+    """Build + train a Class1NeuralNetwork once, return (fit_info, state_dict).
+
+    ``peptides_arg`` is either a plain EncodableSequences (old path) or a
+    prepopulated one (new path). Downstream code in ``fit()`` doesn't know
+    which it got — and that's the point.
+    """
+    network = Class1NeuralNetwork(**_tiny_hyperparameters())
+    network.fit(
+        peptides=peptides_arg,
+        affinities=training_df.measurement_value.values,
+        allele_encoding=allele_encoding,
+        verbose=0,
+        progress_print_interval=None,
+    )
+    fit_info = network.fit_info[-1]
+    # .state_dict() returns tensors on whatever device they're on; we force
+    # CPU above, so these are CPU tensors ready to compare.
+    state_dict = {k: v.detach().cpu().clone() for k, v in network.network().state_dict().items()}
+    return fit_info, state_dict
+
+
+def _state_dicts_allclose(a, b, atol=0.0, rtol=0.0):
+    """Compare two state_dicts; default atol/rtol=0 means bit-identical."""
+    assert set(a.keys()) == set(b.keys()), f"key mismatch: {set(a.keys()) ^ set(b.keys())}"
+    for k in a:
+        if not torch.equal(a[k], b[k]) if atol == 0 and rtol == 0 else torch.allclose(
+            a[k], b[k], atol=atol, rtol=rtol
+        ):
+            return False, k
+    return True, None
+
+
+@pytest.fixture(autouse=True)
+def force_cpu_backend():
+    """Ensure all training in this file runs on CPU for determinism."""
+    configure_pytorch(backend="cpu")
+    yield
+    # Leave backend as-is for any follow-on tests; they'll reconfigure as needed.
+
+
+@pytest.fixture
+def training_df():
+    return _build_training_data()
+
+
+@pytest.fixture
+def allele_encoding(training_df):
+    return AlleleEncoding(
+        alleles=training_df.allele.values,
+        allele_to_sequence=ALLELE_TO_SEQUENCE,
+    )
+
+
+# ---- THE GATE ----
+
+
+def test_training_bit_identical_cached_vs_uncached(
+    training_df, allele_encoding, tmp_path
+):
+    """End-to-end: fit() must produce identical loss and weights cached vs not.
+
+    If this passes, the cache is a pure performance optimization. If it
+    fails, we have a real divergence in training semantics and the PR
+    should not merge.
+    """
+    params = EncodingParams(**DEFAULT_PEPTIDE_ENCODING)
+
+    # Build the encoding cache up-front (as the orchestrator would).
+    cache = EncodingCache(cache_dir=tmp_path / "encoding_cache", params=params)
+    # Cache the unique training peptides (in first-seen order).
+    unique_peptides = list(
+        pandas.Series(training_df.peptide.values).drop_duplicates()
+    )
+    encoded_all, peptide_to_idx = cache.get_or_build(unique_peptides)
+
+    # Path A: fresh EncodableSequences (old path).
+    _seed_everything()
+    peptides_uncached = EncodableSequences(training_df.peptide.values)
+    fit_info_uncached, weights_uncached = _train_one_run(
+        peptides_uncached, training_df, allele_encoding
+    )
+
+    # Path B: prepopulated EncodableSequences (new path).
+    _seed_everything()
+    fold_indices = numpy.array(
+        [peptide_to_idx[p] for p in training_df.peptide.values], dtype=numpy.int64
+    )
+    fold_encoded = encoded_all[fold_indices]
+    peptides_cached = make_preencoded_encodable_sequences(
+        training_df.peptide.values, fold_encoded, params
+    )
+    fit_info_cached, weights_cached = _train_one_run(
+        peptides_cached, training_df, allele_encoding
+    )
+
+    # ---- the assertions ----
+
+    # Loss trajectory bit-identical.
+    numpy.testing.assert_array_equal(
+        fit_info_uncached["loss"], fit_info_cached["loss"]
+    )
+    numpy.testing.assert_array_equal(
+        fit_info_uncached["val_loss"], fit_info_cached["val_loss"]
+    )
+
+    # Weights bit-identical (torch.equal requires exact match, no tolerance).
+    ok, bad_key = _state_dicts_allclose(weights_uncached, weights_cached)
+    assert ok, (
+        f"state_dict mismatch at key {bad_key!r}: "
+        f"uncached[{bad_key!r}]={weights_uncached[bad_key]} "
+        f"cached[{bad_key!r}]={weights_cached[bad_key]}"
+    )
+
+
+def test_training_weights_differ_with_different_seeds(
+    training_df, allele_encoding
+):
+    """Sanity: with different seeds, weights should differ.
+
+    Guards against the above test passing trivially — e.g. if the
+    ``_seed_everything`` calls were accidentally no-ops or the model
+    always converged to a fixed point regardless of seed. If this test
+    fails (weights identical under different seeds), the bit-identical
+    test above proves nothing.
+    """
+    _seed_everything(seed=12345)
+    peptides1 = EncodableSequences(training_df.peptide.values)
+    _, weights1 = _train_one_run(peptides1, training_df, allele_encoding)
+
+    _seed_everything(seed=67890)
+    peptides2 = EncodableSequences(training_df.peptide.values)
+    _, weights2 = _train_one_run(peptides2, training_df, allele_encoding)
+
+    # At least one parameter should differ between the two seeds.
+    any_diff = any(
+        not torch.equal(weights1[k], weights2[k]) for k in weights1
+    )
+    assert any_diff, (
+        "weights identical across different seeds — seeding is broken, "
+        "which would make the bit-identical test above a tautology"
+    )
+
+
+def test_training_loss_decreases(training_df, allele_encoding):
+    """Sanity: training should actually make the loss go down.
+
+    Not strictly required by the bit-identical test but useful as a basic
+    sanity check that the tiny model + data set up above is actually
+    training, not just producing noise.
+    """
+    _seed_everything()
+    peptides = EncodableSequences(training_df.peptide.values)
+    fit_info, _ = _train_one_run(peptides, training_df, allele_encoding)
+    losses = fit_info["loss"]
+    # 2 epochs, last should be lower than first (or at least not exploding).
+    assert len(losses) >= 2
+    assert losses[-1] < losses[0] * 2.0, (
+        f"loss didn't improve: {losses} — training sanity check failed"
+    )
+
+
+# ---- DataLoader num_workers bit-identity gate ----
+
+
+def _train_with_workers(
+    peptides_arg,
+    training_df,
+    allele_encoding,
+    num_workers,
+    persistent_workers=False,
+):
+    """Train identically to _train_one_run but with a configurable num_workers."""
+    hp = _tiny_hyperparameters()
+    hp["dataloader_num_workers"] = num_workers
+    hp["dataloader_persistent_workers"] = persistent_workers
+    network = Class1NeuralNetwork(**hp)
+    network.fit(
+        peptides=peptides_arg,
+        affinities=training_df.measurement_value.values,
+        allele_encoding=allele_encoding,
+        verbose=0,
+        progress_print_interval=None,
+    )
+    fit_info = network.fit_info[-1]
+    state_dict = {
+        k: v.detach().cpu().clone() for k, v in network.network().state_dict().items()
+    }
+    return fit_info, state_dict
+
+
+def test_dataloader_num_workers_0_matches_baseline(
+    training_df, allele_encoding
+):
+    """num_workers=0 (DataLoader wrap without prefetch) must match the pre-
+    DataLoader baseline exactly.
+
+    This isolates the Step 4 change: wrapping the inner batch loop in a
+    DataLoader with num_workers=0 is a pure refactor — same operations,
+    same order, same tensors — and should produce bit-identical training
+    results. If this ever fails, the wrapping introduced a subtle
+    reordering or type coercion that changes numerics.
+    """
+    # The main integration test above already exercises num_workers=0 as
+    # the default, so if this test passes we know the default path is
+    # bit-identical. We explicitly set num_workers=0 to pin the test to
+    # that contract rather than relying on a default value.
+    _seed_everything()
+    peptides_a = EncodableSequences(training_df.peptide.values)
+    fit_a, weights_a = _train_with_workers(
+        peptides_a, training_df, allele_encoding, num_workers=0
+    )
+
+    _seed_everything()
+    peptides_b = EncodableSequences(training_df.peptide.values)
+    fit_b, weights_b = _train_with_workers(
+        peptides_b, training_df, allele_encoding, num_workers=0
+    )
+
+    numpy.testing.assert_array_equal(fit_a["loss"], fit_b["loss"])
+    numpy.testing.assert_array_equal(fit_a["val_loss"], fit_b["val_loss"])
+    for k in weights_a:
+        assert torch.equal(weights_a[k], weights_b[k]), (
+            f"num_workers=0 training is not self-reproducible at key {k!r}"
+        )
+
+
+def test_dataloader_num_workers_2_matches_num_workers_0(
+    training_df, allele_encoding
+):
+    """num_workers=2 (prefetching with worker processes) must match num_workers=0.
+
+    This is the semantic-preservation test for the parallel prefetch path.
+    With shuffle=False and a deterministic training index array already
+    built in the main process, DataLoader workers only do fancy-indexing
+    into pre-built numpy arrays — no RNG, no reordering. PyTorch
+    guarantees batch-delivery order when shuffle=False, so num_workers>0
+    must produce identical batches.
+
+    If this ever fails: we've introduced a subtle nondeterminism —
+    probably via an RNG-touching op in __getitem__ or collate_fn.
+    """
+    _seed_everything()
+    peptides_baseline = EncodableSequences(training_df.peptide.values)
+    fit_baseline, weights_baseline = _train_with_workers(
+        peptides_baseline, training_df, allele_encoding, num_workers=0
+    )
+
+    _seed_everything()
+    peptides_prefetch = EncodableSequences(training_df.peptide.values)
+    fit_prefetch, weights_prefetch = _train_with_workers(
+        peptides_prefetch, training_df, allele_encoding, num_workers=2
+    )
+
+    numpy.testing.assert_array_equal(fit_baseline["loss"], fit_prefetch["loss"])
+    numpy.testing.assert_array_equal(
+        fit_baseline["val_loss"], fit_prefetch["val_loss"]
+    )
+    for k in weights_baseline:
+        assert torch.equal(weights_baseline[k], weights_prefetch[k]), (
+            f"num_workers=2 diverges from num_workers=0 at key {k!r} — "
+            f"prefetching path introduced nondeterminism"
+        )
+
+
+def test_dataloader_cache_plus_workers_still_bit_identical(
+    training_df, allele_encoding, tmp_path
+):
+    """Composition test: encoding cache + num_workers>0 must match baseline.
+
+    This is the stack test: both Phase 1 changes (encoding cache in
+    Step 2/3, DataLoader prefetching in Step 4) active at once must still
+    produce bit-identical training. If either changes semantics
+    independently the integration tests above catch it; this one catches
+    the case where they INTERACT in a bad way.
+    """
+    params = EncodingParams(**DEFAULT_PEPTIDE_ENCODING)
+    cache = EncodingCache(cache_dir=tmp_path / "encoding_cache", params=params)
+    unique_peptides = list(
+        pandas.Series(training_df.peptide.values).drop_duplicates()
+    )
+    encoded_all, peptide_to_idx = cache.get_or_build(unique_peptides)
+
+    # Baseline: uncached, num_workers=0.
+    _seed_everything()
+    peptides_baseline = EncodableSequences(training_df.peptide.values)
+    fit_baseline, weights_baseline = _train_with_workers(
+        peptides_baseline, training_df, allele_encoding, num_workers=0
+    )
+
+    # Stack: cached + num_workers=2.
+    _seed_everything()
+    fold_indices = numpy.array(
+        [peptide_to_idx[p] for p in training_df.peptide.values], dtype=numpy.int64
+    )
+    fold_encoded = encoded_all[fold_indices]
+    peptides_stack = make_preencoded_encodable_sequences(
+        training_df.peptide.values, fold_encoded, params
+    )
+    fit_stack, weights_stack = _train_with_workers(
+        peptides_stack, training_df, allele_encoding, num_workers=2
+    )
+
+    numpy.testing.assert_array_equal(fit_baseline["loss"], fit_stack["loss"])
+    numpy.testing.assert_array_equal(fit_baseline["val_loss"], fit_stack["val_loss"])
+    for k in weights_baseline:
+        assert torch.equal(weights_baseline[k], weights_stack[k]), (
+            f"encoding-cache + DataLoader-workers stack diverges at key {k!r}"
+        )
+
+
+# ---- dataloader_persistent_workers bit-identity gate ----
+
+
+def test_dataloader_persistent_workers_true_matches_false(
+    training_df, allele_encoding
+):
+    """persistent_workers=True must not change training semantics.
+
+    Currently the DataLoader is constructed per-epoch so the flag is
+    effectively a no-op, but the flag is exposed and threaded through
+    _make_fit_dataloader. If a future Phase 2 change hoists DataLoader
+    construction outside the epoch loop, we want this test in place to
+    catch semantic drift.
+
+    Right now: setting persistent_workers=True with num_workers=2 must
+    produce bit-identical results to persistent_workers=False.
+    """
+    _seed_everything()
+    peptides_nonpersist = EncodableSequences(training_df.peptide.values)
+    fit_nonpersist, weights_nonpersist = _train_with_workers(
+        peptides_nonpersist,
+        training_df,
+        allele_encoding,
+        num_workers=2,
+        persistent_workers=False,
+    )
+
+    _seed_everything()
+    peptides_persist = EncodableSequences(training_df.peptide.values)
+    fit_persist, weights_persist = _train_with_workers(
+        peptides_persist,
+        training_df,
+        allele_encoding,
+        num_workers=2,
+        persistent_workers=True,
+    )
+
+    numpy.testing.assert_array_equal(fit_nonpersist["loss"], fit_persist["loss"])
+    numpy.testing.assert_array_equal(
+        fit_nonpersist["val_loss"], fit_persist["val_loss"]
+    )
+    for k in weights_nonpersist:
+        assert torch.equal(weights_nonpersist[k], weights_persist[k]), (
+            f"persistent_workers=True diverges from False at key {k!r}"
+        )
+
+
+def test_dataloader_persistent_workers_ignored_when_no_workers(
+    training_df, allele_encoding
+):
+    """persistent_workers=True with num_workers=0 must not crash.
+
+    PyTorch logs a warning when persistent_workers is set with
+    num_workers=0; our _make_fit_dataloader avoids passing the flag in
+    that case to suppress the warning. This test verifies the path.
+    """
+    _seed_everything()
+    peptides = EncodableSequences(training_df.peptide.values)
+    # Should NOT raise, should NOT emit a PyTorch warning.
+    _train_with_workers(
+        peptides,
+        training_df,
+        allele_encoding,
+        num_workers=0,
+        persistent_workers=True,
+    )

--- a/test/test_encoding_cache_training_integration.py
+++ b/test/test_encoding_cache_training_integration.py
@@ -9,7 +9,7 @@ sampling, minibatch shuffle, validation split).
 
 So: we run actual training on a tiny model, with fixed seeds, via both
 the original code path (fresh ``EncodableSequences``) and the new cached
-path (``make_preencoded_encodable_sequences``). We assert the per-epoch
+path (``make_prepopulated_encodable_sequences``). We assert the per-epoch
 loss trajectories match bit-for-bit AND the final model weights match
 bit-for-bit.
 
@@ -37,7 +37,7 @@ from mhcflurry.encodable_sequences import EncodableSequences
 from mhcflurry.encoding_cache import (
     EncodingCache,
     EncodingParams,
-    make_preencoded_encodable_sequences,
+    make_prepopulated_encodable_sequences,
 )
 
 
@@ -228,7 +228,7 @@ def test_training_bit_identical_cached_vs_uncached(
         [peptide_to_idx[p] for p in training_df.peptide.values], dtype=numpy.int64
     )
     fold_encoded = encoded_all[fold_indices]
-    peptides_cached = make_preencoded_encodable_sequences(
+    peptides_cached = make_prepopulated_encodable_sequences(
         training_df.peptide.values, fold_encoded, params
     )
     fit_info_cached, weights_cached = _train_one_run(
@@ -309,12 +309,10 @@ def _train_with_workers(
     training_df,
     allele_encoding,
     num_workers,
-    persistent_workers=False,
 ):
     """Train identically to _train_one_run but with a configurable num_workers."""
     hp = _tiny_hyperparameters()
     hp["dataloader_num_workers"] = num_workers
-    hp["dataloader_persistent_workers"] = persistent_workers
     network = Class1NeuralNetwork(**hp)
     network.fit(
         peptides=peptides_arg,
@@ -435,7 +433,7 @@ def test_dataloader_cache_plus_workers_still_bit_identical(
         [peptide_to_idx[p] for p in training_df.peptide.values], dtype=numpy.int64
     )
     fold_encoded = encoded_all[fold_indices]
-    peptides_stack = make_preencoded_encodable_sequences(
+    peptides_stack = make_prepopulated_encodable_sequences(
         training_df.peptide.values, fold_encoded, params
     )
     fit_stack, weights_stack = _train_with_workers(
@@ -447,53 +445,6 @@ def test_dataloader_cache_plus_workers_still_bit_identical(
     for k in weights_baseline:
         assert torch.equal(weights_baseline[k], weights_stack[k]), (
             f"encoding-cache + DataLoader-workers stack diverges at key {k!r}"
-        )
-
-
-# ---- dataloader_persistent_workers bit-identity gate ----
-
-
-def test_dataloader_persistent_workers_true_matches_false(
-    training_df, allele_encoding
-):
-    """persistent_workers=True must not change training semantics.
-
-    Currently the DataLoader is constructed per-epoch so the flag is
-    effectively a no-op, but the flag is exposed and threaded through
-    _make_fit_dataloader. If a future Phase 2 change hoists DataLoader
-    construction outside the epoch loop, we want this test in place to
-    catch semantic drift.
-
-    Right now: setting persistent_workers=True with num_workers=2 must
-    produce bit-identical results to persistent_workers=False.
-    """
-    _seed_everything()
-    peptides_nonpersist = EncodableSequences(training_df.peptide.values)
-    fit_nonpersist, weights_nonpersist = _train_with_workers(
-        peptides_nonpersist,
-        training_df,
-        allele_encoding,
-        num_workers=2,
-        persistent_workers=False,
-    )
-
-    _seed_everything()
-    peptides_persist = EncodableSequences(training_df.peptide.values)
-    fit_persist, weights_persist = _train_with_workers(
-        peptides_persist,
-        training_df,
-        allele_encoding,
-        num_workers=2,
-        persistent_workers=True,
-    )
-
-    numpy.testing.assert_array_equal(fit_nonpersist["loss"], fit_persist["loss"])
-    numpy.testing.assert_array_equal(
-        fit_nonpersist["val_loss"], fit_persist["val_loss"]
-    )
-    for k in weights_nonpersist:
-        assert torch.equal(weights_nonpersist[k], weights_persist[k]), (
-            f"persistent_workers=True diverges from False at key {k!r}"
         )
 
 
@@ -625,27 +576,6 @@ def test_fit_generator_validation_tensors_hoisted_once(
         f"Expected ~{expected_max}. If this ballooned, the val-tensor "
         f"hoist regressed — H2D is running per-epoch again, negating the "
         f"Phase 1 fit_generator perf fix."
-    )
-
-
-def test_dataloader_persistent_workers_ignored_when_no_workers(
-    training_df, allele_encoding
-):
-    """persistent_workers=True with num_workers=0 must not crash.
-
-    PyTorch logs a warning when persistent_workers is set with
-    num_workers=0; our _make_fit_dataloader avoids passing the flag in
-    that case to suppress the warning. This test verifies the path.
-    """
-    _seed_everything()
-    peptides = EncodableSequences(training_df.peptide.values)
-    # Should NOT raise, should NOT emit a PyTorch warning.
-    _train_with_workers(
-        peptides,
-        training_df,
-        allele_encoding,
-        num_workers=0,
-        persistent_workers=True,
     )
 
 

--- a/test/test_encoding_cache_training_integration.py
+++ b/test/test_encoding_cache_training_integration.py
@@ -516,3 +516,162 @@ def test_dataloader_persistent_workers_ignored_when_no_workers(
         num_workers=0,
         persistent_workers=True,
     )
+
+
+# ---- Daemon-process compatibility gate ----
+#
+# mhcflurry's training orchestrator runs workers via multiprocessing.Pool.
+# Pool workers are DAEMONIC by default, and Python enforces that daemon
+# processes cannot spawn children — so ``DataLoader(num_workers>0)``
+# inside a Pool worker raises AssertionError: daemonic processes are not
+# allowed to have children. Our _make_fit_dataloader must detect this and
+# transparently downgrade to num_workers=0.
+#
+# Missing this downgrade detonates every 32-work-item pan-allele run at
+# the first epoch. Caught on a live A100 training run, 2026-04-20.
+
+
+def _train_in_daemon_subprocess(result_queue, peptide_list, df_records, allele_encoding_data):
+    """Worker body: reconstruct the minimal training state and call fit().
+
+    Intentionally does NOT import anything pytest-related — this runs in
+    a separate Python process so we need to construct the training inputs
+    from picklable primitives.
+    """
+    import os
+    # Quiet workers in CI output.
+    os.environ["MHCFLURRY_DEFAULT_DEVICE"] = "cpu"
+    try:
+        import multiprocessing as mp
+        import pandas as _pandas
+        from mhcflurry.allele_encoding import AlleleEncoding as _AE
+        from mhcflurry.class1_neural_network import Class1NeuralNetwork as _CNN
+        from mhcflurry.common import configure_pytorch as _configure
+
+        _configure(backend="cpu")
+
+        # Assert we're actually daemonic — the test premise.
+        assert mp.current_process().daemon, \
+            "subprocess expected to be daemonic; test plumbing is broken"
+
+        df = _pandas.DataFrame.from_records(df_records)
+        allele_enc = _AE(
+            alleles=allele_encoding_data["alleles"],
+            allele_to_sequence=allele_encoding_data["allele_to_sequence"],
+        )
+        hp = dict(
+            peptide_encoding={
+                "alignment_method": "left_pad_centered_right_pad",
+                "max_length": 15,
+                "vector_encoding_name": "BLOSUM62",
+            },
+            max_epochs=1,
+            minibatch_size=8,
+            layer_sizes=[8],
+            peptide_dense_layer_sizes=[],
+            allele_dense_layer_sizes=[],
+            locally_connected_layers=[],
+            peptide_allele_merge_method="concatenate",
+            peptide_allele_merge_activation="",
+            peptide_amino_acid_encoding="BLOSUM62",
+            topology="feedforward",
+            dropout_probability=0.0,
+            batch_normalization=False,
+            dense_layer_l1_regularization=0.0,
+            dense_layer_l2_regularization=0.0,
+            validation_split=0.2,
+            early_stopping=False,
+            patience=100,
+            min_delta=0.0,
+            learning_rate=0.001,
+            loss="custom:mse_with_inequalities",
+            optimizer="rmsprop",
+            activation="tanh",
+            output_activation="sigmoid",
+            init="glorot_uniform",
+            data_dependent_initialization_method="lsuv",
+            random_negative_rate=1.0,
+            random_negative_method="by_allele_equalize_nonbinders",
+            random_negative_affinity_min=30000.0,
+            random_negative_affinity_max=50000.0,
+            random_negative_binder_threshold=500.0,
+            random_negative_constant=1,
+            random_negative_distribution_smoothing=0.0,
+            random_negative_match_distribution=True,
+            # THE LOAD-BEARING KNOB: num_workers>0 would crash without the
+            # daemon-context downgrade. A bare DataLoader(num_workers=2)
+            # call raises AssertionError("daemonic processes are not
+            # allowed to have children") deep in torch internals. If this
+            # test crashes, the downgrade in _make_fit_dataloader is
+            # broken.
+            dataloader_num_workers=2,
+        )
+        net = _CNN(**hp)
+        net.fit(
+            peptides=peptide_list,
+            affinities=df["measurement_value"].values,
+            allele_encoding=allele_enc,
+            verbose=0,
+            progress_print_interval=None,
+        )
+        result_queue.put(("ok", len(net.fit_info[-1]["loss"])))
+    except Exception as exc:
+        import traceback as _tb
+        result_queue.put(("error", f"{type(exc).__name__}: {exc}\n{_tb.format_exc()}"))
+
+
+def test_dataloader_num_workers_downgrades_in_daemon_context(
+    training_df, allele_encoding
+):
+    """Regression test: fit(dataloader_num_workers>0) must work in a Pool worker.
+
+    Spawns a daemon subprocess (simulating what multiprocessing.Pool does
+    for its workers) and calls fit() with dataloader_num_workers=2. If
+    _make_fit_dataloader doesn't downgrade to 0 in daemon context, the
+    subprocess crashes with AssertionError. This is THE test that would
+    have caught the 2026-04-20 A100 training crash.
+
+    Uses spawn context for the parent→daemon transition to mirror
+    mhcflurry's actual Pool configuration.
+    """
+    import multiprocessing as mp
+
+    # Serialize inputs as primitives (AlleleEncoding doesn't pickle cleanly
+    # across spawn contexts; the daemon child rebuilds it).
+    ctx = mp.get_context("spawn")
+    result_queue = ctx.Queue()
+
+    # multiprocessing.Process(daemon=True) replicates the Pool-worker
+    # context: child is daemonic, so attempts to spawn its own children
+    # should raise AssertionError in untreated code.
+    peptide_list = list(training_df["peptide"].values)
+    df_records = training_df.to_dict("records")
+    allele_data = {
+        "alleles": list(training_df["allele"].values),
+        "allele_to_sequence": ALLELE_TO_SEQUENCE,
+    }
+
+    p = ctx.Process(
+        target=_train_in_daemon_subprocess,
+        args=(result_queue, peptide_list, df_records, allele_data),
+        daemon=True,
+    )
+    p.start()
+    p.join(timeout=180)
+    if p.is_alive():
+        p.terminate()
+        pytest.fail("daemon-subprocess training did not finish within 3 min")
+
+    assert not result_queue.empty(), (
+        "daemon-subprocess produced no result — likely crashed before "
+        "fit() returned (segfault or non-Python failure)"
+    )
+    status, payload = result_queue.get(timeout=5)
+    assert status == "ok", (
+        f"daemon-subprocess training FAILED. This is the regression that "
+        f"detonated the 2026-04-20 A100 run. Check "
+        f"_effective_num_workers in class1_neural_network.py.\n"
+        f"Subprocess error:\n{payload}"
+    )
+    n_epochs = payload
+    assert n_epochs == 1, f"expected 1 training epoch, got {n_epochs}"

--- a/test/test_encoding_cache_training_integration.py
+++ b/test/test_encoding_cache_training_integration.py
@@ -497,6 +497,137 @@ def test_dataloader_persistent_workers_true_matches_false(
         )
 
 
+def test_fit_generator_self_reproducible(training_df, allele_encoding):
+    """fit_generator with the val-tensor hoist must be self-reproducible.
+
+    Regression lock for the Phase 1 extension (#268) to fit_generator:
+    - val_peptide_device / val_allele_device / val_y_device are allocated
+      once before the epoch loop instead of re-materialized per epoch.
+    - Validation uses those device tensors directly.
+
+    Running the same seeded fit_generator twice must produce bit-identical
+    loss and val_loss trajectories. If the hoist accidentally reuses
+    the tensor in a way that leaks state across epochs (e.g. in-place
+    modification, gradient accumulation on a frozen graph), this test
+    will catch it.
+    """
+    _seed_everything(seed=24680)
+
+    peptides = EncodableSequences(TRAIN_PEPTIDES[:16])
+    affinities = numpy.linspace(50.0, 50000.0, 16)
+
+    allele_list = [TRAIN_ALLELES_CYCLE[i % 3] for i in range(16)]
+    alleles = AlleleEncoding(
+        alleles=allele_list, allele_to_sequence=ALLELE_TO_SEQUENCE,
+    )
+
+    hp = _tiny_hyperparameters()
+
+    def make_generator():
+        # Two chunks; first 8 peptides then next 8.
+        for start in (0, 8):
+            chunk_peptides = EncodableSequences(TRAIN_PEPTIDES[start:start + 8])
+            chunk_alleles = AlleleEncoding(
+                alleles=allele_list[start:start + 8],
+                allele_to_sequence=ALLELE_TO_SEQUENCE,
+            )
+            yield (chunk_alleles, chunk_peptides,
+                   affinities[start:start + 8])
+
+    def run_once():
+        _seed_everything(seed=24680)
+        net = Class1NeuralNetwork(**hp)
+        # Create the network via a dummy call to fit() first; or let
+        # fit_generator build it.
+        net.fit_generator(
+            generator=make_generator(),
+            validation_peptide_encoding=peptides,
+            validation_affinities=affinities,
+            validation_allele_encoding=alleles,
+            steps_per_epoch=2,
+            epochs=3,
+            min_epochs=3,
+            patience=100,
+            verbose=0,
+            progress_print_interval=None,
+        )
+        info = net.fit_info[-1]
+        return list(info["loss"]), list(info["val_loss"])
+
+    loss_a, val_a = run_once()
+    loss_b, val_b = run_once()
+    numpy.testing.assert_array_equal(loss_a, loss_b)
+    numpy.testing.assert_array_equal(val_a, val_b)
+
+
+def test_fit_generator_validation_tensors_hoisted_once(
+    training_df, allele_encoding
+):
+    """The val-tensor H2D happens ONCE, not per epoch.
+
+    Spy on torch.from_numpy to count calls during fit_generator. Before
+    the hoist: 3 calls (peptide, allele, y) × N epochs. After: 3 calls
+    up front, zero inside the epoch loop for validation.
+
+    This is a perf-regression guard — if someone refactors fit_generator
+    and moves the val H2D back inside the epoch loop, this test fires.
+    """
+    import torch as _torch
+
+    _seed_everything(seed=24680)
+    peptides = EncodableSequences(TRAIN_PEPTIDES[:8])
+    affinities = numpy.linspace(50.0, 50000.0, 8)
+    allele_list = [TRAIN_ALLELES_CYCLE[i % 3] for i in range(8)]
+    alleles = AlleleEncoding(
+        alleles=allele_list, allele_to_sequence=ALLELE_TO_SEQUENCE,
+    )
+
+    def make_generator():
+        yield (alleles, peptides, affinities)
+
+    hp = _tiny_hyperparameters()
+    net = Class1NeuralNetwork(**hp)
+
+    # Count all torch.from_numpy calls under fit_generator. The
+    # per-step training loop calls it 3× (peptide/allele/y). The val
+    # side should call it 3× TOTAL (hoisted), not 3× per epoch.
+    call_count = [0]
+    orig = _torch.from_numpy
+
+    def spy(a):
+        call_count[0] += 1
+        return orig(a)
+
+    _torch.from_numpy = spy
+    try:
+        net.fit_generator(
+            generator=make_generator(),
+            validation_peptide_encoding=peptides,
+            validation_affinities=affinities,
+            validation_allele_encoding=alleles,
+            steps_per_epoch=1,
+            epochs=5,
+            min_epochs=5,
+            patience=100,
+            verbose=0,
+            progress_print_interval=None,
+        )
+    finally:
+        _torch.from_numpy = orig
+
+    # Expected calls: 3 val-hoist up front + 3 per training step × 5 epochs
+    # × 1 step = 15. Total = 18. Budget it loosely (±5) to tolerate other
+    # numpy→torch conversions (e.g. loss internals) without hardcoding
+    # an exact number.
+    expected_max = 3 + (3 * 5) + 5  # hoist + step + slack
+    assert call_count[0] <= expected_max, (
+        f"torch.from_numpy called {call_count[0]} times in a 5-epoch run. "
+        f"Expected ~{expected_max}. If this ballooned, the val-tensor "
+        f"hoist regressed — H2D is running per-epoch again, negating the "
+        f"Phase 1 fit_generator perf fix."
+    )
+
+
 def test_dataloader_persistent_workers_ignored_when_no_workers(
     training_df, allele_encoding
 ):

--- a/test/test_local_parallelism.py
+++ b/test/test_local_parallelism.py
@@ -1,8 +1,11 @@
 from argparse import ArgumentParser
 
+import multiprocessing
 import pytest
 
 from mhcflurry.local_parallelism import (
+    NonDaemonPool,
+    NonDaemonProcess,
     add_local_parallelism_args,
     validate_worker_pool_args,
     worker_init_kwargs_for_scheduler,
@@ -97,3 +100,79 @@ def test_validate_worker_pool_args_rejects_invalid_backend():
             backend="gpuu",
             max_workers_per_gpu=1,
         )
+
+
+# ---- Non-daemonic pool regression tests ----------------------------------
+#
+# Phase 1 (#268) needs Pool workers to be non-daemonic so the PyTorch
+# DataLoader inside a training worker can spawn its own prefetch
+# children. The default multiprocessing.Pool ships daemon workers,
+# which makes DataLoader(num_workers>0) raise AssertionError. These
+# tests lock down the new NonDaemonPool / NonDaemonProcess behavior.
+
+
+def _is_daemon_in_pool_worker(_):
+    """Run inside a pool worker; returns whether the current process is a daemon."""
+    return multiprocessing.current_process().daemon
+
+
+def test_nondaemonprocess_reports_not_daemon():
+    """NonDaemonProcess.daemon must always read as False regardless of writes."""
+    p = NonDaemonProcess(target=lambda: None)
+    assert p.daemon is False
+    # The Pool internals WILL assign .daemon = True on every fresh worker —
+    # tolerate the assignment silently without raising or flipping the flag.
+    p.daemon = True
+    assert p.daemon is False, "daemon setter should have been a no-op"
+
+
+def test_nondaemonpool_workers_are_not_daemonic():
+    """The whole point: Pool workers must report daemon=False."""
+    with NonDaemonPool(processes=2) as pool:
+        results = pool.map(_is_daemon_in_pool_worker, [None, None, None, None])
+    assert all(r is False for r in results), (
+        f"expected all workers daemon=False, got {results}. If True values "
+        f"appear, the custom NonDaemonContext isn't threading through to "
+        f"Pool._repopulate_pool, so DataLoader(num_workers>0) will still "
+        f"detonate inside mhcflurry Pool workers."
+    )
+
+
+def _grandchild_entry():
+    """Minimal module-level child entry (pickle-able across spawn)."""
+    return None
+
+
+def _spawn_child_from_pool_worker(_):
+    """Spawn a grandchild process from within a Pool worker.
+
+    The AssertionError from the Phase 1 (#268) A100 crash reproduces here
+    if the Pool worker is daemonic: the inner multiprocessing.Process
+    .start() call raises "daemonic processes are not allowed to have
+    children". With a non-daemonic worker this succeeds.
+    """
+    child = multiprocessing.Process(target=_grandchild_entry)
+    child.start()
+    child.join(timeout=10)
+    return child.exitcode
+
+
+def test_nondaemonpool_worker_can_spawn_children():
+    """Non-daemon pool workers must be able to spawn multiprocessing children.
+
+    This is the regression test for the Phase 1 (#268) A100 crash
+    where DataLoader(num_workers>0) called from a mhcflurry Pool worker
+    raised AssertionError("daemonic processes are not allowed to have
+    children"). With NonDaemonPool, the Pool workers are not daemonic,
+    so spawning a child succeeds.
+    """
+    with NonDaemonPool(processes=2) as pool:
+        # Without the fix, this would raise from deep in the worker's
+        # own multiprocessing machinery with the AssertionError above.
+        exit_codes = pool.map(_spawn_child_from_pool_worker, [None, None])
+    assert all(code == 0 for code in exit_codes), (
+        f"children spawned from pool workers did not exit cleanly: "
+        f"{exit_codes}. If this fails, Pool workers have regressed to "
+        f"daemonic and the DataLoader prefetch optimization is broken "
+        f"in production."
+    )

--- a/test/test_predict_encoding_cache.py
+++ b/test/test_predict_encoding_cache.py
@@ -131,7 +131,7 @@ def test_predict_with_cache_warm_second_call_no_peptide_reencoding(
         f"with {n_networks} networks in the ensemble. Expected ≤2 "
         f"(just the allele-encoding path). If ≥ {n_networks}+1, the "
         f"peptide cache isn't being hit. Check that "
-        f"make_preencoded_encodable_sequences is producing the right key "
+        f"make_prepopulated_encodable_sequences is producing the right key "
         f"tuple + that the EncodableSequences instance isn't being "
         f"recreated somewhere in predict_to_dataframe."
     )

--- a/test/test_predict_encoding_cache.py
+++ b/test/test_predict_encoding_cache.py
@@ -1,0 +1,270 @@
+"""Inference-time encoding cache tests.
+
+Phase 3 extension of issue #268: the encoding cache module was already
+training-agnostic, but the inference predict() path didn't wire it up.
+With ``encoding_cache_dir=<dir>``, a single pass encodes the peptide
+list and every network in the ensemble hits the prepopulated cache on
+its ``peptides_to_network_input`` call.
+
+The load-bearing invariants these tests protect:
+
+  1. ``encoding_cache_dir=None`` is bit-identical to pre-change
+     predict() output (backward-compat).
+  2. ``encoding_cache_dir=<dir>`` produces the SAME predictions as the
+     uncached path — the cache is a pure perf-optimization.
+  3. Networks actually hit the cache (no re-encoding) — detected by
+     spying on ``EncodableSequences.variable_length_to_fixed_length_vector_encoding``.
+  4. Edge cases: empty peptide list, predictor with zero networks,
+     unrecognized peptide_encoding kwargs — all fall back to uncached
+     path without crashing.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from numpy.testing import assert_array_equal
+
+from mhcflurry import Class1AffinityPredictor
+from mhcflurry.downloads import get_path
+from mhcflurry.encodable_sequences import EncodableSequences
+from mhcflurry.encoding_cache import _verify_cache_key_shape
+
+
+# Test fixtures: small peptide set scored on one canonical allele.
+TEST_PEPTIDES = [
+    "SIINFEKL", "GILGFVFTL", "NLVPMVATV", "YLQPRTFLL", "KLVALGINAV",
+    "FLRGRAYGL", "ELAGIGILTV", "RMFPNAPYL",
+]
+TEST_ALLELE = "HLA-A*02:01"
+
+
+@pytest.fixture(scope="module")
+def public_predictor():
+    """Load the public mhcflurry pan-allele predictor once per module."""
+    path = Path(get_path("models_class1_pan")) / "models.combined"
+    if not path.exists():
+        pytest.skip(f"public predictor not downloaded: {path}")
+    return Class1AffinityPredictor.load(str(path))
+
+
+def test_predict_with_cache_matches_uncached(public_predictor, tmp_path):
+    """THE GATE: encoding_cache_dir=<dir> produces identical predictions.
+
+    Any divergence here means the cache is a behavior change, not a
+    pure optimization — unacceptable for an inference-side feature.
+    """
+    # Uncached path.
+    preds_uncached = public_predictor.predict(
+        peptides=TEST_PEPTIDES, allele=TEST_ALLELE
+    )
+    # Cached path.
+    preds_cached = public_predictor.predict(
+        peptides=TEST_PEPTIDES,
+        allele=TEST_ALLELE,
+        encoding_cache_dir=str(tmp_path / "encoding_cache"),
+    )
+    assert_array_equal(preds_uncached, preds_cached)
+
+
+def test_predict_with_cache_warm_second_call_no_peptide_reencoding(
+    public_predictor, tmp_path
+):
+    """Second call on same peptides must skip peptide re-encoding.
+
+    Prime the cache with a first call, then spy on the low-level
+    ``amino_acid.fixed_vectors_encoding`` (only called on true cache
+    miss) and run a second call. Result scales with the ALLELE-encoding
+    path (always 1 call per predict regardless of peptide cache), not
+    with the number of networks in the ensemble.
+
+    With N networks and NO peptide cache: N peptide encodes + 1 allele
+    encode = N+1 calls on each predict. With the peptide cache: just
+    the 1 allele encode, regardless of N.
+
+    The assertion is "encode calls ≤ 2" — tight enough to catch a
+    regression (would be ≥ N+1 = 11 on the 10-network public predictor)
+    while not being so tight that an orthogonal allele-encoding call
+    breaks it.
+    """
+    from mhcflurry import amino_acid
+
+    # Prime the cache-key-shape self-test so it doesn't show up as
+    # encode calls under the spy (it runs once per process).
+    _verify_cache_key_shape()
+
+    cache_dir = str(tmp_path / "encoding_cache")
+
+    # First call builds the cache.
+    public_predictor.predict(
+        peptides=TEST_PEPTIDES,
+        allele=TEST_ALLELE,
+        encoding_cache_dir=cache_dir,
+    )
+
+    # Second call should skip peptide encoding; we spy on the actual
+    # encode work (not the wrapper function which always runs regardless
+    # of cache hit).
+    calls = []
+    original = amino_acid.fixed_vectors_encoding
+
+    def spy(*a, **kw):
+        calls.append(1)
+        return original(*a, **kw)
+
+    amino_acid.fixed_vectors_encoding = spy
+    try:
+        public_predictor.predict(
+            peptides=TEST_PEPTIDES,
+            allele=TEST_ALLELE,
+            encoding_cache_dir=cache_dir,
+        )
+    finally:
+        amino_acid.fixed_vectors_encoding = original
+
+    n_networks = len(public_predictor.neural_networks)
+    # Allele encoding always triggers 1 call; peptide cache should cut
+    # the N peptide encodes down to 0. Budget = 2 (allele + slack).
+    assert len(calls) <= 2, (
+        f"warm-cache predict ran fixed_vectors_encoding {len(calls)} times "
+        f"with {n_networks} networks in the ensemble. Expected ≤2 "
+        f"(just the allele-encoding path). If ≥ {n_networks}+1, the "
+        f"peptide cache isn't being hit. Check that "
+        f"make_preencoded_encodable_sequences is producing the right key "
+        f"tuple + that the EncodableSequences instance isn't being "
+        f"recreated somewhere in predict_to_dataframe."
+    )
+
+
+def test_predict_with_cache_handles_empty_peptide_list(public_predictor, tmp_path):
+    """Empty peptide list shouldn't crash the cache build path."""
+    result = public_predictor.predict(
+        peptides=[],
+        alleles=[],
+        encoding_cache_dir=str(tmp_path / "encoding_cache"),
+    )
+    # predict() returns an array of predictions; empty input → empty output.
+    assert len(result) == 0
+
+
+def test_predict_cache_dir_none_is_default_path(public_predictor):
+    """encoding_cache_dir=None is the pre-change default (backward-compat)."""
+    # Verify explicit None and omitted arg produce the same thing.
+    preds_default = public_predictor.predict(
+        peptides=TEST_PEPTIDES, allele=TEST_ALLELE
+    )
+    preds_none = public_predictor.predict(
+        peptides=TEST_PEPTIDES, allele=TEST_ALLELE, encoding_cache_dir=None
+    )
+    assert_array_equal(preds_default, preds_none)
+
+
+def test_prepare_peptides_helper_fallback_on_empty_predictor(tmp_path):
+    """Predictor with zero networks falls back to uncached path cleanly."""
+    empty = Class1AffinityPredictor(class1_pan_allele_models=[])
+    # Should NOT try to introspect hyperparameters from networks[0].
+    result = empty._prepare_peptides_with_optional_cache(
+        TEST_PEPTIDES, encoding_cache_dir=str(tmp_path / "cache"),
+    )
+    assert isinstance(result, EncodableSequences)
+    assert list(result.sequences) == TEST_PEPTIDES
+
+
+def test_prepare_peptides_helper_fallback_on_unknown_encoding_kwarg(
+    public_predictor, tmp_path
+):
+    """Unknown peptide_encoding kwarg falls back to uncached, not crash.
+
+    Guards against future upstream additions to peptide_encoding that
+    EncodingParams doesn't know about yet.
+    """
+    # Temporarily patch the first network's hyperparameters to include
+    # a key that EncodingParams doesn't accept.
+    net0 = public_predictor.neural_networks[0]
+    original_hp = dict(net0.hyperparameters)
+    try:
+        net0.hyperparameters["peptide_encoding"] = {
+            **original_hp.get("peptide_encoding", {}),
+            "brand_new_unknown_kwarg": 42,
+        }
+        # Should NOT crash — falls back to uncached path.
+        result = public_predictor._prepare_peptides_with_optional_cache(
+            TEST_PEPTIDES, encoding_cache_dir=str(tmp_path / "cache"),
+        )
+        assert isinstance(result, EncodableSequences)
+        # Cache was not populated (fallback path).
+        assert result.encoding_cache == {}
+    finally:
+        net0.hyperparameters.clear()
+        net0.hyperparameters.update(original_hp)
+
+
+def test_prepare_peptides_helper_accepts_encodablesequences_input(
+    public_predictor, tmp_path
+):
+    """Passing an EncodableSequences (not a list) works through the cache path."""
+    es = EncodableSequences(TEST_PEPTIDES)
+    result = public_predictor._prepare_peptides_with_optional_cache(
+        es, encoding_cache_dir=str(tmp_path / "cache"),
+    )
+    assert isinstance(result, EncodableSequences)
+    # Cache entry should be populated since we gave a non-empty list.
+    assert len(result.encoding_cache) == 1
+    assert list(result.sequences) == TEST_PEPTIDES
+
+
+def test_predict_cache_reuses_across_multiple_predictor_instances(
+    public_predictor, tmp_path
+):
+    """Shared cache_dir between two predictor instances avoids re-encoding.
+
+    This is the killer use case: scoring the same peptide set with
+    multiple predictors (ours vs public comparison) shares the encoding
+    cost across both runs.
+    """
+    from mhcflurry import amino_acid
+
+    # Prime the cache-key-shape self-test so it doesn't count here.
+    _verify_cache_key_shape()
+
+    cache_dir = str(tmp_path / "shared_cache")
+    # First predictor builds the cache.
+    public_predictor.predict(
+        peptides=TEST_PEPTIDES,
+        allele=TEST_ALLELE,
+        encoding_cache_dir=cache_dir,
+    )
+
+    # A NEW predictor (same models, different Python instance) pointed
+    # at the same cache_dir should hit warm cache on first call.
+    public_predictor_2 = Class1AffinityPredictor.load(
+        str(Path(get_path("models_class1_pan")) / "models.combined")
+    )
+
+    calls = []
+    original = amino_acid.fixed_vectors_encoding
+
+    def spy(*a, **kw):
+        calls.append(1)
+        return original(*a, **kw)
+
+    amino_acid.fixed_vectors_encoding = spy
+    try:
+        public_predictor_2.predict(
+            peptides=TEST_PEPTIDES,
+            allele=TEST_ALLELE,
+            encoding_cache_dir=cache_dir,
+        )
+    finally:
+        amino_acid.fixed_vectors_encoding = original
+
+    # Same budget as the single-predictor warm-cache test: ≤2 allowed
+    # for the allele-encoding path, but the N peptide encodes per
+    # network (would be ≥ N+1 = 11 without the cache) must be 0.
+    assert len(calls) <= 2, (
+        f"cross-predictor cache sharing is broken — the second predictor "
+        f"ran fixed_vectors_encoding {len(calls)} times. Expected ≤2 "
+        f"(just the allele-encoding path). Likely the orchestrator-side "
+        f"cache-key hash differs from the predict-side hash."
+    )

--- a/test/test_train_pan_allele_encoding_cache.py
+++ b/test/test_train_pan_allele_encoding_cache.py
@@ -1,0 +1,1037 @@
+"""Integration tests for the encoding cache plumbed into train_pan_allele.
+
+This file exercises the specific surfaces that Phase 1 (issue #268) touches
+in ``train_pan_allele_models_command``:
+
+    _build_train_peptides() — per-worker helper that returns an
+        EncodableSequences either directly (cache disabled, old behavior)
+        or via the pre-built memmap (cache enabled, new behavior).
+
+    _deterministic_unique_peptide_list() — both orchestrator and workers
+        must derive identical peptide lists from the same train_data, or
+        the cache key won't match.
+
+    _initialize_encoding_cache() — orchestrator-side build step.
+
+The load-bearing assertion throughout: with or without the cache, the
+bytes that ``peptides_to_network_input`` produces from the returned
+EncodableSequences are identical. Bit-identical. Any deviation here means
+Phase 1 is not semantics-preserving and should not be merged.
+"""
+
+from __future__ import annotations
+
+import pickle
+from pathlib import Path
+from unittest.mock import Mock
+
+import numpy
+import pandas
+import pytest
+from numpy.testing import assert_array_equal
+
+from mhcflurry.allele_encoding import AlleleEncoding
+from mhcflurry.class1_neural_network import Class1NeuralNetwork
+from mhcflurry.encodable_sequences import EncodableSequences
+from mhcflurry.encoding_cache import EncodingCache, EncodingParams
+from mhcflurry.train_pan_allele_models_command import (
+    _build_train_peptides,
+    _deterministic_unique_peptide_list,
+    _initialize_encoding_cache,
+    _read_pretrain_peptide_list,
+    GLOBAL_DATA,
+    pretrain_data_iterator,
+)
+
+
+# Representative 8-15mer peptides + a few repeats, mimicking how real
+# training data has the same peptide appear across multiple alleles.
+SAMPLE_TRAIN_PEPTIDES = [
+    "SIINFEKL",
+    "GILGFVFTL",
+    "NLVPMVATV",
+    "YLQPRTFLL",
+    "KLVALGINAV",
+    "GILGFVFTL",  # repeat
+    "FLRGRAYGL",
+    "ELAGIGILTV",
+    "NLVPMVATV",  # repeat
+    "RMFPNAPYL",
+    "AAAAAAAAA",
+    "SIINFEKL",  # repeat
+]
+
+DEFAULT_PEPTIDE_ENCODING = {
+    "alignment_method": "left_pad_centered_right_pad",
+    "max_length": 15,
+    "vector_encoding_name": "BLOSUM62",
+}
+
+
+@pytest.fixture(autouse=True)
+def clear_global_data():
+    """Reset GLOBAL_DATA between tests so cache state doesn't bleed over."""
+    GLOBAL_DATA.clear()
+    yield
+    GLOBAL_DATA.clear()
+
+
+@pytest.fixture
+def train_data():
+    """Mock train_data DataFrame matching the shape train_model expects.
+
+    The real df also has allele, measurement_value, etc. columns; we only
+    need peptide for this test.
+    """
+    return pandas.DataFrame({"peptide": SAMPLE_TRAIN_PEPTIDES})
+
+
+@pytest.fixture
+def constant_data_no_cache(train_data):
+    return {"train_data": train_data}
+
+
+@pytest.fixture
+def constant_data_with_cache(train_data, tmp_path):
+    """Set up GLOBAL_DATA as if _initialize_encoding_cache had already run."""
+    data = {
+        "train_data": train_data,
+        "encoding_cache_dir": str(tmp_path / "encoding_cache"),
+    }
+    return data
+
+
+@pytest.fixture
+def hyperparameters():
+    return {"peptide_encoding": DEFAULT_PEPTIDE_ENCODING}
+
+
+# ---- _deterministic_unique_peptide_list ----
+
+
+def test_unique_peptide_list_is_first_seen_order(train_data):
+    got = _deterministic_unique_peptide_list(train_data.peptide.values)
+    # Order of first appearance, no duplicates.
+    assert got == [
+        "SIINFEKL",
+        "GILGFVFTL",
+        "NLVPMVATV",
+        "YLQPRTFLL",
+        "KLVALGINAV",
+        "FLRGRAYGL",
+        "ELAGIGILTV",
+        "RMFPNAPYL",
+        "AAAAAAAAA",
+    ]
+
+
+def test_unique_peptide_list_stable_across_calls(train_data):
+    """Must be deterministic — orchestrator and worker must agree."""
+    first = _deterministic_unique_peptide_list(train_data.peptide.values)
+    second = _deterministic_unique_peptide_list(train_data.peptide.values)
+    assert first == second
+
+
+# ---- _build_train_peptides — the semantic preservation test ----
+
+
+def test_build_train_peptides_cache_disabled_returns_plain_encodable(
+    constant_data_no_cache, hyperparameters, train_data
+):
+    """Cache-disabled path must be indistinguishable from EncodableSequences(values).
+
+    Guards against accidentally changing the old-path behavior via refactor.
+    """
+    peptides = train_data.peptide.values
+    got = _build_train_peptides(peptides, hyperparameters, constant_data_no_cache)
+    assert isinstance(got, EncodableSequences)
+    # encoding_cache should be empty on entry (no prepopulation)
+    assert got.encoding_cache == {}
+
+
+def test_build_train_peptides_cache_enabled_returns_prepopulated(
+    constant_data_with_cache, hyperparameters, train_data
+):
+    """Cache-enabled path returns an EncodableSequences whose cache is prepopulated."""
+    # Orchestrator would have run _initialize_encoding_cache first. Fake it.
+    all_work_items = [{"hyperparameters": hyperparameters}]
+    args = Mock(
+        use_encoding_cache=True,
+        encoding_cache_dir=constant_data_with_cache["encoding_cache_dir"],
+        out_models_dir=str(Path(constant_data_with_cache["encoding_cache_dir"]).parent),
+    )
+    GLOBAL_DATA.update(constant_data_with_cache)
+    _initialize_encoding_cache(args, all_work_items)
+    # Verify orchestrator stashed the metadata.
+    assert "encoding_cache_dir" in GLOBAL_DATA
+    constant_data = dict(GLOBAL_DATA)  # shallow copy, what workers would see
+
+    peptides = train_data.peptide.values
+    got = _build_train_peptides(peptides, hyperparameters, constant_data)
+    assert isinstance(got, EncodableSequences)
+    # encoding_cache should have exactly one entry — the prepopulated one.
+    assert len(got.encoding_cache) == 1
+
+
+def test_build_train_peptides_bit_identical_across_modes(
+    constant_data_no_cache, constant_data_with_cache, hyperparameters, train_data
+):
+    """THE GATE: cached and un-cached paths produce byte-identical network input.
+
+    We run peptides_to_network_input on both and assert identical bytes.
+    If this fails, Phase 1 is not semantics-preserving. Do not merge.
+    """
+    # Initialize the cache (orchestrator step).
+    all_work_items = [{"hyperparameters": hyperparameters}]
+    args = Mock(
+        use_encoding_cache=True,
+        encoding_cache_dir=constant_data_with_cache["encoding_cache_dir"],
+        out_models_dir=str(Path(constant_data_with_cache["encoding_cache_dir"]).parent),
+    )
+    GLOBAL_DATA.update(constant_data_with_cache)
+    _initialize_encoding_cache(args, all_work_items)
+    constant_data_cached = dict(GLOBAL_DATA)
+
+    peptides = train_data.peptide.values
+
+    # Old path: plain EncodableSequences, encoded directly.
+    es_old = _build_train_peptides(peptides, hyperparameters, constant_data_no_cache)
+    # New path: prepopulated from cache.
+    es_new = _build_train_peptides(peptides, hyperparameters, constant_data_cached)
+
+    # Encode via a Class1NeuralNetwork (which is how it happens in real training).
+    net = Class1NeuralNetwork(peptide_encoding=DEFAULT_PEPTIDE_ENCODING)
+    encoded_old = net.peptides_to_network_input(es_old)
+    encoded_new = net.peptides_to_network_input(es_new)
+
+    assert encoded_old.shape == encoded_new.shape
+    # Both should be the same dtype post-encoding. Old path may return
+    # float64 (depending on upstream); new path pins float32. Compare
+    # after common-dtype cast — identity is what matters, not dtype width.
+    assert_array_equal(
+        encoded_old.astype(numpy.float32), encoded_new.astype(numpy.float32)
+    )
+
+
+def test_build_train_peptides_preserves_fold_order(
+    constant_data_with_cache, hyperparameters, train_data
+):
+    """The fold's shuffled peptide order is preserved post-cache lookup.
+
+    Training assigns (peptide[i], allele[i], affinity[i]) together. If the
+    cache lookup reshuffled rows, affinities would be paired with the wrong
+    peptides and training would silently learn garbage.
+    """
+    all_work_items = [{"hyperparameters": hyperparameters}]
+    args = Mock(
+        use_encoding_cache=True,
+        encoding_cache_dir=constant_data_with_cache["encoding_cache_dir"],
+        out_models_dir=str(Path(constant_data_with_cache["encoding_cache_dir"]).parent),
+    )
+    GLOBAL_DATA.update(constant_data_with_cache)
+    _initialize_encoding_cache(args, all_work_items)
+    constant_data = dict(GLOBAL_DATA)
+
+    # Simulate a fold that shuffles the training data — sample frac=1.0.
+    shuffled = train_data.sample(frac=1.0, random_state=42)
+    peptides_shuffled = shuffled.peptide.values
+
+    got = _build_train_peptides(peptides_shuffled, hyperparameters, constant_data)
+    net = Class1NeuralNetwork(peptide_encoding=DEFAULT_PEPTIDE_ENCODING)
+    encoded_via_cache = net.peptides_to_network_input(got)
+
+    # What we'd get without the cache on the shuffled list:
+    expected = net.peptides_to_network_input(EncodableSequences(peptides_shuffled))
+
+    assert_array_equal(
+        encoded_via_cache.astype(numpy.float32),
+        expected.astype(numpy.float32),
+    )
+
+
+def test_build_train_peptides_different_archs_different_configs(
+    constant_data_with_cache, train_data
+):
+    """Architectures with different peptide_encoding configs use separate caches.
+
+    Architecture A uses alignment=pad_middle, B uses left_pad_centered.
+    Each needs its own cache entry; they must not collide.
+    """
+    hp_a = {"peptide_encoding": {
+        "alignment_method": "pad_middle",
+        "max_length": 15,
+        "vector_encoding_name": "BLOSUM62",
+    }}
+    hp_b = {"peptide_encoding": {
+        "alignment_method": "left_pad_centered_right_pad",
+        "max_length": 15,
+        "vector_encoding_name": "BLOSUM62",
+    }}
+    all_work_items = [
+        {"hyperparameters": hp_a},
+        {"hyperparameters": hp_b},
+    ]
+    args = Mock(
+        use_encoding_cache=True,
+        encoding_cache_dir=constant_data_with_cache["encoding_cache_dir"],
+        out_models_dir=str(Path(constant_data_with_cache["encoding_cache_dir"]).parent),
+    )
+    GLOBAL_DATA.update(constant_data_with_cache)
+    _initialize_encoding_cache(args, all_work_items)
+    constant_data = dict(GLOBAL_DATA)
+
+    peptides = train_data.peptide.values
+    es_a = _build_train_peptides(peptides, hp_a, constant_data)
+    es_b = _build_train_peptides(peptides, hp_b, constant_data)
+
+    net_a = Class1NeuralNetwork(peptide_encoding=hp_a["peptide_encoding"])
+    net_b = Class1NeuralNetwork(peptide_encoding=hp_b["peptide_encoding"])
+    encoded_a = net_a.peptides_to_network_input(es_a)
+    encoded_b = net_b.peptides_to_network_input(es_b)
+
+    # Shapes differ because alignment changes encoded_len (15 vs 45).
+    assert encoded_a.shape != encoded_b.shape
+
+
+def test_initialize_encoding_cache_is_idempotent(
+    constant_data_with_cache, hyperparameters
+):
+    """Calling _initialize_encoding_cache twice should hit the cache the second time."""
+    all_work_items = [{"hyperparameters": hyperparameters}]
+    args = Mock(
+        use_encoding_cache=True,
+        encoding_cache_dir=constant_data_with_cache["encoding_cache_dir"],
+        out_models_dir=str(Path(constant_data_with_cache["encoding_cache_dir"]).parent),
+    )
+    GLOBAL_DATA.update(constant_data_with_cache)
+
+    _initialize_encoding_cache(args, all_work_items)
+    # Spy on EncodableSequences to verify no re-encoding happens on second call.
+    calls = []
+    original = EncodableSequences.variable_length_to_fixed_length_vector_encoding
+
+    def spy(self, *a, **kw):
+        calls.append(1)
+        return original(self, *a, **kw)
+
+    EncodableSequences.variable_length_to_fixed_length_vector_encoding = spy
+    try:
+        _initialize_encoding_cache(args, all_work_items)
+    finally:
+        EncodableSequences.variable_length_to_fixed_length_vector_encoding = original
+    assert calls == [], "second initialize should not re-encode"
+
+
+# ---- Backward-compat ----
+
+
+def test_disabled_cache_path_does_not_access_cache_dir(
+    constant_data_no_cache, hyperparameters, train_data, tmp_path, monkeypatch
+):
+    """With the cache disabled, no filesystem access should occur under cache_dir.
+
+    Guards against accidental cache-dir lookups in the cache-disabled path —
+    regressions where someone adds a .get() that defaults to the cache dir.
+    """
+    # If constant_data has no 'encoding_cache_dir', EncodingCache must not
+    # be constructed at all. We can't easily assert on that without patching,
+    # but we can assert the call still works and returns a plain
+    # EncodableSequences.
+    got = _build_train_peptides(
+        train_data.peptide.values, hyperparameters, constant_data_no_cache
+    )
+    assert got.encoding_cache == {}
+
+
+# ---- pretrain_data_iterator tests ---------------------------------------
+
+
+PRETRAIN_PEPTIDES = [
+    "SIINFEKL",
+    "GILGFVFTL",
+    "NLVPMVATV",
+    "YLQPRTFLL",
+    "KLVALGINAV",
+    "FLRGRAYGL",
+    "ELAGIGILTV",
+    "RMFPNAPYL",
+]
+
+# Two alleles with arbitrary but canonical-AA sequences. The exact content
+# doesn't matter for the iterator path; only the allele names must match
+# what the AlleleEncoding knows about.
+PRETRAIN_ALLELES = ["HLA-A*02:01", "HLA-B*07:02"]
+ALLELE_TO_SEQUENCE = {
+    "HLA-A*02:01": "YFAMYQENMAHTDANTLYLNYHDYTWAVLAYTWY",
+    "HLA-B*07:02": "YFSTSVSRPGRGEPRFIAVGYVDDTQFVRFDSDAA",
+}
+
+
+@pytest.fixture
+def pretrain_csv(tmp_path):
+    """Write a tiny pretrain CSV matching the iterator's expected format.
+
+    Format: index column is the peptide; remaining columns are allele ->
+    affinity. The iterator reads rows in chunks of ``peptides_per_chunk``.
+    """
+    path = tmp_path / "pretrain.csv"
+    # Generate reproducible synthetic affinities.
+    rng = numpy.random.default_rng(42)
+    rows = []
+    for peptide in PRETRAIN_PEPTIDES:
+        rows.append({
+            "peptide": peptide,
+            **{allele: rng.random() for allele in PRETRAIN_ALLELES},
+        })
+    pandas.DataFrame(rows).to_csv(path, index=False)
+    # The iterator expects the peptide to be the CSV index, not a column,
+    # so re-read and rewrite with index_col.
+    df = pandas.read_csv(path)
+    df.set_index("peptide", inplace=True)
+    df.to_csv(path)
+    return path
+
+
+@pytest.fixture
+def pretrain_allele_encoding():
+    """A minimal AlleleEncoding covering the pretrain alleles."""
+    return AlleleEncoding(
+        alleles=PRETRAIN_ALLELES,
+        allele_to_sequence=ALLELE_TO_SEQUENCE,
+    )
+
+
+def test_read_pretrain_peptide_list_returns_index(pretrain_csv):
+    got = _read_pretrain_peptide_list(pretrain_csv)
+    assert got == PRETRAIN_PEPTIDES
+
+
+def _consume_iterator(iterator, n_chunks):
+    """Pull n_chunks from a pretrain_data_iterator generator.
+
+    Returns a list of (allele_encoding, encodable_peptides, affinities) tuples.
+    """
+    out = []
+    for _ in range(n_chunks):
+        out.append(next(iterator))
+    return out
+
+
+def test_pretrain_iterator_without_cache_yields_normally(
+    pretrain_csv, pretrain_allele_encoding
+):
+    """Sanity: uncached path still works with small chunks."""
+    it = pretrain_data_iterator(
+        str(pretrain_csv),
+        pretrain_allele_encoding,
+        peptides_per_chunk=4,
+    )
+    chunks = _consume_iterator(it, n_chunks=2)
+    # 2 chunks of 4 peptides each = 8 peptides. Each yielded EncodableSequences
+    # has 4 * 2 alleles = 8 peptide slots (peptides × alleles).
+    for (alleles, encodable, affinities) in chunks:
+        assert isinstance(encodable, EncodableSequences)
+        # 4 peptides × 2 alleles
+        assert len(encodable.sequences) == 8
+        assert len(affinities) == 8
+
+
+def test_pretrain_iterator_with_cache_bit_identical(
+    pretrain_csv, pretrain_allele_encoding, tmp_path
+):
+    """THE PRETRAIN GATE: cached yields must match uncached byte-for-byte.
+
+    We consume the same number of chunks from both paths and compare the
+    peptide encoding tensors produced by passing each chunk's
+    EncodableSequences through peptides_to_network_input.
+    """
+    params = EncodingParams(
+        alignment_method="left_pad_centered_right_pad",
+        max_length=15,
+        vector_encoding_name="BLOSUM62",
+    )
+    cache_dir = tmp_path / "cache"
+
+    # Uncached.
+    it_uncached = pretrain_data_iterator(
+        str(pretrain_csv),
+        pretrain_allele_encoding,
+        peptides_per_chunk=4,
+    )
+    chunks_uncached = _consume_iterator(it_uncached, n_chunks=2)
+
+    # Cached.
+    it_cached = pretrain_data_iterator(
+        str(pretrain_csv),
+        pretrain_allele_encoding,
+        peptides_per_chunk=4,
+        encoding_cache_dir=str(cache_dir),
+        encoding_params=params,
+    )
+    chunks_cached = _consume_iterator(it_cached, n_chunks=2)
+
+    # Compare chunk by chunk.
+    net = Class1NeuralNetwork(
+        peptide_encoding={
+            "alignment_method": "left_pad_centered_right_pad",
+            "max_length": 15,
+            "vector_encoding_name": "BLOSUM62",
+        },
+    )
+    for (uncached, cached) in zip(chunks_uncached, chunks_cached):
+        _, enc_uncached, aff_uncached = uncached
+        _, enc_cached, aff_cached = cached
+        # Affinities come from the same CSV; must be identical.
+        assert_array_equal(aff_uncached, aff_cached)
+        # Sequences in both paths should be the same repeated-peptide vector.
+        assert list(enc_uncached.sequences) == list(enc_cached.sequences)
+        # And the encoded peptide tensor through the network must match.
+        enc_via_uncached = net.peptides_to_network_input(enc_uncached).astype(
+            numpy.float32
+        )
+        enc_via_cached = net.peptides_to_network_input(enc_cached).astype(
+            numpy.float32
+        )
+        assert_array_equal(enc_via_uncached, enc_via_cached)
+
+
+def test_pretrain_iterator_cache_hit_avoids_reencoding(
+    pretrain_csv, pretrain_allele_encoding, tmp_path
+):
+    """Second iterator constructor with same params hits the warm cache.
+
+    The first constructor builds the cache; the second should not reencode
+    — verified by spying on EncodableSequences to count encode calls.
+    """
+    params = EncodingParams(
+        alignment_method="left_pad_centered_right_pad",
+        max_length=15,
+        vector_encoding_name="BLOSUM62",
+    )
+    cache_dir = tmp_path / "cache"
+
+    # Warm the cache.
+    it_warm = pretrain_data_iterator(
+        str(pretrain_csv),
+        pretrain_allele_encoding,
+        peptides_per_chunk=4,
+        encoding_cache_dir=str(cache_dir),
+        encoding_params=params,
+    )
+    _consume_iterator(it_warm, n_chunks=1)
+
+    calls = []
+    original = EncodableSequences.variable_length_to_fixed_length_vector_encoding
+
+    def spy(self, *a, **kw):
+        calls.append(1)
+        return original(self, *a, **kw)
+
+    EncodableSequences.variable_length_to_fixed_length_vector_encoding = spy
+    try:
+        it_hot = pretrain_data_iterator(
+            str(pretrain_csv),
+            pretrain_allele_encoding,
+            peptides_per_chunk=4,
+            encoding_cache_dir=str(cache_dir),
+            encoding_params=params,
+        )
+        _consume_iterator(it_hot, n_chunks=1)
+    finally:
+        EncodableSequences.variable_length_to_fixed_length_vector_encoding = original
+
+    # Cache hit should skip the full encoding pass. A few calls MAY happen
+    # (dry-run sample, etc.) but substantially fewer than the chunk size.
+    # Concretely: the cache is already built, so get_or_build skips to
+    # _load without re-encoding. Zero calls expected.
+    assert calls == [], (
+        f"cache hit path should not call variable_length_to_fixed_length_"
+        f"vector_encoding; got {len(calls)} calls"
+    )
+
+
+def test_pretrain_iterator_cache_dir_only_needs_encoding_params(
+    pretrain_csv, pretrain_allele_encoding, tmp_path
+):
+    """Passing cache_dir without encoding_params disables caching safely.
+
+    The guard in pretrain_data_iterator requires BOTH; partial config
+    should fall through to the uncached path rather than crash.
+    """
+    it = pretrain_data_iterator(
+        str(pretrain_csv),
+        pretrain_allele_encoding,
+        peptides_per_chunk=4,
+        encoding_cache_dir=str(tmp_path / "cache"),
+        encoding_params=None,  # explicitly none
+    )
+    chunks = _consume_iterator(it, n_chunks=1)
+    # No crash; chunks yielded normally.
+    assert len(chunks) == 1
+
+
+# ---- Subprocess-boundary (pickle) tests ---------------------------------
+#
+# The real training command runs workers via multiprocessing.Pool, which
+# pickles ``GLOBAL_DATA`` (here, ``constant_data``) and ships it to each
+# worker. The design deliberately keeps only the cache_dir string in
+# GLOBAL_DATA — workers re-open the memmap themselves on disk.
+#
+# These tests exercise the pickle boundary WITHOUT the cost of spawning an
+# actual training subprocess: if these pass, the data that crosses the
+# boundary round-trips cleanly, and the downstream worker helper
+# (``_build_train_peptides``) reconstructs the cache correctly.
+#
+# The heavy subprocess tests live in test_train_pan_allele_models_command.py.
+
+
+def test_constant_data_survives_pickle_roundtrip(
+    constant_data_with_cache, hyperparameters, train_data
+):
+    """Pickle/unpickle the constant_data dict and verify the cache still works.
+
+    Simulates exactly what multiprocessing.Pool does: serialize
+    GLOBAL_DATA in the parent, send the bytes to a worker, deserialize
+    there, then call _build_train_peptides with the reconstructed dict.
+    If anything in constant_data fails to pickle (or lies about its
+    post-pickle identity) this catches it — no spawn needed.
+    """
+    all_work_items = [{"hyperparameters": hyperparameters}]
+    args = Mock(
+        use_encoding_cache=True,
+        encoding_cache_dir=constant_data_with_cache["encoding_cache_dir"],
+        out_models_dir=str(Path(constant_data_with_cache["encoding_cache_dir"]).parent),
+    )
+    GLOBAL_DATA.update(constant_data_with_cache)
+    _initialize_encoding_cache(args, all_work_items)
+    constant_data = dict(GLOBAL_DATA)
+
+    # The pickle round-trip: what Pool workers actually receive.
+    roundtripped = pickle.loads(pickle.dumps(constant_data))
+    assert roundtripped["encoding_cache_dir"] == constant_data["encoding_cache_dir"]
+
+    # Call the worker helper with the unpickled dict — should work.
+    peptides = train_data.peptide.values
+    got = _build_train_peptides(peptides, hyperparameters, roundtripped)
+    assert isinstance(got, EncodableSequences)
+    assert len(got.encoding_cache) == 1, (
+        "worker on reconstructed constant_data did not hit the prepopulation path"
+    )
+
+
+def test_global_data_contains_only_small_primitives(
+    constant_data_with_cache, hyperparameters
+):
+    """Sanity: GLOBAL_DATA must not accidentally embed large arrays post-init.
+
+    The design stores the cache_dir (a ~100-byte string) and nothing else
+    that scales with data size — specifically NOT the memmap'd encoded
+    array nor the peptide_to_idx dict. If a future refactor accidentally
+    shoves the memmap into GLOBAL_DATA, the pickle shipped to each worker
+    balloons from ~1KB to ~1GB, silently defeating the whole optimization.
+
+    We check by asserting the pickled size of GLOBAL_DATA is "small"
+    (under 1 MB). This is loose but catches regressions by an order of
+    magnitude.
+    """
+    all_work_items = [{"hyperparameters": hyperparameters}]
+    args = Mock(
+        use_encoding_cache=True,
+        encoding_cache_dir=constant_data_with_cache["encoding_cache_dir"],
+        out_models_dir=str(Path(constant_data_with_cache["encoding_cache_dir"]).parent),
+    )
+    GLOBAL_DATA.update(constant_data_with_cache)
+    _initialize_encoding_cache(args, all_work_items)
+
+    # Exclude train_data from the size check — that DataFrame is legitimately
+    # large and is loaded into workers regardless of cache mode. We only
+    # want to catch cache-introduced bloat.
+    cache_related = {
+        k: v for k, v in GLOBAL_DATA.items() if k.startswith("encoding_cache")
+    }
+    payload_size = len(pickle.dumps(cache_related))
+    assert payload_size < 1_000_000, (
+        f"cache-related GLOBAL_DATA payload is {payload_size} bytes — "
+        f"looks like an ndarray snuck in. Workers should re-open the memmap, "
+        f"not receive a copy of it."
+    )
+
+
+def test_memmap_reopens_cleanly_in_fresh_encoding_cache(
+    constant_data_with_cache, hyperparameters
+):
+    """A fresh EncodingCache instance opens the same on-disk entry as the builder.
+
+    This mimics exactly what a worker does: orchestrator built the cache
+    entry, then a separate process (a worker) constructs a NEW
+    EncodingCache with the same cache_dir + params and calls get_or_build,
+    which must hit the existing entry and return a memmap pointing at the
+    SAME bytes.
+
+    Failure mode this catches: path construction differing by one character
+    between orchestrator and worker (e.g. trailing slash handling, absolute
+    vs relative path resolution).
+    """
+    all_work_items = [{"hyperparameters": hyperparameters}]
+    args = Mock(
+        use_encoding_cache=True,
+        encoding_cache_dir=constant_data_with_cache["encoding_cache_dir"],
+        out_models_dir=str(Path(constant_data_with_cache["encoding_cache_dir"]).parent),
+    )
+    GLOBAL_DATA.update(constant_data_with_cache)
+    _initialize_encoding_cache(args, all_work_items)
+
+    # "Worker" reconstructs from the pickled cache_dir string.
+    cache_dir_str = GLOBAL_DATA["encoding_cache_dir"]
+    worker_cache = EncodingCache(
+        cache_dir=Path(cache_dir_str),
+        params=EncodingParams(**hyperparameters["peptide_encoding"]),
+    )
+
+    # Same unique-peptides list as orchestrator would have built.
+    df = GLOBAL_DATA["train_data"]
+    unique_peptides = _deterministic_unique_peptide_list(df.peptide.values)
+
+    # Should be a cache HIT — the entry exists from orchestrator's build.
+    entry_dir = worker_cache.entry_path(unique_peptides)
+    assert (entry_dir / ".complete").exists(), (
+        f"orchestrator's entry at {entry_dir} not found by worker-reconstructed cache"
+    )
+
+    # And get_or_build should not re-encode.
+    calls = []
+    original = EncodableSequences.variable_length_to_fixed_length_vector_encoding
+
+    def spy(self, *a, **kw):
+        calls.append(1)
+        return original(self, *a, **kw)
+
+    EncodableSequences.variable_length_to_fixed_length_vector_encoding = spy
+    try:
+        encoded, _ = worker_cache.get_or_build(unique_peptides)
+    finally:
+        EncodableSequences.variable_length_to_fixed_length_vector_encoding = original
+    assert calls == [], "worker cache lookup triggered re-encoding"
+    # Encoded mmap points at the orchestrator's file.
+    assert encoded.shape[0] == len(unique_peptides)
+
+
+def test_encoding_cache_dir_string_normalizes_through_pickle(
+    constant_data_with_cache, hyperparameters
+):
+    """String paths in GLOBAL_DATA survive pickle without Path-vs-str confusion.
+
+    A subtle bug class: orchestrator sets ``GLOBAL_DATA["encoding_cache_dir"]
+    = pathlib.Path(...)`` but worker expects a string (or vice versa).
+    Pickle preserves the concrete type, so we verify the stored value is
+    the expected ``str`` type (not a Path) — workers that Path(str) it
+    will then work on either platform.
+    """
+    all_work_items = [{"hyperparameters": hyperparameters}]
+    args = Mock(
+        use_encoding_cache=True,
+        encoding_cache_dir=constant_data_with_cache["encoding_cache_dir"],
+        out_models_dir=str(Path(constant_data_with_cache["encoding_cache_dir"]).parent),
+    )
+    GLOBAL_DATA.update(constant_data_with_cache)
+    _initialize_encoding_cache(args, all_work_items)
+
+    assert isinstance(GLOBAL_DATA["encoding_cache_dir"], str), (
+        "encoding_cache_dir should be stored as str for robust cross-process "
+        "handling; workers wrap it with Path() themselves"
+    )
+
+
+def test_multiple_workers_simulated_concurrent_lookups(
+    constant_data_with_cache, hyperparameters, train_data
+):
+    """Simulate N workers all constructing their own EncodingCache at once.
+
+    Each would get an independent EncodingCache instance on the same
+    on-disk entry. All should hit the warm cache (built by orchestrator)
+    and return memmap views pointing at the same bytes.
+
+    Real Pool workers are threads/processes; here we use loop iterations
+    as a stand-in — the inputs and assertions are the same since the
+    cache logic is stateless beyond the filesystem.
+    """
+    all_work_items = [{"hyperparameters": hyperparameters}]
+    args = Mock(
+        use_encoding_cache=True,
+        encoding_cache_dir=constant_data_with_cache["encoding_cache_dir"],
+        out_models_dir=str(Path(constant_data_with_cache["encoding_cache_dir"]).parent),
+    )
+    GLOBAL_DATA.update(constant_data_with_cache)
+    _initialize_encoding_cache(args, all_work_items)
+    constant_data = dict(GLOBAL_DATA)
+
+    # Every "worker" gets the pickled-and-unpickled constant_data dict
+    # (what Pool.apply_async would deliver).
+    worker_views = []
+    for _ in range(4):
+        worker_dict = pickle.loads(pickle.dumps(constant_data))
+        es = _build_train_peptides(
+            train_data.peptide.values, hyperparameters, worker_dict
+        )
+        # Retrieve the prepopulated encoded array from the EncodableSequences.
+        params = EncodingParams(**hyperparameters["peptide_encoding"])
+        from mhcflurry.encoding_cache import _vector_encoding_cache_key
+        cache_key = _vector_encoding_cache_key(params)
+        worker_views.append(es.encoding_cache[cache_key])
+
+    # All workers should see byte-identical encoded arrays.
+    reference = worker_views[0]
+    for i, view in enumerate(worker_views[1:], start=1):
+        assert_array_equal(
+            numpy.asarray(view),
+            numpy.asarray(reference),
+            err_msg=f"worker {i} got different bytes than worker 0",
+        )
+
+
+def test_worker_fails_loudly_on_stale_cache_dir(
+    constant_data_no_cache, hyperparameters, train_data, tmp_path
+):
+    """If a worker is handed a cache_dir that doesn't exist, it rebuilds.
+
+    Concretely: orchestrator crashed and left a stale cache_dir reference
+    in GLOBAL_DATA pointing at a now-deleted directory. Worker's call
+    to ``_build_train_peptides`` should still succeed (cache miss → build).
+
+    This isn't the common case but tests fault tolerance at the subprocess
+    boundary where transient state can get weird.
+    """
+    bogus_cache_dir = tmp_path / "does-not-exist-yet"
+    assert not bogus_cache_dir.exists()
+    constant_data = {
+        "train_data": train_data,
+        "encoding_cache_dir": str(bogus_cache_dir),
+    }
+    got = _build_train_peptides(
+        train_data.peptide.values, hyperparameters, constant_data
+    )
+    # Should have worked — cache was built from scratch on access.
+    assert isinstance(got, EncodableSequences)
+    assert len(got.encoding_cache) == 1
+    assert bogus_cache_dir.exists(), (
+        "cache_dir should have been created on-demand"
+    )
+
+
+# ---- Stashed unique_peptides in GLOBAL_DATA -----------------------------
+
+
+def test_initialize_stashes_unique_peptides_in_global_data(
+    constant_data_with_cache, hyperparameters
+):
+    """Orchestrator stashes unique peptide list so workers skip recomputation."""
+    all_work_items = [{"hyperparameters": hyperparameters}]
+    args = Mock(
+        use_encoding_cache=True,
+        encoding_cache_dir=constant_data_with_cache["encoding_cache_dir"],
+        out_models_dir=str(Path(constant_data_with_cache["encoding_cache_dir"]).parent),
+    )
+    GLOBAL_DATA.update(constant_data_with_cache)
+    _initialize_encoding_cache(args, all_work_items)
+
+    assert "encoding_cache_unique_peptides" in GLOBAL_DATA
+    stashed = GLOBAL_DATA["encoding_cache_unique_peptides"]
+    assert isinstance(stashed, list)
+    # Should equal what _deterministic_unique_peptide_list returns.
+    df = GLOBAL_DATA["train_data"]
+    expected = _deterministic_unique_peptide_list(df.peptide.values)
+    assert stashed == expected
+
+
+def test_build_train_peptides_uses_stashed_unique_peptides(
+    constant_data_with_cache, hyperparameters, train_data, monkeypatch
+):
+    """Worker uses stashed peptide list instead of recomputing from train_data."""
+    all_work_items = [{"hyperparameters": hyperparameters}]
+    args = Mock(
+        use_encoding_cache=True,
+        encoding_cache_dir=constant_data_with_cache["encoding_cache_dir"],
+        out_models_dir=str(Path(constant_data_with_cache["encoding_cache_dir"]).parent),
+    )
+    GLOBAL_DATA.update(constant_data_with_cache)
+    _initialize_encoding_cache(args, all_work_items)
+    constant_data = dict(GLOBAL_DATA)
+
+    # Spy on _deterministic_unique_peptide_list to verify it's NOT called.
+    from mhcflurry import train_pan_allele_models_command as cmd
+    calls = []
+    original = cmd._deterministic_unique_peptide_list
+
+    def spy(*a, **kw):
+        calls.append(1)
+        return original(*a, **kw)
+
+    monkeypatch.setattr(cmd, "_deterministic_unique_peptide_list", spy)
+
+    # Call from "worker" side with the pickled constant_data.
+    worker_dict = pickle.loads(pickle.dumps(constant_data))
+    _build_train_peptides(
+        train_data.peptide.values, hyperparameters, worker_dict
+    )
+    assert calls == [], (
+        "worker should reuse stashed unique peptides instead of recomputing"
+    )
+
+
+def test_build_train_peptides_fallback_when_stash_absent(
+    constant_data_no_cache, hyperparameters, train_data, tmp_path, monkeypatch
+):
+    """Backward-compat: works even without the stashed peptide list.
+
+    Older GLOBAL_DATA pickles (pre-fix) or manually-constructed test dicts
+    won't have encoding_cache_unique_peptides. The worker must fall back
+    to recomputing from train_data in that case.
+    """
+    from mhcflurry import train_pan_allele_models_command as cmd
+
+    # Simulate an "old" constant_data: has cache_dir, no stashed peptides.
+    cache_dir = tmp_path / "cache"
+    constant_data = {
+        "train_data": train_data,
+        "encoding_cache_dir": str(cache_dir),
+    }
+    calls = []
+    original = cmd._deterministic_unique_peptide_list
+
+    def spy(*a, **kw):
+        calls.append(1)
+        return original(*a, **kw)
+
+    monkeypatch.setattr(cmd, "_deterministic_unique_peptide_list", spy)
+
+    got = _build_train_peptides(
+        train_data.peptide.values, hyperparameters, constant_data
+    )
+    assert isinstance(got, EncodableSequences)
+    assert len(got.encoding_cache) == 1
+    assert len(calls) == 1, (
+        f"expected exactly 1 fallback call to _deterministic_unique_peptide_list, "
+        f"got {len(calls)}"
+    )
+
+
+def test_stashed_peptides_match_cache_key_peptides(
+    constant_data_with_cache, hyperparameters
+):
+    """The stashed list must be what the cache was built against.
+
+    Workers use the stashed list as-is. If orchestrator's stash ≠
+    orchestrator's cache-build peptide list, worker hits a different
+    cache entry than the one that was actually built → cache miss +
+    silent rebuild of the full encoding pass.
+
+    Belt-and-suspenders regression check.
+    """
+    all_work_items = [{"hyperparameters": hyperparameters}]
+    args = Mock(
+        use_encoding_cache=True,
+        encoding_cache_dir=constant_data_with_cache["encoding_cache_dir"],
+        out_models_dir=str(Path(constant_data_with_cache["encoding_cache_dir"]).parent),
+    )
+    GLOBAL_DATA.update(constant_data_with_cache)
+    _initialize_encoding_cache(args, all_work_items)
+
+    stashed = GLOBAL_DATA["encoding_cache_unique_peptides"]
+    # Reconstruct the same cache the orchestrator built and check that
+    # the stashed list resolves to a complete cache entry.
+    params = EncodingParams(**hyperparameters["peptide_encoding"])
+    cache = EncodingCache(
+        cache_dir=GLOBAL_DATA["encoding_cache_dir"], params=params
+    )
+    assert cache.is_complete_for(stashed), (
+        "stashed peptide list doesn't resolve to a complete cache entry; "
+        "workers using the stash will miss the orchestrator's build"
+    )
+
+
+# ---- pretrain cache: clear KeyError on stale cache ----------------------
+#
+# The stale-cache scenario is narrow: it fires when the CSV content drifts
+# from the peptide list the cache was built against (e.g., race condition
+# where the pretrain file is edited mid-run). In normal flow the iterator
+# builds its own cache entry keyed on the file's current peptides, so no
+# natural test path exists — we patch in a mismatched peptide_to_idx dict
+# to simulate the failure surface directly.
+
+
+def test_pretrain_iterator_raises_clear_keyerror_on_missing_peptide(
+    pretrain_csv, pretrain_allele_encoding, tmp_path, monkeypatch
+):
+    """A missing peptide in the cached lookup raises our helpful KeyError.
+
+    We patch EncodingCache.get_or_build to return a peptide_to_idx dict
+    that's missing one of the peptides that will appear in the CSV chunk.
+    Exercises the error-raising branch in pretrain_data_iterator directly.
+    """
+    import numpy as np
+    from mhcflurry.encoding_cache import EncodingCache as _EC
+
+    params = EncodingParams(
+        alignment_method="left_pad_centered_right_pad",
+        max_length=15,
+        vector_encoding_name="BLOSUM62",
+    )
+    cache_dir = tmp_path / "mycache"
+    cache_dir.mkdir()
+
+    # Fake encoded array + deliberately incomplete peptide_to_idx. Shape
+    # doesn't matter for this test because we never reach indexing.
+    fake_encoded = np.zeros((10, 45, 21), dtype=np.float32)
+    fake_peptide_to_idx = {
+        # Intentionally excludes the peptides that are in pretrain_csv.
+        "SOMETHING_NOT_IN_FILE": 0,
+    }
+
+    def mock_get_or_build(self, peptides):
+        return fake_encoded, fake_peptide_to_idx
+
+    monkeypatch.setattr(_EC, "get_or_build", mock_get_or_build)
+
+    it = pretrain_data_iterator(
+        str(pretrain_csv),
+        pretrain_allele_encoding,
+        peptides_per_chunk=4,
+        encoding_cache_dir=str(cache_dir),
+        encoding_params=params,
+    )
+    with pytest.raises(KeyError, match="not in the encoding cache"):
+        next(it)
+
+
+def test_pretrain_iterator_keyerror_message_names_cache_dir(
+    pretrain_csv, pretrain_allele_encoding, tmp_path, monkeypatch
+):
+    """The KeyError message must point the user at the remediation (cache_dir path)."""
+    import numpy as np
+    from mhcflurry.encoding_cache import EncodingCache as _EC
+
+    params = EncodingParams(
+        alignment_method="left_pad_centered_right_pad",
+        max_length=15,
+        vector_encoding_name="BLOSUM62",
+    )
+    cache_dir = tmp_path / "mycache"
+    cache_dir.mkdir()
+
+    def mock_get_or_build(self, peptides):
+        return np.zeros((0, 45, 21), dtype=np.float32), {}
+
+    monkeypatch.setattr(_EC, "get_or_build", mock_get_or_build)
+
+    it = pretrain_data_iterator(
+        str(pretrain_csv),
+        pretrain_allele_encoding,
+        peptides_per_chunk=8,
+        encoding_cache_dir=str(cache_dir),
+        encoding_params=params,
+    )
+    with pytest.raises(KeyError) as exc_info:
+        next(it)
+    # Message must mention the cache dir path so the user knows what to delete.
+    assert "mycache" in str(exc_info.value)
+    assert "different pretrain CSV" in str(exc_info.value)

--- a/test/test_train_pan_allele_encoding_cache.py
+++ b/test/test_train_pan_allele_encoding_cache.py
@@ -915,6 +915,122 @@ def test_build_train_peptides_fallback_when_stash_absent(
     )
 
 
+def test_initialize_encoding_cache_prebuilds_pretrain_cache(
+    constant_data_with_cache, hyperparameters, pretrain_csv
+):
+    """Orchestrator pre-builds the pretrain cache too, not just the train cache.
+
+    Before this, each Pool worker on its first ``pretrain_data_iterator``
+    call would race to build the pretrain cache. The Phase 1 race fix
+    made that safe, but every worker still paid the redundant encoding
+    cost. Pre-building here means workers hit a warm cache on first
+    access.
+    """
+    all_work_items = [{"hyperparameters": hyperparameters}]
+    args = Mock(
+        use_encoding_cache=True,
+        encoding_cache_dir=constant_data_with_cache["encoding_cache_dir"],
+        out_models_dir=str(Path(constant_data_with_cache["encoding_cache_dir"]).parent),
+        pretrain_data=str(pretrain_csv),
+    )
+    GLOBAL_DATA.update(constant_data_with_cache)
+    _initialize_encoding_cache(args, all_work_items)
+
+    # The pretrain cache entry must be complete after orchestrator init.
+    from mhcflurry.encoding_cache import EncodingParams
+    params = EncodingParams(**hyperparameters["peptide_encoding"])
+    cache = EncodingCache(
+        cache_dir=constant_data_with_cache["encoding_cache_dir"], params=params
+    )
+    pretrain_peptides = _read_pretrain_peptide_list(str(pretrain_csv))
+    assert cache.is_complete_for(pretrain_peptides), (
+        "pretrain cache should have been pre-built by the orchestrator"
+    )
+
+
+def test_initialize_encoding_cache_pretrain_skipped_when_no_pretrain_data(
+    constant_data_with_cache, hyperparameters
+):
+    """With pretrain_data=None the orchestrator skips pretrain pre-build silently.
+
+    Some training configs don't have pretraining; the orchestrator
+    should degrade cleanly (only build the train cache, don't crash).
+    """
+    all_work_items = [{"hyperparameters": hyperparameters}]
+    args = Mock(
+        use_encoding_cache=True,
+        encoding_cache_dir=constant_data_with_cache["encoding_cache_dir"],
+        out_models_dir=str(Path(constant_data_with_cache["encoding_cache_dir"]).parent),
+        pretrain_data=None,
+    )
+    GLOBAL_DATA.update(constant_data_with_cache)
+    # Should NOT raise.
+    _initialize_encoding_cache(args, all_work_items)
+    # Train cache must still be built.
+    assert "encoding_cache_dir" in GLOBAL_DATA
+
+
+def test_pretrain_iterator_hits_orchestrator_prebuilt_cache(
+    constant_data_with_cache, hyperparameters, pretrain_csv,
+    pretrain_allele_encoding,
+):
+    """Worker's first pretrain_data_iterator call should find a warm cache.
+
+    Spy on EncodableSequences.variable_length_to_fixed_length_vector_encoding
+    to verify the worker doesn't re-encode anything — the orchestrator's
+    pre-build already covered the pretrain peptides.
+    """
+    all_work_items = [{"hyperparameters": hyperparameters}]
+    args = Mock(
+        use_encoding_cache=True,
+        encoding_cache_dir=constant_data_with_cache["encoding_cache_dir"],
+        out_models_dir=str(Path(constant_data_with_cache["encoding_cache_dir"]).parent),
+        pretrain_data=str(pretrain_csv),
+    )
+    GLOBAL_DATA.update(constant_data_with_cache)
+    _initialize_encoding_cache(args, all_work_items)
+
+    from mhcflurry.encoding_cache import (
+        EncodingParams,
+        _verify_cache_key_shape,
+    )
+    params = EncodingParams(**hyperparameters["peptide_encoding"])
+
+    # Prime the module-level cache-key-shape self-test so it doesn't
+    # show up as encode calls under the spy. In production this runs
+    # once per process regardless.
+    _verify_cache_key_shape()
+
+    # Now call pretrain_data_iterator as a worker would — no encoding
+    # should happen since the orchestrator pre-built the cache.
+    calls = []
+    original = EncodableSequences.variable_length_to_fixed_length_vector_encoding
+
+    def spy(self, *a, **kw):
+        calls.append(1)
+        return original(self, *a, **kw)
+
+    EncodableSequences.variable_length_to_fixed_length_vector_encoding = spy
+    try:
+        it = pretrain_data_iterator(
+            str(pretrain_csv),
+            pretrain_allele_encoding,
+            peptides_per_chunk=4,
+            encoding_cache_dir=str(constant_data_with_cache["encoding_cache_dir"]),
+            encoding_params=params,
+        )
+        _consume_iterator(it, n_chunks=1)
+    finally:
+        EncodableSequences.variable_length_to_fixed_length_vector_encoding = original
+
+    # Zero encode calls: the cache is warm from orchestrator pre-build.
+    assert calls == [], (
+        f"worker re-encoded {len(calls)} peptide chunks despite orchestrator "
+        f"pre-build. Either pretrain pre-build isn't running, or the worker "
+        f"is using a different cache path than the orchestrator."
+    )
+
+
 def test_stashed_peptides_match_cache_key_peptides(
     constant_data_with_cache, hyperparameters
 ):

--- a/test/test_train_pan_allele_encoding_cache.py
+++ b/test/test_train_pan_allele_encoding_cache.py
@@ -159,6 +159,7 @@ def test_build_train_peptides_cache_enabled_returns_prepopulated(
         use_encoding_cache=True,
         encoding_cache_dir=constant_data_with_cache["encoding_cache_dir"],
         out_models_dir=str(Path(constant_data_with_cache["encoding_cache_dir"]).parent),
+        pretrain_data=None,
     )
     GLOBAL_DATA.update(constant_data_with_cache)
     _initialize_encoding_cache(args, all_work_items)
@@ -187,6 +188,7 @@ def test_build_train_peptides_bit_identical_across_modes(
         use_encoding_cache=True,
         encoding_cache_dir=constant_data_with_cache["encoding_cache_dir"],
         out_models_dir=str(Path(constant_data_with_cache["encoding_cache_dir"]).parent),
+        pretrain_data=None,
     )
     GLOBAL_DATA.update(constant_data_with_cache)
     _initialize_encoding_cache(args, all_work_items)
@@ -227,6 +229,7 @@ def test_build_train_peptides_preserves_fold_order(
         use_encoding_cache=True,
         encoding_cache_dir=constant_data_with_cache["encoding_cache_dir"],
         out_models_dir=str(Path(constant_data_with_cache["encoding_cache_dir"]).parent),
+        pretrain_data=None,
     )
     GLOBAL_DATA.update(constant_data_with_cache)
     _initialize_encoding_cache(args, all_work_items)
@@ -275,6 +278,7 @@ def test_build_train_peptides_different_archs_different_configs(
         use_encoding_cache=True,
         encoding_cache_dir=constant_data_with_cache["encoding_cache_dir"],
         out_models_dir=str(Path(constant_data_with_cache["encoding_cache_dir"]).parent),
+        pretrain_data=None,
     )
     GLOBAL_DATA.update(constant_data_with_cache)
     _initialize_encoding_cache(args, all_work_items)
@@ -302,6 +306,7 @@ def test_initialize_encoding_cache_is_idempotent(
         use_encoding_cache=True,
         encoding_cache_dir=constant_data_with_cache["encoding_cache_dir"],
         out_models_dir=str(Path(constant_data_with_cache["encoding_cache_dir"]).parent),
+        pretrain_data=None,
     )
     GLOBAL_DATA.update(constant_data_with_cache)
 
@@ -601,6 +606,7 @@ def test_constant_data_survives_pickle_roundtrip(
         use_encoding_cache=True,
         encoding_cache_dir=constant_data_with_cache["encoding_cache_dir"],
         out_models_dir=str(Path(constant_data_with_cache["encoding_cache_dir"]).parent),
+        pretrain_data=None,
     )
     GLOBAL_DATA.update(constant_data_with_cache)
     _initialize_encoding_cache(args, all_work_items)
@@ -639,6 +645,7 @@ def test_global_data_contains_only_small_primitives(
         use_encoding_cache=True,
         encoding_cache_dir=constant_data_with_cache["encoding_cache_dir"],
         out_models_dir=str(Path(constant_data_with_cache["encoding_cache_dir"]).parent),
+        pretrain_data=None,
     )
     GLOBAL_DATA.update(constant_data_with_cache)
     _initialize_encoding_cache(args, all_work_items)
@@ -677,6 +684,7 @@ def test_memmap_reopens_cleanly_in_fresh_encoding_cache(
         use_encoding_cache=True,
         encoding_cache_dir=constant_data_with_cache["encoding_cache_dir"],
         out_models_dir=str(Path(constant_data_with_cache["encoding_cache_dir"]).parent),
+        pretrain_data=None,
     )
     GLOBAL_DATA.update(constant_data_with_cache)
     _initialize_encoding_cache(args, all_work_items)
@@ -732,6 +740,7 @@ def test_encoding_cache_dir_string_normalizes_through_pickle(
         use_encoding_cache=True,
         encoding_cache_dir=constant_data_with_cache["encoding_cache_dir"],
         out_models_dir=str(Path(constant_data_with_cache["encoding_cache_dir"]).parent),
+        pretrain_data=None,
     )
     GLOBAL_DATA.update(constant_data_with_cache)
     _initialize_encoding_cache(args, all_work_items)
@@ -760,6 +769,7 @@ def test_multiple_workers_simulated_concurrent_lookups(
         use_encoding_cache=True,
         encoding_cache_dir=constant_data_with_cache["encoding_cache_dir"],
         out_models_dir=str(Path(constant_data_with_cache["encoding_cache_dir"]).parent),
+        pretrain_data=None,
     )
     GLOBAL_DATA.update(constant_data_with_cache)
     _initialize_encoding_cache(args, all_work_items)
@@ -830,6 +840,7 @@ def test_initialize_stashes_unique_peptides_in_global_data(
         use_encoding_cache=True,
         encoding_cache_dir=constant_data_with_cache["encoding_cache_dir"],
         out_models_dir=str(Path(constant_data_with_cache["encoding_cache_dir"]).parent),
+        pretrain_data=None,
     )
     GLOBAL_DATA.update(constant_data_with_cache)
     _initialize_encoding_cache(args, all_work_items)
@@ -852,6 +863,7 @@ def test_build_train_peptides_uses_stashed_unique_peptides(
         use_encoding_cache=True,
         encoding_cache_dir=constant_data_with_cache["encoding_cache_dir"],
         out_models_dir=str(Path(constant_data_with_cache["encoding_cache_dir"]).parent),
+        pretrain_data=None,
     )
     GLOBAL_DATA.update(constant_data_with_cache)
     _initialize_encoding_cache(args, all_work_items)
@@ -1048,6 +1060,7 @@ def test_stashed_peptides_match_cache_key_peptides(
         use_encoding_cache=True,
         encoding_cache_dir=constant_data_with_cache["encoding_cache_dir"],
         out_models_dir=str(Path(constant_data_with_cache["encoding_cache_dir"]).parent),
+        pretrain_data=None,
     )
     GLOBAL_DATA.update(constant_data_with_cache)
     _initialize_encoding_cache(args, all_work_items)

--- a/test/test_train_pan_allele_models_command.py
+++ b/test/test_train_pan_allele_models_command.py
@@ -210,6 +210,232 @@ def test_run_cluster_parallelism():
     ])
 
 
+# ---- Encoding-cache subprocess-boundary tests -----------------------------
+#
+# These exercise the multiprocessing.Pool worker boundary with
+# --use-encoding-cache enabled. The cache plumbing crosses a pickle/
+# unpickle of GLOBAL_DATA (so workers get a cache_dir string and the
+# stashed unique-peptide list), and each worker then constructs a fresh
+# EncodingCache and opens the orchestrator-built memmap.
+#
+# Anything that breaks that flow — e.g., a ndarray accidentally shoved
+# into GLOBAL_DATA, a path normalization mismatch between parent and
+# child, a missing re-import on the worker side — shows up here and not
+# in the in-process tests in test_train_pan_allele_encoding_cache.py.
+
+
+def _run_with_cache_and_check(
+    n_jobs,
+    cache_dir=None,
+    extra_args=None,
+    expect_cache_populated=True,
+):
+    """Parameterized variant of run_and_check that exercises the cache path.
+
+    Returns (models_dir, cache_dir_used) so the caller can assert on
+    on-disk state post-run.
+    """
+    models_dir = tempfile.mkdtemp(prefix="mhcflurry-test-models-cached")
+    cache_dir_used = cache_dir if cache_dir is not None else os.path.join(
+        models_dir, "encoding_cache"
+    )
+
+    hyperparameters_filename = os.path.join(models_dir, "hyperparameters.yaml")
+    with open(hyperparameters_filename, "w") as fd:
+        json.dump(HYPERPARAMETERS_LIST, fd)
+
+    pretrain_data_filename = os.path.join(models_dir, "pretrain_data.csv")
+    with open(pretrain_data_filename, "w") as fd:
+        fd.write(PRETRAIN_DATA)
+        fd.write("\n")
+
+    data_df = pandas.read_csv(
+        get_path("data_curated", "curated_training_data.affinity.csv.bz2")
+    )
+    selected_data_df = data_df.sample(frac=0.1)
+    selected_data_df.to_csv(
+        os.path.join(models_dir, "_train_data.csv"), index=False
+    )
+
+    args = mhcflurry_cli("mhcflurry-class1-train-pan-allele-models") + [
+        "--data", os.path.join(models_dir, "_train_data.csv"),
+        "--allele-sequences", get_path("allele_sequences", "allele_sequences.csv"),
+        "--pretrain-data", pretrain_data_filename,
+        "--hyperparameters", hyperparameters_filename,
+        "--out-models-dir", models_dir,
+        "--num-jobs", str(n_jobs),
+        "--num-folds", "2",
+        "--verbosity", "1",
+        "--use-encoding-cache",
+        "--encoding-cache-dir", cache_dir_used,
+    ] + (extra_args or [])
+    print("Running with args: %s" % args)
+    subprocess.check_call(args)
+
+    # Model-selection step — same as run_and_check, verifies the predictor
+    # trained under the cache path loads and predicts sensibly.
+    models_dir_selected = tempfile.mkdtemp(
+        prefix="mhcflurry-test-models-cached-selected"
+    )
+    args_select = mhcflurry_cli("mhcflurry-class1-select-pan-allele-models") + [
+        "--data", os.path.join(models_dir, "train_data.csv.bz2"),
+        "--models-dir", models_dir,
+        "--out-models-dir", models_dir_selected,
+        "--max-models", "1",
+        "--num-jobs", str(n_jobs),
+    ]
+    subprocess.check_call(args_select)
+
+    predictor = Class1AffinityPredictor.load(
+        models_dir_selected, optimization_level=0
+    )
+    assert len(predictor.neural_networks) == 2
+    predictions = predictor.predict(
+        peptides=["SLYNTVATL"], alleles=["HLA-A*02:01"]
+    )
+    assert predictions.shape == (1,)
+    assert_array_less(predictions, 2000)
+
+    # The cache path actually materialized on disk.
+    if expect_cache_populated:
+        assert os.path.isdir(cache_dir_used), (
+            f"expected cache dir at {cache_dir_used}, not found"
+        )
+        # At least one complete entry.
+        entries = [
+            e for e in os.listdir(cache_dir_used)
+            if os.path.isdir(os.path.join(cache_dir_used, e))
+        ]
+        assert entries, f"cache dir {cache_dir_used} is empty"
+        completes = [
+            e for e in entries
+            if os.path.exists(
+                os.path.join(cache_dir_used, e, ".complete")
+            )
+        ]
+        assert completes, (
+            f"no completed cache entry in {cache_dir_used}; "
+            f"workers likely failed to build/open the memmap"
+        )
+
+    shutil.rmtree(models_dir)
+    shutil.rmtree(models_dir_selected)
+    return cache_dir_used
+
+
+def test_run_parallel_with_encoding_cache():
+    """Cache path completes end-to-end under multiprocessing.Pool (n_jobs=2).
+
+    This is THE subprocess-boundary gate: GLOBAL_DATA is pickled from the
+    orchestrator, shipped to 2 worker processes, and each worker opens
+    the on-disk memmap and runs training. If this passes, the pickle/
+    unpickle of the cache metadata round-trips cleanly and workers
+    successfully hit the shared encoding.
+
+    Prediction assertion matches test_run_parallel — the trained model
+    should place the known binder SLYNTVATL / HLA-A*02:01 under 2000 nM.
+    """
+    _run_with_cache_and_check(n_jobs=2)
+
+
+def test_run_serial_with_encoding_cache():
+    """Cache path in-process (n_jobs=0).
+
+    Unit tests already cover the in-process helper functions. This test
+    ensures the CLI-level path also works serially — regression guard
+    against accidentally coupling cache usage to the multiprocessing
+    codepath.
+    """
+    _run_with_cache_and_check(n_jobs=0)
+
+
+def test_run_parallel_encoding_cache_warm_reuse():
+    """Second training run with the same --encoding-cache-dir hits the warm cache.
+
+    Exercises the cache-hit code path across subprocess invocations:
+    first run builds the cache on disk, second run with the same dir
+    should find the .complete sentinel and skip the encoding pass.
+
+    We don't time this (too flaky in CI), but we verify that (a) both
+    runs succeed, (b) the cache dir from the first run is still
+    .complete after the second run (i.e., nothing got clobbered).
+    """
+    shared_cache_dir = tempfile.mkdtemp(prefix="mhcflurry-shared-cache")
+    try:
+        _run_with_cache_and_check(n_jobs=2, cache_dir=shared_cache_dir)
+        # First run built the cache; capture mtimes to verify they don't
+        # change on the second (warm) run.
+        entries_after_first = sorted(os.listdir(shared_cache_dir))
+        complete_mtimes_first = {
+            e: os.path.getmtime(
+                os.path.join(shared_cache_dir, e, ".complete")
+            )
+            for e in entries_after_first
+            if os.path.isdir(os.path.join(shared_cache_dir, e))
+        }
+
+        _run_with_cache_and_check(n_jobs=2, cache_dir=shared_cache_dir)
+
+        # Second run should not have rewritten .complete (cache hit path).
+        for e, mtime_first in complete_mtimes_first.items():
+            sentinel_path = os.path.join(shared_cache_dir, e, ".complete")
+            mtime_second = os.path.getmtime(sentinel_path)
+            assert mtime_second == mtime_first, (
+                f"{sentinel_path} was rewritten between runs "
+                f"({mtime_first} -> {mtime_second}) — the warm-cache path "
+                f"did not kick in, workers rebuilt from scratch"
+            )
+    finally:
+        shutil.rmtree(shared_cache_dir, ignore_errors=True)
+
+
+def test_run_parallel_no_encoding_cache_leaves_no_cache_dir():
+    """Without --use-encoding-cache, no encoding_cache subdir is created.
+
+    Regression guard: the feature is truly opt-in. Nothing about cache
+    initialization should run by default, and in particular no directory
+    should be created speculatively.
+    """
+    models_dir = tempfile.mkdtemp(prefix="mhcflurry-no-cache")
+    try:
+        hyperparameters_filename = os.path.join(models_dir, "hyperparameters.yaml")
+        with open(hyperparameters_filename, "w") as fd:
+            json.dump(HYPERPARAMETERS_LIST, fd)
+
+        pretrain_data_filename = os.path.join(models_dir, "pretrain_data.csv")
+        with open(pretrain_data_filename, "w") as fd:
+            fd.write(PRETRAIN_DATA)
+            fd.write("\n")
+
+        data_df = pandas.read_csv(
+            get_path("data_curated", "curated_training_data.affinity.csv.bz2")
+        )
+        data_df.sample(frac=0.1).to_csv(
+            os.path.join(models_dir, "_train_data.csv"), index=False
+        )
+
+        args = mhcflurry_cli("mhcflurry-class1-train-pan-allele-models") + [
+            "--data", os.path.join(models_dir, "_train_data.csv"),
+            "--allele-sequences", get_path("allele_sequences", "allele_sequences.csv"),
+            "--pretrain-data", pretrain_data_filename,
+            "--hyperparameters", hyperparameters_filename,
+            "--out-models-dir", models_dir,
+            "--num-jobs", "2",
+            "--num-folds", "2",
+            "--verbosity", "1",
+            # Deliberately NO --use-encoding-cache.
+        ]
+        subprocess.check_call(args)
+
+        unexpected_cache = os.path.join(models_dir, "encoding_cache")
+        assert not os.path.exists(unexpected_cache), (
+            f"encoding_cache directory created at {unexpected_cache} despite "
+            f"--use-encoding-cache not being set"
+        )
+    finally:
+        shutil.rmtree(models_dir, ignore_errors=True)
+
+
 if __name__ == "__main__":
     # run_and_check(n_jobs=0, delete=False)
     test_run_cluster_parallelism()


### PR DESCRIPTION
## What this PR does

Implements issue #268 (CPU-bound pan-allele training) in two phases. All changes are **semantics-preserving** — verified bit-identical on CPU by end-to-end integration tests and against the public mhcflurry 2.2.0 release on a 15-model partial A100 training run.

Draft because:
- The training validation was on a **partial** 15-of-32 model run (killed mid-run for iteration). A full 32-model run on 8×A100 is the remaining empirical validation step.
- The daemon-downgrade in `_effective_num_workers` is now vestigial after the NonDaemonPool fix (Phase 2). Minor simplification pass pending.
- Phase 3 inference-side plumbing (exposing `encoding_cache_dir=` on `Class1AffinityPredictor.predict`) is scoped but not in this PR.

## Summary of changes

### Phase 1 — core encoding cache + DataLoader wrap

| Commit | File(s) | What |
|---|---|---|
| `c40c4bf` | `mhcflurry/encoding_cache.py` (new) | Memmap-backed BLOSUM62 encoding cache with atomic-build `.complete` sentinel; `EncodingParams` dataclass, `EncodingCache.get_or_build / is_complete_for`, `make_preencoded_encodable_sequences` helper, runtime self-test (`EncodingCacheKeyMismatchError`) that converts upstream cache-key drift from a silent perf regression into a loud error at first use |
| `67035a0` | `train_pan_allele_models_command.py` | `--use-encoding-cache` / `--encoding-cache-dir` CLI flags (default off — bit-identical). Orchestrator pre-builds one cache entry per distinct `peptide_encoding` config across the sweep; stashes `cache_dir` + orchestrator-computed unique-peptide list in `GLOBAL_DATA`. Workers' `_build_train_peptides` + `pretrain_data_iterator` return `EncodableSequences` with prepopulated `encoding_cache`. Clear `KeyError` with cache-dir in message on stale pretrain cache |
| `321e4ab` | `class1_neural_network.py` | Wrap `fit()`'s inner batch loop in `torch.utils.data.DataLoader` (default `num_workers=0` = bit-identical pure refactor; `num_workers>0` adds spawn-context prefetch workers + pinned memory). On-device validation tensor caching when `val_indices` lies entirely in the static training portion of the concatenated `[random_negs, training]` arrays. `dataloader_persistent_workers` hyperparameter threaded through for forward-compat |
| `9132354` | `test_train_pan_allele_models_command.py` | 4 heavy subprocess-boundary tests that spawn the actual `mhcflurry-class1-train-pan-allele-models` CLI under `multiprocessing.Pool` with `--use-encoding-cache`, exercising the pickle/unpickle of `GLOBAL_DATA` across the worker boundary |

### Phase 1 — fixes caught on live A100

| Commit | File(s) | Bug |
|---|---|---|
| `2bff27c` | `class1_neural_network.py` + test | `DataLoader(num_workers>0)` crashed every training run with `AssertionError: daemonic processes are not allowed to have children`. Phase 1 tests ran in the main process so never hit this. Added `_effective_num_workers` runtime downgrade + regression test that spawns an actual daemon subprocess |
| `d02289c` | `encoding_cache.py` + tests | `EncodingCache._build` raced when two Pool workers simultaneously built the same entry (e.g. pretrain cache). Second worker's `os.replace` failed with `FileNotFoundError` because tmp was consumed by the first. Fixed with per-PID tmp paths + re-check of `is_complete` inside `_build`. Tests use real `multiprocessing.spawn` to reproduce the race |

### Phase 2 — perf follow-ups after A100 measurements

| Commit | File(s) | What |
|---|---|---|
| `c1699e1` | `local_parallelism.py` + test | **Non-daemonic Pool.** Replace `multiprocessing.Pool` with `NonDaemonPool` (subclass with `NonDaemonContext` → `NonDaemonProcess`). Unblocks DataLoader prefetch workers inside Pool worker processes in production. Before this, the Phase 1 `num_workers=4` hyperparameter was silently downgraded to 0 in prod (runtime defense stays as safety net) |
| `f538a9b` | `train_pan_allele_models_command.py` + tests | **Orchestrator pre-builds pretrain cache too.** Previously workers raced to build it on first `pretrain_data_iterator` call; race fix made it safe but each worker paid the redundant encoding pass. Now a single orchestrator-side pre-build; workers hit a warm cache (verified by spy test showing zero encode calls) |
| `a8c6725` | `class1_neural_network.py` + tests | **Hoist `fit_generator` validation tensors** out of the epoch loop. Same trick Phase 1 applied to `fit()`. Semantics preserved (val data is static across pretrain epochs); two tests lock it down (self-reproducibility + `torch.from_numpy` call-count budget) |
| `2ac0ba7` | `pan_allele_presentation_subset.sh` | **nsys PATH fallback** so `NSYS_PROFILE=1` actually runs. pytorch `:devel` image installs nsys at `/usr/local/cuda/bin/nsys` but doesn't put it in PATH |

### Infra / scripts

| Commit | File(s) | What |
|---|---|---|
| `b38ee1e` | `scripts/training/*.sh`, `jobs/*.py` | `MAX_WORKERS_PER_GPU=2` default (A100-80GB safe ceiling per worker GPU memory profile), `MKL/OPENBLAS_NUM_THREADS=1` alongside `OMP_NUM_THREADS=1`, runplz floor bumped to 3.2.0, presentation-subset pinned to massedcompute 1×A100-80GB (org $30/hr cap blocked 8×A100), devel image for nsys |
| `dfe053e`, `8969ab3` | `scripts/training/pan_allele_*.sh` | Shell scripts pass `--use-encoding-cache` + inject `dataloader_num_workers=4` into every arch. `USE_ENCODING_CACHE=0` / `DATALOADER_NUM_WORKERS=0` restore pre-#268 legacy path |
| `8969ab3` | `scripts/validate_presentation_with_flanks.py` (new) | 10 well-characterized epitopes incl. SLLQHLIGL with its real PRAME flanks (`GNSISISALQ...SNLTHVLYPV`, position 424) looked up from `data_references/uniprot_proteins.csv.bz2`; 7-allele pool; reports overall Spearman, per-peptide Spearman, canonical-allele rank-1 hit count |

## Test coverage

All 85 local tests pass (was 0 pre-#268, so all new):

| File | Tests | Purpose |
|---|---|---|
| `test_encoding_cache.py` | 34 | Cache unit tests: byte-for-byte encoder equivalence, atomic build, partial-write safety, mmap read-only, concurrent readers, 2× concurrent-build-race tests (multiprocessing.spawn), `is_complete_for` public API, runtime cache-key-shape self-test |
| `test_train_pan_allele_encoding_cache.py` | 29 | Train-command integration: `_build_train_peptides` bit-identical across cached/uncached modes, `_deterministic_unique_peptide_list` stability, pickle round-trip of `GLOBAL_DATA` (subprocess boundary simulation), GLOBAL_DATA payload size guard, pretrain cache pre-build, pretrain KeyError on stale cache |
| `test_encoding_cache_training_integration.py` | 10 | **THE GATE:** end-to-end bit-identical CPU training with `torch.use_deterministic_algorithms(True)` + seeded RNG. Cache on vs off → identical loss trajectory + state_dict; `num_workers=0/2` self-reproducible + match each other; `persistent_workers=True/False` bit-identical; full stack (cache + workers) matches baseline; daemon-subprocess regression test; fit_generator self-reproducible + val-hoist call-count budget |
| `test_local_parallelism.py` | 11 | `NonDaemonProcess.daemon` setter is a no-op; Pool workers report daemon=False; workers can spawn multiprocessing children end-to-end |
| `test_train_pan_allele_models_command.py` (new subprocess tests) | 4 | Heavy CLI-subprocess tests: `mhcflurry-class1-train-pan-allele-models --use-encoding-cache` works under `Pool` (`n_jobs=2` + `n_jobs=0`), warm cache on second run (mtime check), opt-in regression guard (no cache dir when flag absent) |

## Empirical validation — 15/32 partial A100 run

A partial training on 1× A100-80GB (MassedCompute, killed at 15/32 work items after ~6.8 hr for iteration) produced a usable 15-model ensemble with Phase 1 + Phase 1 bug fixes applied (Phase 2 NOT yet in that run — those commits are later).

### Perf numbers

- Encoding cache: **5.9 s for 517K training peptides** (amortized once; orchestrator-side)
- Per work item: ~52 min (pretrain 11 min + finetune 41 min)
- Per batch: 3.7 ms finetune, 7 ms pretrain (A100 theoretical min: 1–2 ms — we're 2–4× slower than GPU-bound)
- GPU util: 33–85% mean ~60% — headroom left for Phase 2 prefetch (not yet exercised)
- Worker RSS: stable at ~30 GB each (2 workers × 30 GB / 80 GB box, safe margin)
- Val loss median across 15 models: 0.0356 (consistent, good convergence)

### Accuracy vs public mhcflurry 2.2.0 (10 well-characterized epitopes × 9-allele pool = 90 pairs)

| Metric | Ours (15 partial, no model-selection) | Public 2.2.0 (140 selected) |
|---|---|---|
| Canonical-allele rank-1 hits | **10/10** | 10/10 |
| **Spearman (affinity)** | **ρ = 0.913** | — |
| **Spearman (presentation)** | **ρ = 0.946** | — |
| Best-allele agreement (random 4-subset) | — | 192/222 (86%) |

SLLQHLIGL (PRAME 424) predictions: ours 23.16 nM, public 15.32 nM — same top allele A*02:01, presentation score 0.99 both.

Artifacts (not in this PR): `out/partial_models/` 15 weight files + manifest, `out/run4_perf/summary.md` + `validation_summary.md` + `runplz-last.log`, `out/validation/preds_*.csv`.

## What Phase 2 changes empirically

The 15-model run ran with Phase 1 + Phase 1 bug fixes but NOT the Phase 2 optimizations. Expected Phase 2 improvements (not yet measured):

- **NonDaemonPool** — unlocks DataLoader `num_workers=4` + pinned memory + non_blocking H2D. Expected 2–3× speedup on the inner batch loop, which is ~70% of per-item time. Net per-item ETA drops from ~52 → ~25–30 min.
- **Pretrain cache pre-built** — saves ~15 min aggregate (across 32 items on 2 parallel workers → ~7 min wall-clock).
- **fit_generator val hoist** — ~10–20% reduction in pretrain phase (11 min → ~9 min per item).

If all Phase 2 wins land as predicted, the 8–12 hr estimate drops to ~5–7 hr for the same 32-item subset.

## Out of scope for this PR

- **Phase 3 inference-side cache**: add `encoding_cache_dir=` param to `Class1AffinityPredictor.predict()`. Small (~20 LOC) follow-up.
- **Daemon-downgrade cleanup**: `_effective_num_workers` is now defensive safety rather than hot path. Could simplify to an assertion with a clearer error message.
- **Larger minibatch_size**: changes convergence, requires validation; not a drop-in perf fix.
- **`torch.compile()`** on the network forward pass.
- **CUDA MPS / streams** to parallelize the 2 Pool workers sharing 1 GPU.
- **Phase 2 validation**: actually run 32/32 work items on 8×A100 with Phase 2 enabled and measure real speedup.

## Issues filed during this work

- runplz [#28] — transient API EOF errors raise fatally instead of retrying
- runplz [#29] — billed box leaks when post-create setup raises
- runplz [#34] — 1200s SSH-ready timeout too tight for 8×A100 cold boots
- runplz [#35] — test suite provisions real billed boxes by default
- runplz [#38] — SIGTERM on orchestrator leaks SSH + Brev instance (`on_finish='delete'` never fires)

## Test plan

- [x] All 85 automated tests pass locally (see coverage table above)
- [x] CPU bit-identical gate: training with cache on vs off produces byte-identical state_dicts
- [x] CPU bit-identical gate: `num_workers=0/2/persistent` all bit-identical
- [x] Daemon-subprocess regression test: confirmed end-to-end against real `multiprocessing.Process(daemon=True)`
- [x] Concurrent-builder regression test: confirmed with real `multiprocessing.spawn` processes
- [x] Live A100 end-to-end: training runs to 15/32 completion with Phase 1 + fixes; validated against public mhcflurry at ρ=0.913/0.946
- [ ] Live A100 end-to-end with Phase 2 fixes (not yet run)
- [ ] 8×A100 32/32 completion + model selection + calibration
- [ ] Full presentation-predictor validation (stage 2 + stage 3)