### PR TITLE
release_exact: unify train+select+calibrate+eval+plot pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,17 @@ jobs:
           python-version: ${{ matrix.python-version }}
           auto-activate-base: false
 
+      - name: Lint shell scripts
+        run: |
+          # Catch syntax regressions in the training-pipeline shell
+          # wrappers cheaply. ``bash -n`` parses without executing.
+          set -e
+          mapfile -t shell_scripts < <(find scripts -type f -name "*.sh")
+          for script in "${shell_scripts[@]}"; do
+              echo "bash -n $script"
+              bash -n "$script"
+          done
+
       - name: Install python dependencies
         run: |
           pip install --upgrade pip

--- a/scripts/training/compare_new_vs_public.py
+++ b/scripts/training/compare_new_vs_public.py
@@ -1,0 +1,200 @@
+"""Compare the new pan-allele training run against the public 2.2.0 release
+on the data_evaluation mass-spec train-excluded benchmark.
+
+This benchmark provides hit/decoy peptide sets per HLA allele. We score
+peptides with both ensembles and report how well each ranks hits above
+decoys. Lower predicted nM = stronger binder, so we negate the affinity
+for AUC/AP calculations.
+
+Metrics per allele:
+  - ROC-AUC
+  - Average-precision (PR-AUC) at the positive class
+  - PPV at N (N = number of true hits in the set; fraction of top-N
+    predictions that are actual hits)
+
+Usage:
+    python compare_new_vs_public.py \\
+        --new-models-dir results/new_run/models.combined \\
+        --public-models-dir "$HOME/Library/Application Support/mhcflurry/4/2.2.0/models_class1_pan/models.combined" \\
+        --data-dir "$HOME/Library/Application Support/mhcflurry/4/2.2.0/data_evaluation" \\
+        --out results/comparison
+"""
+import argparse
+import glob
+import json
+import os
+import sys
+
+import numpy
+import pandas
+from sklearn.metrics import average_precision_score, roc_auc_score
+
+
+def ppv_at_n(y_true, y_score, n):
+    order = numpy.argsort(-y_score)
+    top = order[:n]
+    return float(y_true[top].sum()) / float(n) if n > 0 else numpy.nan
+
+
+def metrics(y_true, y_score):
+    y_true = numpy.asarray(y_true)
+    y_score = numpy.asarray(y_score)
+    n_pos = int(y_true.sum())
+    n_neg = int(len(y_true) - n_pos)
+    if n_pos == 0 or n_neg == 0:
+        return dict(n=int(len(y_true)), n_pos=n_pos, roc_auc=numpy.nan,
+                    pr_auc=numpy.nan, ppv_at_n=numpy.nan)
+    return dict(
+        n=int(len(y_true)),
+        n_pos=n_pos,
+        roc_auc=float(roc_auc_score(y_true, y_score)),
+        pr_auc=float(average_precision_score(y_true, y_score)),
+        ppv_at_n=ppv_at_n(y_true, y_score, n_pos),
+    )
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--new-models-dir", required=True)
+    p.add_argument("--public-models-dir", required=True)
+    p.add_argument("--data-dir", required=True,
+                   help="data_evaluation/ directory with "
+                        "benchmark.monoallelic.*.train_excluded.*.csv.bz2")
+    p.add_argument("--source", choices=["mixmhcpred", "netmhcpan4", "both"],
+                   default="mixmhcpred",
+                   help="Which baseline-variant to pull benchmark files from")
+    p.add_argument("--out", required=True)
+    p.add_argument("--limit-alleles", type=int, default=None,
+                   help="Debug/dry-run: only evaluate first N allele files")
+    args = p.parse_args()
+
+    os.makedirs(args.out, exist_ok=True)
+
+    from mhcflurry import Class1AffinityPredictor
+
+    print(f"[1/5] Loading new ensemble: {args.new_models_dir}")
+    new = Class1AffinityPredictor.load(args.new_models_dir)
+    print(f"      {len(new.neural_networks)} networks, "
+          f"{len(new.supported_alleles)} alleles supported")
+
+    print(f"[2/5] Loading public ensemble: {args.public_models_dir}")
+    pub = Class1AffinityPredictor.load(args.public_models_dir)
+    print(f"      {len(pub.neural_networks)} networks, "
+          f"{len(pub.supported_alleles)} alleles supported")
+
+    print(f"[3/5] Finding benchmark files...")
+    if args.source == "both":
+        patterns = ["mixmhcpred", "netmhcpan4"]
+    else:
+        patterns = [args.source]
+    files = []
+    for pat in patterns:
+        files.extend(sorted(glob.glob(
+            os.path.join(args.data_dir,
+                         f"benchmark.monoallelic.{pat}.train_excluded.*.csv.bz2")
+        )))
+    if args.limit_alleles:
+        files = files[:args.limit_alleles]
+    print(f"      {len(files)} benchmark files")
+
+    all_dfs = []
+    for i, f in enumerate(files):
+        df = pandas.read_csv(f)
+        df["source_file"] = os.path.basename(f)
+        all_dfs.append(df)
+        if (i + 1) % 50 == 0:
+            print(f"      loaded {i + 1}/{len(files)}")
+    test = pandas.concat(all_dfs, ignore_index=True)
+    print(f"      total rows: {len(test):,}")
+
+    new_alleles = set(new.supported_alleles)
+    pub_alleles = set(pub.supported_alleles)
+    both = new_alleles & pub_alleles
+    print(f"      new alleles: {len(new_alleles)}, public: {len(pub_alleles)}, "
+          f"intersect: {len(both)}")
+    before = len(test)
+    test = test[test.hla.isin(both)].copy()
+    if len(test) < before:
+        print(f"      dropped {before - len(test)} rows (alleles outside intersect)")
+    # Filter to supported peptide lengths (8-15)
+    test["peptide_len"] = test["peptide"].str.len()
+    test = test[(test.peptide_len >= 8) & (test.peptide_len <= 15)].copy()
+    print(f"      evaluable rows after filter: {len(test):,}")
+
+    print(f"[4/5] Predicting with both ensembles...")
+    test["new_pred"] = new.predict(
+        peptides=test.peptide.values,
+        alleles=test.hla.values,
+        throw=False,
+    )
+    test["public_pred"] = pub.predict(
+        peptides=test.peptide.values,
+        alleles=test.hla.values,
+        throw=False,
+    )
+    test = test.dropna(subset=["new_pred", "public_pred"])
+    print(f"      rows with both predictions: {len(test):,}")
+    # Score = -log10(predicted nM) (higher = binder-like)
+    test["new_score"] = -numpy.log10(numpy.clip(test.new_pred, 1e-3, 1e8))
+    test["public_score"] = -numpy.log10(numpy.clip(test.public_pred, 1e-3, 1e8))
+
+    print(f"[5/5] Computing metrics per allele...")
+    rows = []
+    for allele, group in test.groupby("hla"):
+        if len(group) < 30 or group.hit.sum() == 0:
+            continue
+        m_new = metrics(group.hit.values, group.new_score.values)
+        m_pub = metrics(group.hit.values, group.public_score.values)
+        rows.append({
+            "allele": allele,
+            "n": m_new["n"], "n_pos": m_new["n_pos"],
+            "new_roc_auc": m_new["roc_auc"],
+            "public_roc_auc": m_pub["roc_auc"],
+            "new_pr_auc": m_new["pr_auc"],
+            "public_pr_auc": m_pub["pr_auc"],
+            "new_ppv_at_n": m_new["ppv_at_n"],
+            "public_ppv_at_n": m_pub["ppv_at_n"],
+        })
+    per_allele = pandas.DataFrame(rows)
+    for col in ["roc_auc", "pr_auc", "ppv_at_n"]:
+        per_allele[f"{col}_diff"] = per_allele[f"new_{col}"] - per_allele[f"public_{col}"]
+    per_allele = per_allele.sort_values("n", ascending=False)
+    per_allele_path = os.path.join(args.out, "per_allele.csv")
+    per_allele.to_csv(per_allele_path, index=False)
+    print(f"      wrote {per_allele_path} ({len(per_allele)} alleles)")
+
+    m_new_all = metrics(test.hit.values, test.new_score.values)
+    m_pub_all = metrics(test.hit.values, test.public_score.values)
+
+    summary = {
+        "n_rows": int(len(test)),
+        "n_hits": int(test.hit.sum()),
+        "n_alleles_reported": int(len(per_allele)),
+        "micro_pooled": {"new": m_new_all, "public": m_pub_all},
+        "macro_mean_over_alleles": {
+            metric: {
+                "new": float(per_allele[f"new_{metric}"].mean()),
+                "public": float(per_allele[f"public_{metric}"].mean()),
+            } for metric in ["roc_auc", "pr_auc", "ppv_at_n"]
+        },
+        "allele_count": {
+            "new_better_roc_auc": int((per_allele.roc_auc_diff > 0).sum()),
+            "public_better_roc_auc": int((per_allele.roc_auc_diff < 0).sum()),
+            "tie_roc_auc": int((per_allele.roc_auc_diff == 0).sum()),
+            "new_better_pr_auc": int((per_allele.pr_auc_diff > 0).sum()),
+            "public_better_pr_auc": int((per_allele.pr_auc_diff < 0).sum()),
+            "new_better_ppv_at_n": int((per_allele.ppv_at_n_diff > 0).sum()),
+            "public_better_ppv_at_n": int((per_allele.ppv_at_n_diff < 0).sum()),
+        },
+    }
+    summary_path = os.path.join(args.out, "summary.json")
+    with open(summary_path, "w") as fd:
+        json.dump(summary, fd, indent=2, sort_keys=True)
+    print(f"      wrote {summary_path}")
+    print()
+    print("=== SUMMARY ===")
+    print(json.dumps(summary, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/training/pan_allele_release_exact.sh
+++ b/scripts/training/pan_allele_release_exact.sh
@@ -48,12 +48,16 @@ HEARTBEAT_LOG="$MHCFLURRY_OUT/release_heartbeat.log"
 TRAIN_LOG="$MHCFLURRY_OUT/train.log"
 SELECT_LOG="$MHCFLURRY_OUT/select.log"
 CALIBRATE_LOG="$MHCFLURRY_OUT/calibrate.log"
+EVAL_LOG="$MHCFLURRY_OUT/eval.log"
+PLOT_LOG="$MHCFLURRY_OUT/plot_loss_curves.log"
 
 : > "$RELEASE_LOG"
 : > "$HEARTBEAT_LOG"
 : > "$TRAIN_LOG"
 : > "$SELECT_LOG"
 : > "$CALIBRATE_LOG"
+: > "$EVAL_LOG"
+: > "$PLOT_LOG"
 
 CURRENT_PHASE="bootstrap"
 GPU_SAMPLER_PID=""
@@ -351,10 +355,59 @@ do
         "${PARALLELISM_ARGS[@]}"
 done
 
+# ---- eval against public release ------------------------------------
+# Compares the freshly-trained ensemble vs the published 2.2.0 ensemble
+# on the data_evaluation hit/decoy benchmark. Per-allele ROC-AUC,
+# PR-AUC, PPV@N. Skip cleanly with SKIP_EVAL=1.
+SKIP_EVAL="${SKIP_EVAL:-0}"
+if [ "$SKIP_EVAL" != "1" ]; then
+    CURRENT_PHASE="eval"
+    log_release_event phase_info "starting eval against public release"
+    run_logged_step "fetch_eval_data" "$EVAL_LOG" \
+        mhcflurry-downloads fetch data_evaluation models_class1_pan
+    PUBLIC_MODELS_DIR="$(mhcflurry-downloads path models_class1_pan)/models.combined"
+    DATA_EVAL_DIR="$(mhcflurry-downloads path data_evaluation)"
+    EVAL_OUT="$MHCFLURRY_OUT/eval_comparison"
+    mkdir -p "$EVAL_OUT"
+    COMPARE_SCRIPT="$SCRIPT_DIR/compare_new_vs_public.py"
+    if [ ! -f "$COMPARE_SCRIPT" ]; then
+        log_release_event eval_skipped "missing compare_new_vs_public.py"
+    else
+        run_logged_step "eval_compare_new_vs_public" "$EVAL_LOG" \
+            python3 "$COMPARE_SCRIPT" \
+            --new-models-dir "$MHCFLURRY_OUT/models.combined" \
+            --public-models-dir "$PUBLIC_MODELS_DIR" \
+            --data-dir "$DATA_EVAL_DIR" \
+            --out "$EVAL_OUT"
+    fi
+fi
+
+# ---- loss-curve plots -----------------------------------------------
+# Reads fit_info from the candidate-pool + selected manifests; emits
+# loss_curves_by_model.png, loss_curves_by_arch.png, per_fold_summary.png,
+# summary.csv. Skip cleanly with SKIP_PLOTS=1.
+SKIP_PLOTS="${SKIP_PLOTS:-0}"
+if [ "$SKIP_PLOTS" != "1" ]; then
+    CURRENT_PHASE="plot"
+    PLOT_SCRIPT="$SCRIPT_DIR/plot_loss_curves.py"
+    PLOT_OUT="$MHCFLURRY_OUT/loss_plots"
+    if [ ! -f "$PLOT_SCRIPT" ]; then
+        log_release_event plot_skipped "missing plot_loss_curves.py"
+    else
+        run_logged_step "plot_loss_curves" "$PLOT_LOG" \
+            python3 "$PLOT_SCRIPT" \
+            --selected-dir "$MHCFLURRY_OUT/models.combined" \
+            --unselected-dir "$MHCFLURRY_OUT/models.unselected.combined" \
+            --out "$PLOT_OUT"
+    fi
+fi
+
 CURRENT_PHASE="complete"
 log_release_event complete "final_dir=$MHCFLURRY_OUT/models.combined"
 {
-    echo "Full release-exact training completed."
-    echo "Final ensemble: $MHCFLURRY_OUT/models.combined/"
+    echo "Full release-exact pipeline completed."
+    echo "Final ensemble:   $MHCFLURRY_OUT/models.combined/"
+    echo "Eval comparison:  $MHCFLURRY_OUT/eval_comparison/  (if SKIP_EVAL!=1)"
+    echo "Loss-curve plots: $MHCFLURRY_OUT/loss_plots/       (if SKIP_PLOTS!=1)"
     ls -la "$MHCFLURRY_OUT/models.combined" | head -30
 } | tee -a "$RELEASE_LOG"

--- a/scripts/training/pan_allele_release_exact.sh
+++ b/scripts/training/pan_allele_release_exact.sh
@@ -48,6 +48,7 @@ HEARTBEAT_LOG="$MHCFLURRY_OUT/release_heartbeat.log"
 TRAIN_LOG="$MHCFLURRY_OUT/train.log"
 SELECT_LOG="$MHCFLURRY_OUT/select.log"
 CALIBRATE_LOG="$MHCFLURRY_OUT/calibrate.log"
+FETCH_LOG="$MHCFLURRY_OUT/fetch_eval_data.log"
 EVAL_LOG="$MHCFLURRY_OUT/eval.log"
 PLOT_LOG="$MHCFLURRY_OUT/plot_loss_curves.log"
 
@@ -56,6 +57,7 @@ PLOT_LOG="$MHCFLURRY_OUT/plot_loss_curves.log"
 : > "$TRAIN_LOG"
 : > "$SELECT_LOG"
 : > "$CALIBRATE_LOG"
+: > "$FETCH_LOG"
 : > "$EVAL_LOG"
 : > "$PLOT_LOG"
 
@@ -359,11 +361,20 @@ done
 # Compares the freshly-trained ensemble vs the published 2.2.0 ensemble
 # on the data_evaluation hit/decoy benchmark. Per-allele ROC-AUC,
 # PR-AUC, PPV@N. Skip cleanly with SKIP_EVAL=1.
+#
+# CURRENT_PHASE is set unconditionally so the heartbeat / error trap
+# logs the right phase even when the stage is skipped (otherwise the
+# preceding ``calibrate_combined`` would leak through).
+CURRENT_PHASE="eval"
 SKIP_EVAL="${SKIP_EVAL:-0}"
-if [ "$SKIP_EVAL" != "1" ]; then
-    CURRENT_PHASE="eval"
+if [ "$SKIP_EVAL" = "1" ]; then
+    log_release_event phase_skipped "SKIP_EVAL=1"
+else
     log_release_event phase_info "starting eval against public release"
-    run_logged_step "fetch_eval_data" "$EVAL_LOG" \
+    # ``mhcflurry-downloads fetch`` accepts multiple targets via nargs="*"
+    # (see mhcflurry/downloads_command.py:74). Both go to FETCH_LOG so
+    # the per-allele eval output stays unpolluted by extraction progress.
+    run_logged_step "fetch_eval_data" "$FETCH_LOG" \
         mhcflurry-downloads fetch data_evaluation models_class1_pan
     PUBLIC_MODELS_DIR="$(mhcflurry-downloads path models_class1_pan)/models.combined"
     DATA_EVAL_DIR="$(mhcflurry-downloads path data_evaluation)"
@@ -386,9 +397,11 @@ fi
 # Reads fit_info from the candidate-pool + selected manifests; emits
 # loss_curves_by_model.png, loss_curves_by_arch.png, per_fold_summary.png,
 # summary.csv. Skip cleanly with SKIP_PLOTS=1.
+CURRENT_PHASE="plot"
 SKIP_PLOTS="${SKIP_PLOTS:-0}"
-if [ "$SKIP_PLOTS" != "1" ]; then
-    CURRENT_PHASE="plot"
+if [ "$SKIP_PLOTS" = "1" ]; then
+    log_release_event phase_skipped "SKIP_PLOTS=1"
+else
     PLOT_SCRIPT="$SCRIPT_DIR/plot_loss_curves.py"
     PLOT_OUT="$MHCFLURRY_OUT/loss_plots"
     if [ ! -f "$PLOT_SCRIPT" ]; then


### PR DESCRIPTION
## Why

When the runplz wrapper crashed early on the 2026-04-25 8×A100 run,
training still reached 140/140 saves but everything downstream was
manual reconstruction:

- ``models.combined/`` — had to run ``mhcflurry-class1-select-pan-allele-models`` by hand.
- Percentile-rank calibration — had to run ``mhcflurry-calibrate-percentile-ranks`` by hand.
- Eval against the public release — buried under ``results/compare_new_vs_public.py``.
- Loss-curve plots — separate script, separate invocation.
- ``mhcflurry-downloads fetch data_evaluation models_class1_pan`` was an undocumented prereq.

Each piece worked individually but nothing tied them together, so a
half-finished run meant manually piecing together five commands and
hoping the recipe args matched.

## What

Adds three new stages to ``pan_allele_release_exact.sh`` using the
same ``run_logged_step`` pattern as the existing train/select/calibrate:

- ``fetch_eval_data`` — ``mhcflurry-downloads fetch``
- ``eval_compare_new_vs_public`` — runs the comparison script, per-allele
  ROC-AUC / PR-AUC / PPV@N to ``$MHCFLURRY_OUT/eval_comparison/``.
- ``plot_loss_curves`` — runs the existing plot script, PNGs + summary.csv
  to ``$MHCFLURRY_OUT/loss_plots/``.

Each gets its own log file under ``$MHCFLURRY_OUT/`` and
``log_release_event phase_start/phase_end`` markers in the release
driver log. Both can be skipped via ``SKIP_EVAL=1`` / ``SKIP_PLOTS=1``
for incremental reruns.

Also relocates ``compare_new_vs_public.py`` from ``results/`` (a
generated-output sibling — weird location for source) to
``scripts/training/`` next to ``plot_loss_curves.py`` and the rest
of the training machinery.

## Test plan

- [x] ``bash -n scripts/training/pan_allele_release_exact.sh`` clean.
- [ ] Re-run the 2026-04-25 release_exact pipeline end-to-end with
      this script (deferred until the in-flight finalize completes).
- [ ] Verify ``$MHCFLURRY_OUT/release_driver.log`` shows phase_start/end
      events for fetch_eval_data, eval_compare_new_vs_public, and
      plot_loss_curves.