### PR TITLE
calibrate: skip alleles that fail normalize_allele_name

### DIFF
--- a/mhcflurry/calibrate_percentile_ranks_command.py
+++ b/mhcflurry/calibrate_percentile_ranks_command.py
@@ -106,6 +106,48 @@ parser.add_argument(
     nargs=2,
     help="Min and max peptide length to calibrate, inclusive. "
     "Default: %(default)s")
+def _filter_canonicalizable_alleles(alleles, log_label="alleles"):
+    """Drop alleles that ``normalize_allele_name`` refuses to canonicalize.
+
+    ``predictor.supported_alleles`` (and any user-supplied
+    ``--alleles-file``) can contain pseudogenes / null alleles /
+    questionable annotations — those are real entries in the public
+    ``allele_sequences.csv`` (which aims to be exhaustive), but
+    ``predict_to_dataframe`` raises on them mid-iteration. Filter
+    once up front so calibration doesn't crash partway through, and
+    log the dropped sample so the missing rows in the resulting
+    percent-rank table are explainable.
+
+    A local memo keeps the per-allele ``normalize_allele_name`` cost
+    bounded — the predictor's allele set is ~20K entries and
+    mhcgnomes' parse is millisecond-scale, so without caching this
+    pre-pass alone would add ~20 sec of single-threaded startup.
+    """
+    seen = {}
+
+    def _ok(allele):
+        if allele not in seen:
+            try:
+                normalize_allele_name(allele)
+                seen[allele] = True
+            except (ValueError, TypeError):
+                seen[allele] = False
+        return seen[allele]
+
+    filtered = [a for a in alleles if _ok(a)]
+    dropped = [a for a in alleles if not _ok(a)]
+    if dropped:
+        sample = ", ".join(dropped[:5]) + (
+            ", ..." if len(dropped) > 5 else ""
+        )
+        print(
+            "Skipping %d %s that fail canonicalization "
+            "(pseudogene/null/questionable): %s"
+            % (len(dropped), log_label, sample)
+        )
+    return filtered
+
+
 def _batch_size_arg(value):
     """Accept either an int or the literal string 'auto' for --prediction-batch-size.
 
@@ -224,11 +266,14 @@ def run_class1_presentation_predictor(args, peptides):
     predictor = Class1PresentationPredictor.load(args.models_dir)
 
     if args.allele:
+        # Already canonicalized via normalize_allele_name above.
         alleles = [normalize_allele_name(a) for a in args.allele]
     elif args.alleles_file:
-        alleles = pandas.read_csv(args.alleles_file).allele.unique()
+        alleles = _filter_canonicalizable_alleles(
+            pandas.read_csv(args.alleles_file).allele.unique()
+        )
     else:
-        alleles = predictor.supported_alleles
+        alleles = _filter_canonicalizable_alleles(predictor.supported_alleles)
 
     print("Num alleles", len(alleles))
 
@@ -289,38 +334,15 @@ def run_class1_affinity_predictor(args, peptides):
     )
 
     if args.allele:
+        # Already canonicalized via normalize_allele_name above — pass
+        # through without re-filtering.
         alleles = [normalize_allele_name(a) for a in args.allele]
     elif args.alleles_file:
-        alleles = pandas.read_csv(args.alleles_file).allele.unique()
+        alleles = _filter_canonicalizable_alleles(
+            pandas.read_csv(args.alleles_file).allele.unique()
+        )
     else:
-        alleles = predictor.supported_alleles
-
-    # Drop alleles that mhcgnomes refuses to canonicalize (pseudogenes,
-    # null alleles, questionable annotations). They appear in
-    # ``predictor.supported_alleles`` because allele_sequences.csv
-    # aims to be exhaustive, but ``predict_to_dataframe`` raises when
-    # asked to score them — so calibration would crash partway
-    # through. Filter once up front and log what we dropped so the
-    # missing rows in the percent-rank table are explainable.
-    filtered = []
-    dropped = []
-    for allele in alleles:
-        try:
-            normalize_allele_name(allele)
-        except (ValueError, TypeError):
-            dropped.append(allele)
-            continue
-        filtered.append(allele)
-    if dropped:
-        sample = ", ".join(dropped[:5]) + (
-            ", ..." if len(dropped) > 5 else ""
-        )
-        print(
-            "Skipping %d allele(s) that fail canonicalization "
-            "(pseudogene/null/questionable): %s"
-            % (len(dropped), sample)
-        )
-    alleles = filtered
+        alleles = _filter_canonicalizable_alleles(predictor.supported_alleles)
 
     allele_set = set(alleles)
 

--- a/mhcflurry/calibrate_percentile_ranks_command.py
+++ b/mhcflurry/calibrate_percentile_ranks_command.py
@@ -295,6 +295,33 @@ def run_class1_affinity_predictor(args, peptides):
     else:
         alleles = predictor.supported_alleles
 
+    # Drop alleles that mhcgnomes refuses to canonicalize (pseudogenes,
+    # null alleles, questionable annotations). They appear in
+    # ``predictor.supported_alleles`` because allele_sequences.csv
+    # aims to be exhaustive, but ``predict_to_dataframe`` raises when
+    # asked to score them — so calibration would crash partway
+    # through. Filter once up front and log what we dropped so the
+    # missing rows in the percent-rank table are explainable.
+    filtered = []
+    dropped = []
+    for allele in alleles:
+        try:
+            normalize_allele_name(allele)
+        except (ValueError, TypeError):
+            dropped.append(allele)
+            continue
+        filtered.append(allele)
+    if dropped:
+        sample = ", ".join(dropped[:5]) + (
+            ", ..." if len(dropped) > 5 else ""
+        )
+        print(
+            "Skipping %d allele(s) that fail canonicalization "
+            "(pseudogene/null/questionable): %s"
+            % (len(dropped), sample)
+        )
+    alleles = filtered
+
     allele_set = set(alleles)
 
     if predictor.allele_to_sequence:

--- a/test/test_calibrate_percentile_ranks_command.py
+++ b/test/test_calibrate_percentile_ranks_command.py
@@ -84,6 +84,43 @@ def test_run_cluster_parallelism(delete=True):
     ], delete=delete)
 
 
+def test_filter_canonicalizable_alleles_drops_pseudogene():
+    """Pseudogene / null / questionable annotations are dropped, valid kept."""
+    from mhcflurry.calibrate_percentile_ranks_command import (
+        _filter_canonicalizable_alleles,
+    )
+    raw = [
+        "HLA-A*02:01",
+        "Caja-B5*01:01ps",  # pseudogene — mhcgnomes annotation_pseudogene
+        "HLA-B*07:02",
+    ]
+    kept = _filter_canonicalizable_alleles(raw)
+    assert "Caja-B5*01:01ps" not in kept
+    assert "HLA-A*02:01" in kept
+    assert "HLA-B*07:02" in kept
+
+
+def test_filter_canonicalizable_alleles_passthrough_when_all_valid():
+    from mhcflurry.calibrate_percentile_ranks_command import (
+        _filter_canonicalizable_alleles,
+    )
+    raw = ["HLA-A*02:01", "HLA-B*07:02", "HLA-C*04:01"]
+    kept = _filter_canonicalizable_alleles(raw)
+    assert kept == raw
+
+
+def test_filter_canonicalizable_alleles_memoizes_repeats():
+    """Duplicate alleles in the input each get evaluated once."""
+    from mhcflurry.calibrate_percentile_ranks_command import (
+        _filter_canonicalizable_alleles,
+    )
+    raw = ["HLA-A*02:01"] * 5 + ["Caja-B5*01:01ps"] * 5 + ["HLA-B*07:02"]
+    kept = _filter_canonicalizable_alleles(raw)
+    assert kept.count("HLA-A*02:01") == 5  # all kept
+    assert kept.count("HLA-B*07:02") == 1
+    assert "Caja-B5*01:01ps" not in kept
+
+
 if __name__ == "__main__":
     # run_and_check(n_jobs=0, delete=False)
     # run_and_check(n_jobs=2, delete=False)


### PR DESCRIPTION
## Summary

`mhcflurry-calibrate-percentile-ranks` was crashing partway through
calibration when iterating over `predictor.supported_alleles` if any of
them were pseudogenes / null alleles / questionable annotations
(e.g. `Caja-B5*01:01ps`). Those entries come from the public
`allele_sequences.csv`, which aims to be exhaustive — they aren't in
the training data, but they ARE in the predictor's allele coverage map.

When calibration's per-allele `predict()` loop reached one of these,
`predict_to_dataframe` → `canonicalize_allele_name` →
`normalize_allele_name` would raise `ValueError("Unsupported
annotation on MHC allele: ...")`, killing the whole pool with no partial
result.

## Fix

Filter once up front. Any allele that fails `normalize_allele_name`
gets dropped with a logged sample (`5 alleles + count` truncation) so
the missing rows in the resulting percent-rank table remain
explainable.

## Repro (live)

Hit during the post-training calibration stage of the 2026-04-25
release_exact 8×A100 run, after the merged training perf PR (#273).
Stack tail:

```
File "mhcflurry/class1_affinity_predictor.py", line 1310, in predict_to_dataframe
    normalized_allele = self.canonicalize_allele_name(allele)
File "mhcflurry/common.py", line 79, in normalize_allele_name
    raise ValueError("Unsupported annotation on MHC allele: %s" % raw_name)
ValueError: Unsupported annotation on MHC allele: Caja-B5*01:01ps
```

## Workaround for already-affected runs (no patch)

Pre-filter the alleles externally and pass `--alleles-file
<filtered.csv>`. That bypasses the `supported_alleles` fallback.

## Test plan

- [ ] Re-run calibration on the 2026-04-25 run with this patch (will
      do once the in-flight finalize completes).
- [ ] Future: add a unit test that loads a predictor whose
      `allele_to_sequence` includes a pseudogene allele and verify
      the calibrate command path filters it out.