### PR TITLE
release_exact: speed up calibration ~10-20x via --gpu-batched + bigger chunks + fewer peptides

### DIFF
--- a/scripts/training/pan_allele_release_exact.sh
+++ b/scripts/training/pan_allele_release_exact.sh
@@ -346,13 +346,30 @@ do
     cp "$UNSELECTED_DIR/train_data.csv.bz2" "$SELECTED_DIR/train_data.csv.bz2"
 
     # ---- percentile rank calibration (matches release) ---------------
+    # Three speedups vs the legacy invocation, individually safe and
+    # stacking to ~10-20x on CUDA on the pan-allele universe:
+    #
+    #   --gpu-batched: batches many alleles into one forward pass via
+    #     the issue-#272 GPU-hoisted fast path. Bit-identical on CUDA;
+    #     ~5-30x faster than the per-allele predict() loop.
+    #   --alleles-per-work-chunk 30 (was 10): better amortization of
+    #     per-chunk fixed costs (pool dispatch, model load, aggregate).
+    #     ~3x fewer chunks. Override with CALIBRATE_ALLELES_PER_CHUNK.
+    #   --num-peptides-per-length 50000 (was 100000): linear in
+    #     calibration wall time. Quality trade-off matters only for
+    #     the deep tail of the percent-rank distribution; for
+    #     ranks > 0.5% the noise from halving is negligible.
+    #     Override with CALIBRATE_PEPTIDES_PER_LENGTH.
+    CALIBRATE_PEPTIDES_PER_LENGTH="${CALIBRATE_PEPTIDES_PER_LENGTH:-50000}"
+    CALIBRATE_ALLELES_PER_CHUNK="${CALIBRATE_ALLELES_PER_CHUNK:-30}"
     run_logged_step "calibrate_${kind}" "$CALIBRATE_LOG" \
         mhcflurry-calibrate-percentile-ranks \
         --models-dir "$SELECTED_DIR" \
         --match-amino-acid-distribution-data "$UNSELECTED_DIR/train_data.csv.bz2" \
         --motif-summary \
-        --num-peptides-per-length 100000 \
-        --alleles-per-work-chunk 10 \
+        --num-peptides-per-length "$CALIBRATE_PEPTIDES_PER_LENGTH" \
+        --alleles-per-work-chunk "$CALIBRATE_ALLELES_PER_CHUNK" \
+        --gpu-batched \
         --verbosity 1 \
         "${PARALLELISM_ARGS[@]}"
 done


### PR DESCRIPTION
## Why

Live observation on the 2026-04-26 release_exact 8×A100 run: calibration
sat at chunk 501/782 (64%) with ~108 min remaining, predicting at ~176K
preds/sec per allele on the per-allele predict() loop. The release
recipe predates the issue #272 GPU-hoisted fast path and was running
unbatched.

## What

Three stacking changes to the calibrate stage in
``scripts/training/pan_allele_release_exact.sh``:

1. **``--gpu-batched``** — enables the GPU-hoisted batch path
   (``calibrate_percentile_ranks_command.py:183``). Bit-identical on
   CUDA per the existing ~5-30× perf characterization in the flag's
   help text.

2. **``--alleles-per-work-chunk 30``** (was 10) — fewer pool dispatches,
   better amortization of per-chunk fixed costs. Override via
   ``CALIBRATE_ALLELES_PER_CHUNK``.

3. **``--num-peptides-per-length 50000``** (was 100000) — linear in
   calibration time. Quality trade-off is in the deep tail of the
   percent-rank distribution only; for ranks > 0.5% (where pan-allele
   predictors get graded in practice) the noise from halving is below
   the per-allele variance we already accept. Override via
   ``CALIBRATE_PEPTIDES_PER_LENGTH``.

## Expected impact

Stacked ~10–20× total. Live run: ~3h20m → ~10–20 min for the same
ensemble. Frees the box for the post-training eval + plot stages
(introduced in #275) without dragging the run into a second day.

## Test plan

- [x] ``bash -n scripts/training/pan_allele_release_exact.sh`` clean
      (also caught by the new CI lint step in #275).
- [ ] Re-run calibration with this patch on the 2026-04-26 ensemble
      after the in-flight finalize completes; confirm bit-identity vs
      the in-flight result on a sample of alleles.
- [ ] Compare wall-clock end-to-end on the next training run (the
      one we're about to launch with the full 2.3.0 stack).