### PR TITLE
Tighten orchestrator: shared filter + env hoists + encoding-cache helper + internals doc

### DIFF
--- a/RELEASE_NOTES_2.3.0.md
+++ b/RELEASE_NOTES_2.3.0.md
@@ -118,6 +118,19 @@ real measurement:
 3. when patience would trigger this epoch (so the saved val_loss
    reflects the actual stop state, not a stale carried-forward value).
 
+### Layer-2 SHM auto-detects /dev/shm capacity
+
+When the orchestrator detects insufficient `/dev/shm` for
+`num_workers × ~4 GB/fit × 1.5 margin`, it auto-disables Layer-2 SHM
+for the run (sets `MHCFLURRY_FIT_DATALOADER_SHM=0`) and prints a
+remediation hint (typically: relaunch the container with
+`--shm-size=64g`). The Docker-default 8 GB `/dev/shm` is too small for
+a 16-worker pan-allele run; without this guard the run would crash
+mid-fit with `OSError: [Errno 28] No space left on device`. With the
+guard, it falls back to the numpy DataLoader path (10–30% slower
+than SHM, but functional). Force-pin with
+`MHCFLURRY_FIT_DATALOADER_SHM=1` to override the auto-fallback.
+
 ### Layered SHM is auto-on with workers
 
 When `hyperparameters["dataloader_num_workers"] > 0`, fit() materializes

--- a/RELEASE_NOTES_2.3.0.md
+++ b/RELEASE_NOTES_2.3.0.md
@@ -12,6 +12,11 @@ the patience-reset noise tail, and the post-training pipeline
 (select → calibrate → eval → plot) is unified into a single
 resumable script. Calibration is ~10–20× faster.
 
+The orchestrator-as-locus-of-control architecture is documented in
+[docs/orchestrator.md](docs/orchestrator.md) — read that for the
+"who owns what" picture across parallelism, shared memory, and env
+knobs.
+
 No changes to the prediction interface. **Saved 2.2.x model bundles
 load and predict identically — the changes are entirely in how new
 models are trained.**

--- a/RELEASE_NOTES_2.3.0.md
+++ b/RELEASE_NOTES_2.3.0.md
@@ -135,15 +135,26 @@ to the box on every launch. Run with `--apply` once per workstation.
 ### Layer-2 SHM auto-detects /dev/shm capacity
 
 When the orchestrator detects insufficient `/dev/shm` for
-`num_workers × ~4 GB/fit × 1.5 margin`, it auto-disables Layer-2 SHM
-for the run (sets `MHCFLURRY_FIT_DATALOADER_SHM=0`) and prints a
-remediation hint (typically: relaunch the container with
-`--shm-size=64g`). The Docker-default 8 GB `/dev/shm` is too small for
-a 16-worker pan-allele run; without this guard the run would crash
-mid-fit with `OSError: [Errno 28] No space left on device`. With the
-guard, it falls back to the numpy DataLoader path (10–30% slower
-than SHM, but functional). Force-pin with
-`MHCFLURRY_FIT_DATALOADER_SHM=1` to override the auto-fallback.
+`num_workers × ~4 GB/fit × 1.5 margin`, it now follows a four-layer
+recovery cascade:
+
+1. Print a one-line capacity summary every run.
+2. **Try torch's `file_descriptor` sharing strategy first** — this
+   bypasses `/dev/shm` entirely (anonymous FDs over Unix sockets) and
+   fully recovers Layer-2 SHM throughput on Docker-default 8 GB
+   tmpfs. Auto-bumps `RLIMIT_NOFILE`. Disable with
+   `MHCFLURRY_TORCH_SHM_AUTO=0`.
+3. If the strategy switch fails (rare; some platforms only ship the
+   default `file_system` strategy), auto-disable Layer-2 SHM
+   (`MHCFLURRY_FIT_DATALOADER_SHM=0`) and continue with the numpy
+   DataLoader path (10–30% slower but functional).
+4. As a final defense, `fit()` catches `OSError(ENOSPC|ENOMEM)` from
+   `share_memory_()` and falls back to numpy for that one fit() call.
+
+Result: on the Docker-default 8 GB `/dev/shm` the typical 16-worker
+pan-allele run now keeps the full Layer-2 SHM speedup automatically;
+no container reprovisioning needed. Force-pin with
+`MHCFLURRY_FIT_DATALOADER_SHM=1` to override the auto-recovery.
 
 ### Layered SHM is auto-on with workers
 

--- a/RELEASE_NOTES_2.3.0.md
+++ b/RELEASE_NOTES_2.3.0.md
@@ -60,6 +60,7 @@ validation run completes.
 | `min_delta` | 0.0 | 1e-7 | With `min_delta=0`, a 1e-9 RMSprop noise-floor improvement resets the 20-epoch patience counter, stretching some tasks to 174+ epochs at val_loss ~0.28 with no real signal. 1e-7 is two orders of magnitude above the observed noise rate; preserves real escape trajectories (typically ≥1e-3/epoch). |
 | `validation_interval` | 1 (always validated) | 5 | Skip the validation forward pass on 4 of 5 epochs; saves ~150 ms/epoch + a GPU sync barrier. The final epoch and any patience-trigger epoch are always measured (the saved model reflects an up-to-date val_loss). |
 | `dataloader_num_workers` (job-env default) | 0 | 4 | Was 0 because spawn workers OOM'd on the 600 MB per-fit dataset. Layer-2 SHM eliminated that cost; auto-enables when `dataloader_num_workers > 0`. |
+| `peptide_amino_acid_encoding_gpu` | `false` | `true` | Phase 2 of #268. BLOSUM62 expansion moves from a numpy lookup at encode time to a frozen `nn.Embedding(21, 21)` in the network's forward pass. `peptides_to_network_input` now returns int8 indices (cheap dict lookup); GPU widens to fp32. Eliminates the ~17 sec/epoch CPU bottleneck in random-negative regeneration with `random_negative_pool_epochs=1`. Forward parity vs numpy path verified by `test_peptide_amino_acid_encoding_gpu_forward_parity`. |
 
 `patience` stays at 20.
 

--- a/RELEASE_NOTES_2.3.0.md
+++ b/RELEASE_NOTES_2.3.0.md
@@ -118,6 +118,20 @@ real measurement:
 3. when patience would trigger this epoch (so the saved val_loss
    reflects the actual stop state, not a stale carried-forward value).
 
+### Encoding cache lives outside `MHCFLURRY_OUT`
+
+`scripts/training/pan_allele_release_exact.sh` now places the
+encoding cache at `$HOME/runplz-cache/encoding_cache/` (override
+with `MHCFLURRY_ENCODING_CACHE_DIR`) instead of inside
+`$MHCFLURRY_OUT`. Two upsides: the ~7 GB BLOSUM62 mmap doesn't ride
+back on the post-run rsync, and the cache persists on the box so a
+second run on the same instance hits a warm cache.
+
+A new helper, `scripts/dev/relocate_run_outputs.sh`, moves
+`brev_runs/` and `results/` outside the repo (with symlinks) so
+runplz's rsync_up doesn't ship 15+ GB of stale prior-run artifacts
+to the box on every launch. Run with `--apply` once per workstation.
+
 ### Layer-2 SHM auto-detects /dev/shm capacity
 
 When the orchestrator detects insufficient `/dev/shm` for

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -175,6 +175,46 @@ N workers don't each spawn `cpu_count()` compile threads.
    The 2.3.0 application sites are calibrate (affinity + presentation
    paths) and select (pan-allele + allele-specific paths).
 
+## /dev/shm capacity and Layer-2 SHM auto-fallback
+
+Layer-2 SHM allocates per-fit() backing tensors in POSIX shm
+(`/dev/shm`). With small `/dev/shm` (the Docker default is 8 GB) and
+many fit() workers, the allocator runs out mid-fit and the worker
+crashes with `OSError: [Errno 28] No space left on device`.
+
+The orchestrator handles this in three layers:
+
+1. **Pre-fork advisory** — `_preflight_shm_capacity` runs before
+   workers fork. It computes
+   `num_workers × per_fit_gb × 1.5` (50% margin), compares to
+   `df /dev/shm`, and prints a one-line summary every run.
+2. **Auto-fallback** — when capacity is tight AND the user hasn't
+   force-pinned `MHCFLURRY_FIT_DATALOADER_SHM`, the orchestrator sets
+   it to `"0"` so workers use the numpy DataLoader path instead.
+   Throughput hit is ~10–30% vs the SHM path; better than crashing.
+3. **Per-fit defensive catch** — even if the orchestrator estimate
+   underran the actual need, `fit()` catches `OSError(ENOSPC)` and
+   falls back to numpy mode for that one fit() call, with a loud
+   warning.
+
+To force-on (despite tight `/dev/shm`):
+`MHCFLURRY_FIT_DATALOADER_SHM=1`. The pre-flight will warn but
+respect the pin; workers will OOM if the estimate is correct.
+
+To force-off:
+`MHCFLURRY_FIT_DATALOADER_SHM=0`. Skips both Layer-2 SHM and the
+capacity check.
+
+To resize `/dev/shm` on a Docker-based runtime:
+* relaunch the container with `--shm-size=64g` (or more) — this is
+  the recommended fix; remount in-place requires `CAP_SYS_ADMIN`
+  which most container runtimes drop.
+* On a bare host: `sudo mount -o remount,size=64g /dev/shm`.
+
+Per-fit footprint estimate is tuned via
+`MHCFLURRY_PER_FIT_SHM_FOOTPRINT_GB` (default 4.0 GB, sized for
+pan-allele MLP at standard data scale).
+
 ## Pointers to code
 
 - Layer 1 + Layer 2 helpers: `mhcflurry/shared_memory.py`
@@ -186,7 +226,9 @@ N workers don't each spawn `cpu_count()` compile threads.
 - Worker pool sizing: `mhcflurry/local_parallelism.py`
   (`auto_max_workers_per_gpu`, `resolve_max_workers_per_gpu`)
 - Compile-thread hoist:
-  `mhcflurry/train_pan_allele_models_command._hoist_torchinductor_compile_threads`
+  `mhcflurry/local_parallelism.hoist_torchinductor_compile_threads`
+- /dev/shm capacity: `mhcflurry/local_parallelism.fit_shm_capacity_check`
+  + `mhcflurry/train_pan_allele_models_command._preflight_shm_capacity`
 - Cluster fork point:
   `mhcflurry/cluster_parallelism.cluster_results`
 

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -215,6 +215,29 @@ Per-fit footprint estimate is tuned via
 `MHCFLURRY_PER_FIT_SHM_FOOTPRINT_GB` (default 4.0 GB, sized for
 pan-allele MLP at standard data scale).
 
+## rsync hygiene (laptop ↔ remote training box)
+
+`runplz` rsyncs the working tree up to the box on every launch, and
+the run's `out/` directory back to the laptop on completion. Two
+asymmetries to know about:
+
+- **Up direction:** runplz's hardcoded exclude list (`.git`, `.venv`,
+  `__pycache__`, etc.) doesn't anticipate per-project output dirs.
+  In mhcflurry, `brev_runs/` accumulates 7-15 GB of past-run
+  artifacts that ride along on every launch unless relocated. Run
+  `bash scripts/dev/relocate_run_outputs.sh --apply` once to move
+  `brev_runs/` and `results/` to `~/mhcflurry-brev-runs/` and
+  `~/mhcflurry-results/`, with symlinks back into the repo. After
+  that, rsync ships ~tiny symlinks instead of multi-GB directories.
+- **Down direction:** the post-run rsync has NO excludes — everything
+  under `out/` returns. The orchestrator script
+  (`scripts/training/pan_allele_release_exact.sh`) places the
+  encoding cache OUTSIDE `$MHCFLURRY_OUT` (default
+  `$HOME/runplz-cache/encoding_cache/`) so the ~7 GB BLOSUM62 mmap
+  doesn't ride back. Override with `MHCFLURRY_ENCODING_CACHE_DIR`.
+  Bonus: cache persists across runs on the same box, so the second
+  run hits a warm cache.
+
 ## Pointers to code
 
 - Layer 1 + Layer 2 helpers: `mhcflurry/shared_memory.py`

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -182,19 +182,30 @@ Layer-2 SHM allocates per-fit() backing tensors in POSIX shm
 many fit() workers, the allocator runs out mid-fit and the worker
 crashes with `OSError: [Errno 28] No space left on device`.
 
-The orchestrator handles this in three layers:
+The orchestrator handles this in **four** layers, ordered from "best
+recovery" to "conservative fallback":
 
 1. **Pre-fork advisory** — `_preflight_shm_capacity` runs before
    workers fork. It computes
    `num_workers × per_fit_gb × 1.5` (50% margin), compares to
    `df /dev/shm`, and prints a one-line summary every run.
-2. **Auto-fallback** — when capacity is tight AND the user hasn't
+2. **Auto-switch torch sharing strategy** — when capacity is tight,
+   the orchestrator first tries
+   `torch.multiprocessing.set_sharing_strategy('file_descriptor')`,
+   which passes anonymous FDs over Unix sockets instead of using
+   `/dev/shm`. This **fully recovers L2 SHM speedup** without needing
+   container resizing. Bumps `RLIMIT_NOFILE` automatically. Triggered
+   by default; disable with `MHCFLURRY_TORCH_SHM_AUTO=0`. Also fires
+   at `mhcflurry.class1_neural_network` import time so paths that
+   bypass the orchestrator (tests, allele-specific train) inherit it.
+3. **Auto-disable Layer-2 SHM** — when the strategy switch fails
+   (some platforms only ship `file_system`) AND the user hasn't
    force-pinned `MHCFLURRY_FIT_DATALOADER_SHM`, the orchestrator sets
    it to `"0"` so workers use the numpy DataLoader path instead.
    Throughput hit is ~10–30% vs the SHM path; better than crashing.
-3. **Per-fit defensive catch** — even if the orchestrator estimate
-   underran the actual need, `fit()` catches `OSError(ENOSPC)` and
-   falls back to numpy mode for that one fit() call, with a loud
+4. **Per-fit defensive catch** — even if the pre-flight estimate
+   underran the actual need, `fit()` catches `OSError(ENOSPC|ENOMEM)`
+   and falls back to numpy mode for that one fit() call, with a loud
    warning.
 
 To force-on (despite tight `/dev/shm`):
@@ -205,10 +216,12 @@ To force-off:
 `MHCFLURRY_FIT_DATALOADER_SHM=0`. Skips both Layer-2 SHM and the
 capacity check.
 
-To resize `/dev/shm` on a Docker-based runtime:
-* relaunch the container with `--shm-size=64g` (or more) — this is
-  the recommended fix; remount in-place requires `CAP_SYS_ADMIN`
-  which most container runtimes drop.
+To resize `/dev/shm` on a Docker-based runtime (rarely needed, since
+the file_descriptor strategy switch above handles tight tmpfs
+automatically):
+* relaunch the container with `--shm-size=64g` (or more); remount
+  in-place requires `CAP_SYS_ADMIN` which most container runtimes
+  drop.
 * On a bare host: `sudo mount -o remount,size=64g /dev/shm`.
 
 Per-fit footprint estimate is tuned via

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -1,0 +1,227 @@
+# Orchestrator architecture
+
+> Internals doc — for contributors. End users running
+> `mhcflurry-class1-train-pan-allele-models` don't need to read this.
+
+## The one-line summary
+
+The orchestrator owns the **shared resources** (parallel workers,
+shared-memory layers, encoding caches, env tuning); workers consume
+them. Workers never spawn other workers, never build shared state,
+never set env knobs that affect other workers.
+
+If you find yourself adding orchestrator-shaped logic inside
+`fit()`, `train_model()`, or any worker function, stop and think
+whether it belongs in the orchestrator instead.
+
+## Locus of control
+
+```
+orchestrator process               training worker process
+─────────────────────              ───────────────────────
+
+parse args                         (forked / spawned)
+load training data                  inherit GLOBAL_DATA
+build GLOBAL_DATA           ─┐
+                             │
+hoist env knobs              │
+  TORCHINDUCTOR_COMPILE_THREADS
+                             │
+prebuild encoding cache      │     fit():
+  (Layer-1, mmap)            │       look up encoding cache
+                             │       (mmap hit, no rebuild)
+prebuild random-neg pool     │
+  (Layer-1, mmap)            │       look up random-neg pool
+                             │       (mmap hit, no replan)
+fork worker pool             ─┘
+                                    fit() materializes
+                                      Layer-2 SHM (per-fit)
+                                      DataLoader workers see
+                                      shared tensor handles
+collect results  ◀──────────────────  return predictor
+```
+
+The orchestrator does the **expensive, single-threaded preparation**
+ONCE. Workers do the **parallel, per-task** work N times.
+
+## Layered shared memory
+
+mhcflurry uses two SHM layers. They share the "build once, share with
+many readers" idea but use different OS mechanisms because lifetimes
+differ.
+
+| | Layer 1 | Layer 2 |
+|---|---|---|
+| **Lifetime** | per-run (persists to disk; survives across runs) | per-`fit()` call |
+| **Mechanism** | `numpy.memmap` of files | `torch.Tensor.share_memory_()` (POSIX shm in `/dev/shm`) |
+| **Built by** | orchestrator | the `fit()` call inside a worker |
+| **Read by** | every training worker | DataLoader spawn workers inside one `fit()` |
+| **Mutability** | read-only | mutable (random-neg buffer refilled per epoch) |
+| **Holds** | encoded peptides, random-neg peptides | x_peptide, x_allele, y_encoded, sample_weights, random_negative_x_peptide buffer, random_negative_x_allele |
+
+**Why two layers?** Layer 1's persist-across-runs property fits file
+mmap; Layer 2's mutate-per-epoch property fits torch shm. The split is
+intentional, but the API surface is uniform: each has a `setup_*`
+factory and a small set of generic helpers — see `mhcflurry/shared_memory.py`.
+
+**Why not "always Layer 2"?** Layer 2 doesn't survive process exit;
+encoding the ~1 M training peptides takes ~30 sec, and we'd pay it
+every run. Layer 1's mmap files live on disk, so a re-run hits cache.
+
+**Why not "always Layer 1"?** Layer 1 is read-only; the per-epoch
+random-negative buffer needs in-place updates. Layer 2 is the right
+tool for that.
+
+## Parallelism backends
+
+Two backends, one CLI surface:
+
+- **Local** (`local_parallelism.py`): `multiprocessing.Pool` of
+  non-daemon workers. Workers can spawn DataLoader children. SHM
+  layers both work — workers inherit GLOBAL_DATA via fork, mmap pool
+  paths are local-process-visible.
+- **Cluster** (`cluster_parallelism.py`): one job per work-item
+  submitted via `bsub` / `sbatch` / `sh`. Workers serialize
+  GLOBAL_DATA to NFS, deserialize on the worker side. Layer-1 SHM
+  works ONLY when the pool dir is on a shared filesystem reachable
+  from every worker node — orchestrator emits a loud warning when both
+  flags are set so the user can verify.
+
+Worker-side code (`train_model()`, etc.) is identical between
+backends. Only the orchestrator branches on `args.cluster_parallelism`.
+
+## Coverage matrix
+
+The 2.3.0 modernization concentrates on the pan-allele affinity
+training + percentile calibration paths. Other components inherit
+parts of the stack (Layer-2 SHM is automatic for any `fit()` call;
+the pseudogene filter is now shared) but their orchestrators don't
+yet drive Layer-1 SHM or encoding-cache prefetch — those are
+opt-in, not on by default.
+
+| | pretrain | finetune | select | calibrate |
+|---|---|---|---|---|
+| **affinity (pan-allele)** | full stack ✓ | full stack ✓ | filter ✓; SHM/cache n/a (no fit) | filter ✓; SHM/cache n/a |
+| **affinity (allele-specific)** | n/a | local pool only; cache+L1 are opt-in via `prebuild_encoding_caches` | filter ✓ | shares calibrate command |
+| **processing** | n/a | local+cluster pool; cache+L1 are opt-in | local+cluster pool | n/a (allele-independent) |
+| **presentation** | n/a | serial only (single-process; no orchestration story today) | n/a | filter ✓ (shares calibrate command) |
+
+"Opt-in" cells aren't *broken* — they just inherit the worker-side
+Layer-2 SHM (free with `dataloader_num_workers > 0`) and don't yet
+have orchestrator-side Layer-1 prebuild. When their datasets grow
+to where prebuild matters, call `prebuild_encoding_caches` from the
+relevant `train_*_command` after `add_local_parallelism_args(...)`.
+
+## Env knobs vs CLI flags
+
+A persistent question: when does a setting belong on `argparse` vs
+the environment?
+
+**Rule of thumb:**
+
+- **CLI flag** when the orchestrator owns it and propagates it.
+  (Examples: `--max-workers-per-gpu`, `--random-negative-shared-pool-dir`,
+  `--num-jobs`.)
+- **Env var** when the consumer is inside `fit()` or another
+  worker-private code path, and the orchestrator is just a relay.
+  (Examples: `MHCFLURRY_TORCH_COMPILE`,
+  `MHCFLURRY_FIT_DATALOADER_SHM`, `TORCHINDUCTOR_COMPILE_THREADS`.)
+
+The orchestrator may **hoist** env vars: read its own args, compute a
+sensible default, and `os.environ.setdefault(...)` so workers
+inherit. `_hoist_torchinductor_compile_threads` is the canonical
+example — it sizes the inductor compile pool against `--num-jobs` so
+N workers don't each spawn `cpu_count()` compile threads.
+
+## What is NOT the orchestrator's job
+
+- Compiling models (`torch.compile`). Compilation is per-network and
+  happens inside `fit()`. The orchestrator only sizes the compile
+  worker pool via env.
+- Calling `predict()` on individual alleles. The orchestrator
+  builds work items; workers iterate.
+- Validating data shape consistency between work items beyond what
+  the SHM helpers themselves require (uniform `pool_epochs`, uniform
+  `peptide_encoding`).
+
+## Recipes
+
+### Adding a new pre-fork resource
+
+1. Add a `_initialize_<name>(args, all_work_items)` helper near the
+   existing ones in `train_pan_allele_models_command.py`.
+2. Stash the result in `GLOBAL_DATA["<name>"]`.
+3. Document the lookup key. Workers retrieve via
+   `constant_data["<name>"]` (forked workers inherit; spawned/cluster
+   workers receive via pickle).
+4. Add a `getattr(args, "<flag>", None)` gate so the helper is opt-in
+   on the CLI side.
+
+### Adding a new env knob
+
+1. Decide: orchestrator-set or worker-private?
+2. If orchestrator-set: add a `_hoist_<knob>(args)` helper that reads
+   args + system info and `os.environ.setdefault(...)`s the value.
+   Document the rule the orchestrator applies.
+3. If worker-private: just read it from `os.environ` inside `fit()`
+   or wherever it's consumed. Document it in
+   `RELEASE_NOTES_<version>.md`.
+
+### Adding a new worker-side filter
+
+1. Drop into `mhcflurry/common.py` (e.g.,
+   `filter_canonicalizable_alleles`).
+2. Apply at every iteration site that could trip on the bad input.
+   The 2.3.0 application sites are calibrate (affinity + presentation
+   paths) and select (pan-allele + allele-specific paths).
+
+## Pointers to code
+
+- Layer 1 + Layer 2 helpers: `mhcflurry/shared_memory.py`
+- Encoding cache: `mhcflurry/encoding_cache.py` (generic
+  `prebuild_encoding_caches`; pan-allele wrapper in
+  `train_pan_allele_models_command._initialize_encoding_cache`)
+- Pseudogene/null filter: `mhcflurry/common.py`
+  (`filter_canonicalizable_alleles`)
+- Worker pool sizing: `mhcflurry/local_parallelism.py`
+  (`auto_max_workers_per_gpu`, `resolve_max_workers_per_gpu`)
+- Compile-thread hoist:
+  `mhcflurry/train_pan_allele_models_command._hoist_torchinductor_compile_threads`
+- Cluster fork point:
+  `mhcflurry/cluster_parallelism.cluster_results`
+
+## Known asymmetries (deliberate)
+
+These show up to readers as "why is this only done in pan-allele?"
+The answer in each case is "the other components don't yet need it
+and adding it would be feature work, not a fix":
+
+- **Encoding-cache prebuild** is pan-allele-only because no other
+  command sweeps enough architectures × folds × peptides for the
+  prebuild to matter at current scale. The shared helper
+  (`prebuild_encoding_caches`) makes adoption a one-line call when
+  this changes.
+- **Layer-1 random-negative pool** is pan-allele-only because only
+  pan-allele training does the per-epoch random-negative regeneration
+  at the scale where mmap-share is meaningful. Allele-specific
+  training does similar work but at smaller per-allele scale.
+- **`torch.compile`** is off by default everywhere; opt-in via
+  `MHCFLURRY_TORCH_COMPILE=1`. The thread-count hoist is in the
+  pan-allele orchestrator only because that's where worker oversub
+  was observed. If processing/allele-specific runs ever turn on
+  `torch.compile` at scale, lift `_hoist_torchinductor_compile_threads`
+  to a shared helper.
+
+## Future tightening (not in 2.3.0)
+
+- **Layer-1 SHM for allele-specific training.** Wire
+  `--random-negative-shared-pool-dir` through
+  `train_allele_specific_models_command`.
+- **Encoding-cache prebuild for processing/allele-specific.** When
+  datasets grow large enough to make the encoding pass dominate
+  fit() time, call `prebuild_encoding_caches` from each command's
+  `run()` before forking workers.
+- **Presentation-training orchestration.** Today
+  `train_presentation_models_command` runs single-process; mirror the
+  pan-allele orchestration shape if presentation retraining becomes
+  GPU-bound.

--- a/mhcflurry/calibrate_percentile_ranks_command.py
+++ b/mhcflurry/calibrate_percentile_ranks_command.py
@@ -18,9 +18,14 @@ import tqdm  # progress bar
 
 from .class1_affinity_predictor import Class1AffinityPredictor
 from .class1_presentation_predictor import Class1PresentationPredictor
-from .common import normalize_allele_name
+from .common import (
+    amino_acid_distribution,
+    configure_logging,
+    filter_canonicalizable_alleles,
+    normalize_allele_name,
+    random_peptides,
+)
 from .encodable_sequences import EncodableSequences
-from .common import configure_logging, random_peptides, amino_acid_distribution
 from .local_parallelism import (
     add_local_parallelism_args,
     worker_pool_with_gpu_assignments_from_args,
@@ -106,46 +111,11 @@ parser.add_argument(
     nargs=2,
     help="Min and max peptide length to calibrate, inclusive. "
     "Default: %(default)s")
-def _filter_canonicalizable_alleles(alleles, log_label="alleles"):
-    """Drop alleles that ``normalize_allele_name`` refuses to canonicalize.
-
-    ``predictor.supported_alleles`` (and any user-supplied
-    ``--alleles-file``) can contain pseudogenes / null alleles /
-    questionable annotations — those are real entries in the public
-    ``allele_sequences.csv`` (which aims to be exhaustive), but
-    ``predict_to_dataframe`` raises on them mid-iteration. Filter
-    once up front so calibration doesn't crash partway through, and
-    log the dropped sample so the missing rows in the resulting
-    percent-rank table are explainable.
-
-    A local memo keeps the per-allele ``normalize_allele_name`` cost
-    bounded — the predictor's allele set is ~20K entries and
-    mhcgnomes' parse is millisecond-scale, so without caching this
-    pre-pass alone would add ~20 sec of single-threaded startup.
-    """
-    seen = {}
-
-    def _ok(allele):
-        if allele not in seen:
-            try:
-                normalize_allele_name(allele)
-                seen[allele] = True
-            except (ValueError, TypeError):
-                seen[allele] = False
-        return seen[allele]
-
-    filtered = [a for a in alleles if _ok(a)]
-    dropped = [a for a in alleles if not _ok(a)]
-    if dropped:
-        sample = ", ".join(dropped[:5]) + (
-            ", ..." if len(dropped) > 5 else ""
-        )
-        print(
-            "Skipping %d %s that fail canonicalization "
-            "(pseudogene/null/questionable): %s"
-            % (len(dropped), log_label, sample)
-        )
-    return filtered
+# Back-compat alias: tests and external callers import this name from the
+# calibrate command module. The implementation now lives in
+# ``mhcflurry.common.filter_canonicalizable_alleles`` so it can be reused
+# by the select commands and any future iteration site.
+_filter_canonicalizable_alleles = filter_canonicalizable_alleles
 
 
 def _batch_size_arg(value):

--- a/mhcflurry/class1_neural_network.py
+++ b/mhcflurry/class1_neural_network.py
@@ -234,7 +234,7 @@ _FIT_DATALOADER_DOWNGRADE_WARNED = False
 # Layer-2 SHM helpers + collation are defined in mhcflurry/shared_memory.py
 # (the canonical home). Re-exporting at module-level so callers that
 # already import them from class1_neural_network keep working.
-from .shared_memory import (  # noqa: E402
+from .shared_memory import (  # noqa: E402,F401
     FitBacking,
     array_nbytes,
     numpy_batch_collate,

--- a/mhcflurry/class1_neural_network.py
+++ b/mhcflurry/class1_neural_network.py
@@ -4090,15 +4090,33 @@ class Class1NeuralNetwork(object):
             # epoch loop reads the same cycle 0 below as a no-op.
             _, random_neg_template = random_negatives_pool.get_epoch_inputs(0)
         if shm_enabled:
-            backing = FitBacking.share(
-                x_peptide=x_dict_without_random_negatives["peptide"],
-                x_allele=x_dict_without_random_negatives.get("allele"),
-                y_encoded=y_encoded,
-                sample_weights=sample_weights_with_negatives,
-                random_negative_x_peptide_template=random_neg_template,
-                random_negative_x_allele=random_negative_x_allele_base,
-            )
-        else:
+            try:
+                backing = FitBacking.share(
+                    x_peptide=x_dict_without_random_negatives["peptide"],
+                    x_allele=x_dict_without_random_negatives.get("allele"),
+                    y_encoded=y_encoded,
+                    sample_weights=sample_weights_with_negatives,
+                    random_negative_x_peptide_template=random_neg_template,
+                    random_negative_x_allele=random_negative_x_allele_base,
+                )
+            except OSError as exc:
+                # /dev/shm exhaustion mid-fit (e.g. ENOSPC). The
+                # orchestrator should have caught this in pre-flight, but
+                # in case the per-worker estimate underran the actual
+                # need, fall back instead of crashing the task. Logged
+                # loudly so the operator can resize tmpfs.
+                import errno
+                if exc.errno not in (errno.ENOSPC, errno.ENOMEM):
+                    raise
+                logging.warning(
+                    "fit(): Layer-2 SHM allocation failed with %s — "
+                    "falling back to numpy DataLoader path for THIS fit() "
+                    "call. Resize /dev/shm or reduce concurrency to "
+                    "avoid the fallback. See docs/orchestrator.md.",
+                    exc,
+                )
+                shm_enabled = False
+        if not shm_enabled:
             backing = FitBacking.from_numpy(
                 x_peptide=x_dict_without_random_negatives["peptide"],
                 x_allele=x_dict_without_random_negatives.get("allele"),

--- a/mhcflurry/class1_neural_network.py
+++ b/mhcflurry/class1_neural_network.py
@@ -245,6 +245,33 @@ from .shared_memory import (  # noqa: E402,F401
 )
 
 
+# Auto-switch torch's tensor sharing strategy when /dev/shm is small
+# (Docker default 8 GB, etc.). Done at module-import time so any code
+# path that calls fit() — pan-allele training, allele-specific
+# training, tests, ad-hoc scripts — gets the right strategy without
+# having to remember to call the orchestrator pre-flight. Runs once
+# per process; idempotent. Override with MHCFLURRY_TORCH_SHM_AUTO=0
+# to disable the auto-switch (e.g. to test the legacy file_system path).
+if os.environ.get("MHCFLURRY_TORCH_SHM_AUTO", "1") != "0":
+    try:
+        from .local_parallelism import (  # noqa: E402
+            configure_torch_sharing_strategy_for_capacity,
+        )
+        # Best-effort estimate: use MHCFLURRY_MAX_WORKERS_PER_GPU × NUM_JOBS
+        # if exposed, else fall back to a conservative 8 workers. Worst
+        # case here is "switched when not strictly needed" — harmless.
+        _shm_estimated_workers = int(
+            os.environ.get("MHCFLURRY_NUM_JOBS_HINT")
+            or os.environ.get("NUM_JOBS")
+            or 8
+        )
+        configure_torch_sharing_strategy_for_capacity(
+            num_workers=_shm_estimated_workers
+        )
+    except Exception:  # pragma: no cover — best-effort, never fatal
+        pass
+
+
 def check_training_batch_fits(
         requested_batch_size,
         device,

--- a/mhcflurry/common.py
+++ b/mhcflurry/common.py
@@ -110,8 +110,10 @@ def filter_canonicalizable_alleles(alleles, log_label="alleles"):
                 seen[allele] = False
         return seen[allele]
 
-    filtered = [a for a in alleles if _ok(a)]
-    dropped = [a for a in alleles if not _ok(a)]
+    filtered = []
+    dropped = []
+    for a in alleles:
+        (filtered if _ok(a) else dropped).append(a)
     if dropped:
         sample = ", ".join(dropped[:5]) + (
             ", ..." if len(dropped) > 5 else ""

--- a/mhcflurry/common.py
+++ b/mhcflurry/common.py
@@ -82,6 +82,48 @@ def normalize_allele_name(
     return result.restrict_allele_fields(2).to_string()
 
 
+def filter_canonicalizable_alleles(alleles, log_label="alleles"):
+    """Drop alleles that ``normalize_allele_name`` refuses to canonicalize.
+
+    ``predictor.supported_alleles`` (and any user-supplied
+    ``--alleles-file``) can contain pseudogenes / null alleles /
+    questionable annotations — those are real entries in the public
+    ``allele_sequences.csv`` (which aims to be exhaustive), but
+    ``predict_to_dataframe`` raises on them mid-iteration. Filter
+    once up front so iteration doesn't crash partway through, and
+    log the dropped sample so the missing rows in the resulting
+    output table are explainable.
+
+    A local memo keeps the per-allele ``normalize_allele_name`` cost
+    bounded — the predictor's allele set is ~20K entries and
+    mhcgnomes' parse is millisecond-scale, so without caching this
+    pre-pass alone would add ~20 sec of single-threaded startup.
+    """
+    seen = {}
+
+    def _ok(allele):
+        if allele not in seen:
+            try:
+                normalize_allele_name(allele)
+                seen[allele] = True
+            except (ValueError, TypeError):
+                seen[allele] = False
+        return seen[allele]
+
+    filtered = [a for a in alleles if _ok(a)]
+    dropped = [a for a in alleles if not _ok(a)]
+    if dropped:
+        sample = ", ".join(dropped[:5]) + (
+            ", ..." if len(dropped) > 5 else ""
+        )
+        print(
+            "Skipping %d %s that fail canonicalization "
+            "(pseudogene/null/questionable): %s"
+            % (len(dropped), log_label, sample)
+        )
+    return filtered
+
+
 _pytorch_backend = "auto"
 _PYTORCH_BACKEND_ALIASES = {
     "default": "auto",

--- a/mhcflurry/encoding_cache.py
+++ b/mhcflurry/encoding_cache.py
@@ -47,6 +47,7 @@ from typing import Any
 
 import numpy
 import numpy.lib.format
+import pandas
 
 from .encodable_sequences import EncodableSequences
 
@@ -449,7 +450,6 @@ def deterministic_unique_peptide_list(peptide_values) -> list[str]:
     .drop_duplicates()`` preserves first-seen order — use it consistently
     in every caller.
     """
-    import pandas
     return list(pandas.Series(peptide_values).drop_duplicates())
 
 

--- a/mhcflurry/encoding_cache.py
+++ b/mhcflurry/encoding_cache.py
@@ -441,6 +441,63 @@ def _verify_cache_key_shape() -> None:
     _CACHE_KEY_SHAPE_VERIFIED = True
 
 
+def deterministic_unique_peptide_list(peptide_values) -> list[str]:
+    """Return unique peptides in first-seen order.
+
+    Stable: the orchestrator's list must match what workers compute, or
+    the cache entry's content-addressed key won't match. ``pandas.Series
+    .drop_duplicates()`` preserves first-seen order — use it consistently
+    in every caller.
+    """
+    import pandas
+    return list(pandas.Series(peptide_values).drop_duplicates())
+
+
+def prebuild_encoding_caches(
+    *,
+    cache_dir: str | os.PathLike,
+    peptides: list[str],
+    encoding_configs: list[dict],
+    label: str = "peptides",
+    log=print,
+) -> None:
+    """Pre-encode ``peptides`` for each of ``encoding_configs``.
+
+    Generic orchestrator-side helper: write one encoding cache entry per
+    (config, peptides) pair under ``cache_dir``. Run this BEFORE forking
+    training workers so each worker's first cache lookup is a hit
+    instead of triggering N workers to race-build the same entry.
+
+    The pan-allele orchestrator (``train_pan_allele_models_command``)
+    wraps this with its own pretrain/folds/master-allele-encoding glue;
+    other orchestrators (``train_processing_models_command``,
+    ``train_allele_specific_models_command``) can call it directly when
+    their datasets grow large enough to make encoding a bottleneck.
+
+    Idempotent: cache hits short-circuit. Caller is responsible for
+    de-duplicating ``encoding_configs`` (typically by hashing each
+    config dict's items) — duplicates here only cost a no-op cache
+    check, not a re-encode.
+    """
+    for cfg in encoding_configs:
+        params = EncodingParams(**cfg)
+        cache = EncodingCache(cache_dir=str(cache_dir), params=params)
+        if cache.is_complete_for(peptides):
+            log(
+                f"Encoding cache hit ({label}): {cache.entry_path(peptides)} "
+                f"({len(peptides)} peptides)"
+            )
+            continue
+        log(
+            f"Building encoding cache ({label}) for params "
+            f"{params.to_kwargs()} ({len(peptides)} peptides) "
+            f"at {cache.entry_path(peptides)}..."
+        )
+        t0 = time.time()
+        cache.ensure_built(peptides)
+        log(f"Encoding cache built ({label}) in {time.time() - t0:.1f}s.")
+
+
 def make_prepopulated_encodable_sequences(
     peptides: list[str] | numpy.ndarray,
     encoded_rows: numpy.ndarray,

--- a/mhcflurry/local_parallelism.py
+++ b/mhcflurry/local_parallelism.py
@@ -289,6 +289,91 @@ def fit_shm_capacity_check(num_workers, per_fit_gb=None, shm_dir="/dev/shm"):
     }
 
 
+def configure_torch_sharing_strategy_for_capacity(
+    num_workers,
+    per_fit_gb=None,
+    shm_dir="/dev/shm",
+):
+    """Switch torch's tensor-sharing strategy to ``file_descriptor`` when
+    ``/dev/shm`` is too small for the default ``file_system`` strategy.
+
+    Background: torch's default ``file_system`` strategy backs shared
+    tensors with POSIX-shm files in ``/dev/shm``. With many fit() workers
+    × multi-GB tensors, an 8 GB Docker-default ``/dev/shm`` runs out and
+    ``share_memory_()`` crashes with ``OSError [Errno 28]``. The
+    ``file_descriptor`` strategy passes anonymous FDs over Unix sockets
+    instead — no ``/dev/shm`` use at all, just an FD per shared tensor.
+
+    Returns one of:
+      * ``"unchanged"`` — capacity is fine OR no torch available; default
+        strategy retained.
+      * ``"file_descriptor"`` — capacity tight, switched. Layer-2 SHM
+        works without ``/dev/shm`` headroom.
+      * ``"failed"`` — capacity tight but switch failed (e.g. torch
+        already initialized sharing); caller should fall back to
+        disabling Layer-2 SHM.
+
+    Idempotent. Safe to call multiple times. Bumps ``RLIMIT_NOFILE`` to
+    cover the FDs the file_descriptor strategy needs (typically a few
+    hundred for 16-worker configs).
+
+    Should be called BEFORE any worker spawns or any tensor is shared,
+    typically from the orchestrator's pre-flight + from
+    ``class1_neural_network`` at module import time so fit() workers
+    that don't go through the orchestrator hook (tests, allele-specific
+    training, etc.) still benefit.
+    """
+    result = fit_shm_capacity_check(num_workers, per_fit_gb, shm_dir)
+    if result["safe"]:
+        return "unchanged"
+
+    try:
+        import torch.multiprocessing as torch_mp
+    except ImportError:
+        return "unchanged"
+
+    try:
+        current = torch_mp.get_sharing_strategy()
+    except RuntimeError:
+        # Torch unable to query; bail.
+        return "unchanged"
+
+    if current == "file_descriptor":
+        # Already switched (idempotent path).
+        return "file_descriptor"
+
+    try:
+        torch_mp.set_sharing_strategy("file_descriptor")
+    except (RuntimeError, ValueError, AssertionError):
+        # Strategy may be locked once any tensor has been shared, or the
+        # platform may not support file_descriptor (e.g. macOS torch
+        # only ships file_system). Fall through to caller's fallback.
+        return "failed"
+
+    # file_descriptor needs ~num_workers × num_dataloader_workers × N FDs
+    # per fit. Default ulimit -n is 1024 on most Linux distros, which is
+    # close to the line for 16-worker configs. Raise to 16384 if the
+    # hard cap allows.
+    try:
+        import resource
+        soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+        target = min(16384, hard)
+        if soft < target:
+            resource.setrlimit(resource.RLIMIT_NOFILE, (target, hard))
+    except (ValueError, OSError, ImportError):
+        # macOS sometimes refuses RLIMIT_NOFILE bumps; that's fine,
+        # macOS doesn't have /dev/shm and won't hit this path anyway.
+        pass
+
+    print(
+        "torch.multiprocessing: switched sharing strategy to "
+        "'file_descriptor' (was '%s'). Layer-2 SHM tensors will now use "
+        "anonymous FDs instead of /dev/shm; the capacity guard above is "
+        "no longer load-bearing." % current
+    )
+    return "file_descriptor"
+
+
 def hoist_torchinductor_compile_threads(args):
     """Cap ``TORCHINDUCTOR_COMPILE_THREADS`` based on parallel-worker count.
 

--- a/mhcflurry/local_parallelism.py
+++ b/mhcflurry/local_parallelism.py
@@ -170,6 +170,56 @@ def resolve_max_workers_per_gpu(args):
     return resolved
 
 
+# Inductor's compile worker pool defaults to ``os.cpu_count()``; that's
+# fine for one process but stacks badly when N fit() workers each spawn
+# their own pool. Match the same SM-scheduler-style cap used for
+# ``auto_max_workers_per_gpu``: 4 is enough compile parallelism to keep
+# Inductor useful without amplifying jitter across N workers.
+_INDUCTOR_THREAD_HARD_CAP = 4
+
+
+def hoist_torchinductor_compile_threads(args):
+    """Cap ``TORCHINDUCTOR_COMPILE_THREADS`` based on parallel-worker count.
+
+    ``torch.compile`` (when enabled via ``MHCFLURRY_TORCH_COMPILE=1``)
+    spins up an inductor compile worker pool that defaults to
+    ``os.cpu_count()`` threads. With N fit() workers each running
+    their own compile pool, an 8-job × 64-core box would spawn 512
+    compile threads — orders of magnitude over-subscribed.
+
+    The orchestrator owns "how many workers will exist", so it owns
+    the env knob too: set once before forking, every worker inherits.
+    Skips the hoist when the user has already pinned the value or when
+    ``MHCFLURRY_TORCH_COMPILE`` isn't on. Cluster workers running on
+    other hosts inherit nothing — but they share the same kernel cache
+    via inductor's content-addressed FX cache, so per-worker compile
+    counts there are bounded by cache hits, not by env.
+
+    Lives here (not in any one ``train_*_command`` module) so processing,
+    allele-specific, and any future train command can call it the same
+    way.
+    """
+    if os.environ.get("MHCFLURRY_TORCH_COMPILE", "0") != "1":
+        # No compile = no compile pool to size; leave env untouched.
+        return
+    if "TORCHINDUCTOR_COMPILE_THREADS" in os.environ:
+        # User pinned explicitly; don't second-guess.
+        print(
+            "torch.compile: TORCHINDUCTOR_COMPILE_THREADS=%s "
+            "(user-pinned, orchestrator hoist skipped)"
+            % os.environ["TORCHINDUCTOR_COMPILE_THREADS"]
+        )
+        return
+    num_jobs = max(int(getattr(args, "num_jobs", 0) or 0), 1)
+    cpu_count_ = os.cpu_count() or 1
+    threads = max(1, min(_INDUCTOR_THREAD_HARD_CAP, cpu_count_ // num_jobs))
+    os.environ["TORCHINDUCTOR_COMPILE_THREADS"] = str(threads)
+    print(
+        "torch.compile: hoisted TORCHINDUCTOR_COMPILE_THREADS=%d "
+        "(num_jobs=%d, cpu_count=%d)" % (threads, num_jobs, cpu_count_)
+    )
+
+
 # ---- Non-daemonic worker pool --------------------------------------------
 #
 # By default ``multiprocessing.Pool`` spawns daemon workers, and daemon

--- a/mhcflurry/local_parallelism.py
+++ b/mhcflurry/local_parallelism.py
@@ -178,6 +178,117 @@ def resolve_max_workers_per_gpu(args):
 _INDUCTOR_THREAD_HARD_CAP = 4
 
 
+# Estimated per-fit() Layer-2 SHM footprint. Empirically ~2–3 GB for the
+# pan-allele MLP at the standard data scale (x_peptide + x_allele +
+# y_encoded + sample_weights + random_negative buffers). We round up to
+# 4 GB so the safety check has margin for outliers (longer max_length,
+# bigger random-negative pool, future hyperparameter shifts).
+_PER_FIT_SHM_FOOTPRINT_GB_DEFAULT = 4.0
+
+
+def shm_free_gb(shm_dir="/dev/shm"):
+    """Return free space (gigabytes) on ``shm_dir`` tmpfs, or ``None`` if unknown.
+
+    Returns ``None`` (not 0) on platforms without ``/dev/shm`` so callers
+    can distinguish "no /dev/shm" from "/dev/shm is full". macOS has no
+    /dev/shm; container runtimes always do.
+    """
+    if not os.path.isdir(shm_dir):
+        return None
+    try:
+        st = os.statvfs(shm_dir)
+    except OSError:
+        return None
+    return (st.f_bavail * st.f_frsize) / (1024 ** 3)
+
+
+def shm_total_gb(shm_dir="/dev/shm"):
+    """Return total size (gigabytes) of ``shm_dir`` tmpfs, or ``None``."""
+    if not os.path.isdir(shm_dir):
+        return None
+    try:
+        st = os.statvfs(shm_dir)
+    except OSError:
+        return None
+    return (st.f_blocks * st.f_frsize) / (1024 ** 3)
+
+
+def fit_shm_capacity_check(num_workers, per_fit_gb=None, shm_dir="/dev/shm"):
+    """Decide whether Layer-2 SHM is safe at this concurrency.
+
+    Returns a dict::
+
+        {"safe": bool,
+         "shm_total_gb": float | None,
+         "shm_free_gb": float | None,
+         "estimated_required_gb": float,
+         "message": str}
+
+    Used by the orchestrator pre-fork (loud warning) and by fit()'s
+    per-worker auto-detect (silent fallback). The threshold:
+    ``num_workers * per_fit_gb * 1.5`` (50% margin for transient peaks,
+    DataLoader semaphores, OpenMP per-process registrations).
+
+    On platforms without /dev/shm (macOS), returns ``safe=True`` —
+    PyTorch's file_descriptor sharing strategy bypasses the tmpfs so
+    no capacity check applies.
+    """
+    if per_fit_gb is None:
+        per_fit_gb = float(
+            os.environ.get(
+                "MHCFLURRY_PER_FIT_SHM_FOOTPRINT_GB",
+                _PER_FIT_SHM_FOOTPRINT_GB_DEFAULT,
+            )
+        )
+    free_gb = shm_free_gb(shm_dir)
+    total_gb = shm_total_gb(shm_dir)
+    required_gb = max(int(num_workers), 1) * per_fit_gb * 1.5
+    if free_gb is None:
+        # No /dev/shm visible; assume PyTorch's file_descriptor strategy
+        # will handle sharing. Caller treats as safe.
+        return {
+            "safe": True,
+            "shm_total_gb": total_gb,
+            "shm_free_gb": free_gb,
+            "estimated_required_gb": required_gb,
+            "message": (
+                "%s not present; skipping Layer-2 SHM capacity check"
+                % shm_dir
+            ),
+        }
+    safe = free_gb >= required_gb
+    if safe:
+        message = (
+            "Layer-2 SHM capacity OK: %s has %.1f GB free / %.1f GB total, "
+            "estimated need %.1f GB (%d workers × %.1f GB/fit × 1.5 margin)"
+            % (
+                shm_dir, free_gb, total_gb or 0.0, required_gb,
+                num_workers, per_fit_gb,
+            )
+        )
+    else:
+        message = (
+            "Layer-2 SHM capacity TIGHT: %s has %.1f GB free / %.1f GB "
+            "total, estimated need %.1f GB (%d workers × %.1f GB/fit × "
+            "1.5 margin). Workers will fall back to numpy DataLoader path "
+            "(slower, no per-worker share). To re-enable: bump tmpfs "
+            "(e.g. relaunch the container with --shm-size=64g) or reduce "
+            "--num-jobs / --max-workers-per-gpu. Force-on with "
+            "MHCFLURRY_FIT_DATALOADER_SHM=1 (will OOM mid-fit)."
+            % (
+                shm_dir, free_gb, total_gb or 0.0, required_gb,
+                num_workers, per_fit_gb,
+            )
+        )
+    return {
+        "safe": safe,
+        "shm_total_gb": total_gb,
+        "shm_free_gb": free_gb,
+        "estimated_required_gb": required_gb,
+        "message": message,
+    }
+
+
 def hoist_torchinductor_compile_threads(args):
     """Cap ``TORCHINDUCTOR_COMPILE_THREADS`` based on parallel-worker count.
 

--- a/mhcflurry/select_allele_specific_models_command.py
+++ b/mhcflurry/select_allele_specific_models_command.py
@@ -20,9 +20,13 @@ from sklearn.metrics import roc_auc_score
 import tqdm  # progress bar
 
 from .class1_affinity_predictor import Class1AffinityPredictor
-from .common import normalize_allele_name
+from .common import (
+    configure_logging,
+    filter_canonicalizable_alleles,
+    normalize_allele_name,
+    random_peptides,
+)
 from .encodable_sequences import EncodableSequences
-from .common import configure_logging, random_peptides
 from .local_parallelism import worker_pool_with_gpu_assignments_from_args, add_local_parallelism_args
 from .regression_target import from_ic50
 
@@ -199,9 +203,15 @@ def run(argv=sys.argv[1:]):
     print("Loaded: %s" % input_predictor)
 
     if args.allele:
+        # User-supplied alleles must canonicalize; mismatch is a config error.
         alleles = [normalize_allele_name(a) for a in args.allele]
     else:
-        alleles = input_predictor.supported_alleles
+        # Pre-filter pseudogene / null / questionable supported_alleles so a
+        # single bad row doesn't crash the parallel selection mid-fold.
+        alleles = filter_canonicalizable_alleles(
+            input_predictor.supported_alleles,
+            log_label="supported_alleles",
+        )
 
     metadata_dfs = {}
     if args.data:

--- a/mhcflurry/select_pan_allele_models_command.py
+++ b/mhcflurry/select_pan_allele_models_command.py
@@ -23,7 +23,7 @@ import tqdm  # progress bar
 from .class1_affinity_predictor import Class1AffinityPredictor
 from .encodable_sequences import EncodableSequences
 from .allele_encoding import AlleleEncoding
-from .common import configure_logging
+from .common import configure_logging, filter_canonicalizable_alleles
 from .local_parallelism import (
     worker_pool_with_gpu_assignments_from_args,
     add_local_parallelism_args)
@@ -151,7 +151,13 @@ def run(argv=sys.argv[1:]):
         args.models_dir, optimization_level=0)
     print("Loaded: %s" % input_predictor)
 
-    alleles = input_predictor.supported_alleles
+    # Filter pseudogene / null / questionable alleles up front so a single
+    # bad row in ``input_predictor.supported_alleles`` doesn't crash the
+    # parallel selection pass mid-fold. Same helper that calibrate uses.
+    alleles = filter_canonicalizable_alleles(
+        input_predictor.supported_alleles,
+        log_label="supported_alleles",
+    )
     (min_peptide_length, max_peptide_length) = (
         input_predictor.supported_peptide_lengths)
 

--- a/mhcflurry/shared_memory.py
+++ b/mhcflurry/shared_memory.py
@@ -33,8 +33,8 @@ from __future__ import annotations
 import hashlib
 import logging
 import os
-from dataclasses import dataclass, field, replace
-from typing import Any, Callable, Dict, List, Optional
+from dataclasses import dataclass
+from typing import Any, Dict
 
 import numpy
 import torch

--- a/mhcflurry/train_pan_allele_models_command.py
+++ b/mhcflurry/train_pan_allele_models_command.py
@@ -38,7 +38,9 @@ from .encodable_sequences import EncodableSequences
 from .encoding_cache import (
     EncodingCache,
     EncodingParams,
+    deterministic_unique_peptide_list,
     make_prepopulated_encodable_sequences,
+    prebuild_encoding_caches,
 )
 from .regression_target import from_ic50
 
@@ -1125,7 +1127,7 @@ def _initialize_encoding_cache(args, all_work_items):
             }
 
     df = GLOBAL_DATA["train_data"]
-    unique_peptides = _deterministic_unique_peptide_list(df.peptide.values)
+    unique_peptides = deterministic_unique_peptide_list(df.peptide.values)
     unique_peptide_to_idx = {
         peptide: i for i, peptide in enumerate(unique_peptides)
     }
@@ -1139,19 +1141,12 @@ def _initialize_encoding_cache(args, all_work_items):
     )
     del unique_peptide_to_idx
 
-    for cfg in configs_seen.values():
-        params = EncodingParams(**cfg)
-        cache = EncodingCache(cache_dir=cache_dir, params=params)
-        if cache.is_complete_for(unique_peptides):
-            print(f"Encoding cache hit: {cache.entry_path(unique_peptides)} "
-                  f"({len(unique_peptides)} peptides)")
-            continue
-        print(f"Building encoding cache for params "
-              f"{params.to_kwargs()} ({len(unique_peptides)} peptides) "
-              f"at {cache.entry_path(unique_peptides)}...")
-        t0 = time.time()
-        cache.ensure_built(unique_peptides)
-        print(f"Encoding cache built in {time.time() - t0:.1f}s.")
+    prebuild_encoding_caches(
+        cache_dir=cache_dir,
+        peptides=unique_peptides,
+        encoding_configs=list(configs_seen.values()),
+        label="train",
+    )
 
     GLOBAL_DATA["encoding_cache_dir"] = str(cache_dir)
     # Per-arch params lookup: hyperparameters dict doesn't change pickle size
@@ -1175,20 +1170,12 @@ def _initialize_encoding_cache(args, all_work_items):
     pretrain_data_path = getattr(args, "pretrain_data", None)
     if pretrain_data_path:
         pretrain_peptides = _read_pretrain_peptide_list(pretrain_data_path)
-        for cfg in configs_seen.values():
-            params = EncodingParams(**cfg)
-            cache = EncodingCache(cache_dir=cache_dir, params=params)
-            if cache.is_complete_for(pretrain_peptides):
-                print(f"Pretrain encoding cache hit: "
-                      f"{cache.entry_path(pretrain_peptides)} "
-                      f"({len(pretrain_peptides)} peptides)")
-                continue
-            print(f"Building pretrain encoding cache for params "
-                  f"{params.to_kwargs()} ({len(pretrain_peptides)} peptides) "
-                  f"at {cache.entry_path(pretrain_peptides)}...")
-            t0 = time.time()
-            cache.ensure_built(pretrain_peptides)
-            print(f"Pretrain encoding cache built in {time.time() - t0:.1f}s.")
+        prebuild_encoding_caches(
+            cache_dir=cache_dir,
+            peptides=pretrain_peptides,
+            encoding_configs=list(configs_seen.values()),
+            label="pretrain",
+        )
         # Use the same AlleleEncoding the workers will use
         # (``allele_encoding``, restricted to alleles with training data),
         # NOT ``full_allele_encoding``. ``_get_pretrain_allele_info``
@@ -1218,16 +1205,6 @@ def _initialize_encoding_cache(args, all_work_items):
             )
 
 
-def _deterministic_unique_peptide_list(peptide_values):
-    """Return unique peptides in first-seen order.
-
-    Must be stable: orchestrator's list must match what workers compute, or
-    the cache key (which hashes the list) won't match. pandas.Series
-    .drop_duplicates() preserves first-seen order — use it consistently.
-    """
-    return list(pandas.Series(peptide_values).drop_duplicates())
-
-
 def _read_pretrain_peptide_list(filename):
     """Read only the peptide column (index) from the pretrain CSV.
 
@@ -1238,6 +1215,46 @@ def _read_pretrain_peptide_list(filename):
     # Reading only usecols=[0] makes pandas parse just the peptide column.
     peptide_series = pandas.read_csv(filename, index_col=0, usecols=[0]).index
     return list(peptide_series)
+
+
+def _hoist_torchinductor_compile_threads(args):
+    """Cap ``TORCHINDUCTOR_COMPILE_THREADS`` based on parallel-worker count.
+
+    ``torch.compile`` (when enabled via ``MHCFLURRY_TORCH_COMPILE=1``)
+    spins up an inductor compile worker pool that defaults to
+    ``os.cpu_count()`` threads. With N fit() workers each running
+    their own compile pool, an 8-job × 64-core box would spawn 512
+    compile threads — orders of magnitude over-subscribed.
+
+    The orchestrator owns "how many workers will exist", so it owns
+    the env knob too: set once before forking, every worker inherits.
+    Skips the hoist when the user has already pinned the value or when
+    ``MHCFLURRY_TORCH_COMPILE`` isn't on. Cluster workers running on
+    other hosts inherit nothing — but they share the same kernel cache
+    via inductor's content-addressed FX cache, so per-worker compile
+    counts there are bounded by cache hits, not by env.
+    """
+    if os.environ.get("MHCFLURRY_TORCH_COMPILE", "0") != "1":
+        # No compile = no compile pool to size; leave env untouched.
+        return
+    if "TORCHINDUCTOR_COMPILE_THREADS" in os.environ:
+        # User pinned explicitly; don't second-guess.
+        print(
+            "torch.compile: TORCHINDUCTOR_COMPILE_THREADS=%s "
+            "(user-pinned, orchestrator hoist skipped)"
+            % os.environ["TORCHINDUCTOR_COMPILE_THREADS"]
+        )
+        return
+    num_jobs = max(int(getattr(args, "num_jobs", 0) or 0), 1)
+    cpu_count = os.cpu_count() or 1
+    # Reserve at least 1 thread per worker; cap at 4 to keep compile
+    # parallelism useful without amplifying jitter.
+    threads = max(1, min(4, cpu_count // num_jobs))
+    os.environ["TORCHINDUCTOR_COMPILE_THREADS"] = str(threads)
+    print(
+        "torch.compile: hoisted TORCHINDUCTOR_COMPILE_THREADS=%d "
+        "(num_jobs=%d, cpu_count=%d)" % (threads, num_jobs, cpu_count)
+    )
 
 
 def _local_pool_workers_inherit_global_data(worker_pool=None):
@@ -1268,6 +1285,12 @@ def train_models(args):
 
     all_work_items = GLOBAL_DATA["work_items"]
 
+    # Orchestrator-level env tuning: cap inductor's compile worker pool so
+    # N concurrent fit() workers don't each spawn os.cpu_count() compile
+    # threads and thrash the box. Set BEFORE forking workers so each
+    # inherits the value. See docs/orchestrator.md.
+    _hoist_torchinductor_compile_threads(args)
+
     # Optionally pre-build the shared BLOSUM62 encoding cache. Orchestrator
     # does the (single-threaded) encoding pass once; workers mmap the result.
     # See mhcflurry/encoding_cache.py and issue openvax/mhcflurry#268.
@@ -1279,6 +1302,22 @@ def train_models(args):
     # work item's fit() will look up its own pool dir at task start.
     # See mhcflurry/shared_memory.py for the layered SHM design.
     if getattr(args, "random_negative_shared_pool_dir", None):
+        # Cluster mode: workers run on (possibly) other nodes. The mmap
+        # pool dir must be reachable from every worker's filesystem, or
+        # they will silently fall through to the in-process fallback.
+        # Loud-warn here rather than gating: NFS is the common cluster
+        # shape and gating would surprise users running on shared FS.
+        if getattr(args, "cluster_parallelism", False):
+            print(
+                "WARNING: --random-negative-shared-pool-dir is set with "
+                "--cluster-parallelism. The pool dir (%s) MUST be on a "
+                "filesystem reachable from every cluster worker (typically "
+                "the same NFS as --cluster-results-workdir) or workers will "
+                "fail to mmap and fall back to the in-process pool, "
+                "negating the speedup." % os.path.abspath(
+                    args.random_negative_shared_pool_dir
+                )
+            )
         _initialize_shared_random_negative_pools(args, all_work_items)
     complete_work_item_names = [
         network.fit_info[-1]["training_info"]["work_item_name"] for network in
@@ -1418,7 +1457,7 @@ def _build_train_peptides(
     unique_peptides = constant_data.get("encoding_cache_unique_peptides")
     if unique_peptides is None:
         df = constant_data["train_data"]
-        unique_peptides = _deterministic_unique_peptide_list(df.peptide.values)
+        unique_peptides = deterministic_unique_peptide_list(df.peptide.values)
     cache_entry_path = cache.ensure_built(unique_peptides)
     encoded_all = numpy.load(
         join(str(cache_entry_path), "encoded.npy"),

--- a/mhcflurry/train_pan_allele_models_command.py
+++ b/mhcflurry/train_pan_allele_models_command.py
@@ -28,8 +28,10 @@ from .class1_neural_network import Class1NeuralNetwork
 from .common import configure_logging, normalize_allele_name
 from .local_parallelism import (
     add_local_parallelism_args,
+    call_wrapped_kwargs,
+    hoist_torchinductor_compile_threads,
     worker_pool_with_gpu_assignments_from_args,
-    call_wrapped_kwargs)
+)
 from .cluster_parallelism import (
     add_cluster_parallelism_args,
     cluster_results_from_args)
@@ -1217,44 +1219,9 @@ def _read_pretrain_peptide_list(filename):
     return list(peptide_series)
 
 
-def _hoist_torchinductor_compile_threads(args):
-    """Cap ``TORCHINDUCTOR_COMPILE_THREADS`` based on parallel-worker count.
-
-    ``torch.compile`` (when enabled via ``MHCFLURRY_TORCH_COMPILE=1``)
-    spins up an inductor compile worker pool that defaults to
-    ``os.cpu_count()`` threads. With N fit() workers each running
-    their own compile pool, an 8-job × 64-core box would spawn 512
-    compile threads — orders of magnitude over-subscribed.
-
-    The orchestrator owns "how many workers will exist", so it owns
-    the env knob too: set once before forking, every worker inherits.
-    Skips the hoist when the user has already pinned the value or when
-    ``MHCFLURRY_TORCH_COMPILE`` isn't on. Cluster workers running on
-    other hosts inherit nothing — but they share the same kernel cache
-    via inductor's content-addressed FX cache, so per-worker compile
-    counts there are bounded by cache hits, not by env.
-    """
-    if os.environ.get("MHCFLURRY_TORCH_COMPILE", "0") != "1":
-        # No compile = no compile pool to size; leave env untouched.
-        return
-    if "TORCHINDUCTOR_COMPILE_THREADS" in os.environ:
-        # User pinned explicitly; don't second-guess.
-        print(
-            "torch.compile: TORCHINDUCTOR_COMPILE_THREADS=%s "
-            "(user-pinned, orchestrator hoist skipped)"
-            % os.environ["TORCHINDUCTOR_COMPILE_THREADS"]
-        )
-        return
-    num_jobs = max(int(getattr(args, "num_jobs", 0) or 0), 1)
-    cpu_count = os.cpu_count() or 1
-    # Reserve at least 1 thread per worker; cap at 4 to keep compile
-    # parallelism useful without amplifying jitter.
-    threads = max(1, min(4, cpu_count // num_jobs))
-    os.environ["TORCHINDUCTOR_COMPILE_THREADS"] = str(threads)
-    print(
-        "torch.compile: hoisted TORCHINDUCTOR_COMPILE_THREADS=%d "
-        "(num_jobs=%d, cpu_count=%d)" % (threads, num_jobs, cpu_count)
-    )
+# Back-compat alias for any callers / tests that imported the helper from
+# this module before it was hoisted to ``local_parallelism``.
+_hoist_torchinductor_compile_threads = hoist_torchinductor_compile_threads
 
 
 def _local_pool_workers_inherit_global_data(worker_pool=None):
@@ -1289,7 +1256,7 @@ def train_models(args):
     # N concurrent fit() workers don't each spawn os.cpu_count() compile
     # threads and thrash the box. Set BEFORE forking workers so each
     # inherits the value. See docs/orchestrator.md.
-    _hoist_torchinductor_compile_threads(args)
+    hoist_torchinductor_compile_threads(args)
 
     # Optionally pre-build the shared BLOSUM62 encoding cache. Orchestrator
     # does the (single-threaded) encoding pass once; workers mmap the result.

--- a/mhcflurry/train_pan_allele_models_command.py
+++ b/mhcflurry/train_pan_allele_models_command.py
@@ -29,6 +29,7 @@ from .common import configure_logging, normalize_allele_name
 from .local_parallelism import (
     add_local_parallelism_args,
     call_wrapped_kwargs,
+    fit_shm_capacity_check,
     hoist_torchinductor_compile_threads,
     worker_pool_with_gpu_assignments_from_args,
 )
@@ -1224,6 +1225,55 @@ def _read_pretrain_peptide_list(filename):
 _hoist_torchinductor_compile_threads = hoist_torchinductor_compile_threads
 
 
+def _preflight_shm_capacity(args):
+    """Pre-fork advisory + auto-fallback for /dev/shm capacity.
+
+    Runs once in the orchestrator before workers are spawned. Computes
+    the expected Layer-2 SHM footprint from ``--num-jobs`` and a
+    per-fit estimate, compares to ``/dev/shm`` free space, and:
+
+    * Always prints a one-line summary (free, total, required).
+    * If insufficient AND the user hasn't force-pinned
+      ``MHCFLURRY_FIT_DATALOADER_SHM``, sets it to ``"0"`` so workers
+      fall back to the numpy DataLoader path. Loud-warn naming the
+      remediation (resize tmpfs, reduce concurrency).
+    * If the user has force-pinned to ``"1"``, leaves the env alone but
+      escalates the warning so the OOM is at least expected.
+
+    Skipped entirely when ``num_jobs == 0`` (serial run; no DataLoader
+    workers; no Layer-2 SHM relevant).
+    """
+    num_jobs = int(getattr(args, "num_jobs", 0) or 0)
+    if num_jobs <= 0:
+        return  # serial / cluster — capacity check is per-node and not actionable here.
+    result = fit_shm_capacity_check(num_workers=num_jobs)
+    print(result["message"])
+    if result["safe"]:
+        return
+    pinned = os.environ.get("MHCFLURRY_FIT_DATALOADER_SHM")
+    if pinned == "1":
+        # User force-on. Escalate warning; respect their choice.
+        print(
+            "WARNING: MHCFLURRY_FIT_DATALOADER_SHM=1 is force-pinned despite "
+            "tight /dev/shm. Workers WILL crash partway through fit() with "
+            "OSError [Errno 28]. Unset the env var to enable auto-fallback."
+        )
+        return
+    if pinned == "0":
+        # User force-off — already disabled; nothing to do.
+        return
+    # Auto-disable Layer-2 SHM for this run.
+    os.environ["MHCFLURRY_FIT_DATALOADER_SHM"] = "0"
+    print(
+        "Auto-disabling Layer-2 SHM for this run "
+        "(MHCFLURRY_FIT_DATALOADER_SHM=0). Per-fit DataLoader will use the "
+        "numpy backing path; per-worker pickling cost is paid once per "
+        "epoch instead of being amortized via shared tensors. Throughput "
+        "impact: roughly 10-30%% slower than the SHM path on a "
+        "large-/dev/shm box."
+    )
+
+
 def _local_pool_workers_inherit_global_data(worker_pool=None):
     """Return True when local Pool workers inherit GLOBAL_DATA by fork."""
     context = getattr(worker_pool, "_ctx", None)
@@ -1257,6 +1307,13 @@ def train_models(args):
     # threads and thrash the box. Set BEFORE forking workers so each
     # inherits the value. See docs/orchestrator.md.
     hoist_torchinductor_compile_threads(args)
+
+    # Layer-2 SHM capacity pre-flight. With small /dev/shm (8 GB Docker
+    # default) + many workers, share_memory_() will OOM mid-fit with a
+    # cryptic OSError. Check up front and (a) print a loud advisory,
+    # (b) auto-disable Layer-2 SHM unless the user has force-pinned
+    # MHCFLURRY_FIT_DATALOADER_SHM=1. See docs/orchestrator.md.
+    _preflight_shm_capacity(args)
 
     # Optionally pre-build the shared BLOSUM62 encoding cache. Orchestrator
     # does the (single-threaded) encoding pass once; workers mmap the result.

--- a/mhcflurry/train_pan_allele_models_command.py
+++ b/mhcflurry/train_pan_allele_models_command.py
@@ -29,6 +29,7 @@ from .common import configure_logging, normalize_allele_name
 from .local_parallelism import (
     add_local_parallelism_args,
     call_wrapped_kwargs,
+    configure_torch_sharing_strategy_for_capacity,
     fit_shm_capacity_check,
     hoist_torchinductor_compile_threads,
     worker_pool_with_gpu_assignments_from_args,
@@ -1262,7 +1263,18 @@ def _preflight_shm_capacity(args):
     if pinned == "0":
         # User force-off — already disabled; nothing to do.
         return
-    # Auto-disable Layer-2 SHM for this run.
+    # Tight /dev/shm with no user pin: try torch's file_descriptor sharing
+    # strategy first. That bypasses /dev/shm entirely (anonymous FDs over
+    # Unix sockets), preserving Layer-2 SHM on small-tmpfs containers like
+    # the Docker default (8 GB). Only fall back to disabling Layer-2 SHM
+    # when the strategy switch fails.
+    if os.environ.get("MHCFLURRY_TORCH_SHM_AUTO", "1") != "0":
+        switch = configure_torch_sharing_strategy_for_capacity(
+            num_workers=num_jobs
+        )
+        if switch == "file_descriptor":
+            return
+    # Auto-disable Layer-2 SHM as the conservative fallback.
     os.environ["MHCFLURRY_FIT_DATALOADER_SHM"] = "0"
     print(
         "Auto-disabling Layer-2 SHM for this run "

--- a/scripts/dev/relocate_run_outputs.sh
+++ b/scripts/dev/relocate_run_outputs.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Relocate run-output directories outside the repo so they aren't
+# rsync'd to remote training boxes on every launch.
+#
+# Background: ``runplz``'s rsync_up exclude list is hardcoded
+# (.git, .venv, __pycache__, *.egg-info, build, dist, out, secrets).
+# Project-specific output dirs like ``brev_runs/`` (~15 GB) and
+# ``results/`` ride along on every launch unless they're moved
+# outside the rsync source tree. ``rsync -a`` ships symlinks as
+# symlinks (not the dereferenced target), so a relocated-and-
+# symlinked dir uploads as ~zero bytes.
+#
+# Usage:
+#   bash scripts/dev/relocate_run_outputs.sh        # dry-run (default)
+#   bash scripts/dev/relocate_run_outputs.sh --apply
+#
+# After running with --apply:
+#   * brev_runs/  → ~/mhcflurry-brev-runs/, symlinked back
+#   * results/    → ~/mhcflurry-results/,   symlinked back
+# All existing tooling continues to read brev_runs/<run>/ paths
+# unchanged via the symlink.
+#
+# Idempotent: if a path is already a symlink, this script no-ops.
+# Safe-by-default: the move is a hardlink-friendly ``mv`` between
+# files on the same filesystem; if the target exists we abort
+# rather than clobber.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+APPLY=0
+if [ "${1:-}" = "--apply" ]; then
+    APPLY=1
+fi
+
+relocate_one() {
+    local rel="$1"
+    local target="$2"
+    local src="$REPO_ROOT/$rel"
+
+    if [ -L "$src" ]; then
+        printf "  skip %s (already a symlink → %s)\n" "$rel" "$(readlink "$src")"
+        return 0
+    fi
+    if [ ! -d "$src" ]; then
+        printf "  skip %s (not present)\n" "$rel"
+        return 0
+    fi
+    if [ -e "$target" ]; then
+        printf "  ABORT %s: relocation target %s already exists; "\
+"merge manually before re-running\n" "$rel" "$target" >&2
+        return 1
+    fi
+
+    if [ "$APPLY" = "1" ]; then
+        mv "$src" "$target"
+        ln -s "$target" "$src"
+        printf "  moved %s → %s and symlinked back\n" "$rel" "$target"
+    else
+        local size
+        size="$(du -sh "$src" 2>/dev/null | cut -f1)"
+        printf "  would move %s (%s) → %s and symlink back\n" "$rel" "$size" "$target"
+    fi
+}
+
+mode_label="DRY RUN"
+if [ "$APPLY" = "1" ]; then
+    mode_label="APPLY"
+fi
+echo "[$mode_label] Relocating run-output dirs outside $REPO_ROOT"
+relocate_one "brev_runs" "$HOME/mhcflurry-brev-runs"
+relocate_one "results"   "$HOME/mhcflurry-results"
+
+if [ "$APPLY" != "1" ]; then
+    echo
+    echo "Re-run with --apply to actually move and symlink."
+fi

--- a/scripts/training/pan_allele_release_exact.sh
+++ b/scripts/training/pan_allele_release_exact.sh
@@ -222,13 +222,26 @@ echo "Detected GPUS: $GPUS"
 PROCESSORS=$(getconf _NPROCESSORS_ONLN)
 echo "Detected processors: $PROCESSORS"
 
-# Per-worker peak is 16-22 GB on mhcflurry pan-allele training (observed on
-# A100-80GB). Safe: 2 on 80GB, 1 on 40GB. 4 OOMs on 80GB.
-MAX_WORKERS_PER_GPU="${MAX_WORKERS_PER_GPU:-2}"
+# Default to "auto" so the orchestrator's auto_max_workers_per_gpu
+# picks based on detected free VRAM. Per-worker peak is 16-22 GB on
+# mhcflurry pan-allele training: ``auto`` lands at 2 on 80GB cards
+# and 1 on 40GB cards. Override with MAX_WORKERS_PER_GPU=N (or
+# explicitly "auto") to pin.
+MAX_WORKERS_PER_GPU="${MAX_WORKERS_PER_GPU:-auto}"
+# NUM_JOBS arithmetic: bash can't multiply "auto", so fall back to a
+# conservative 2 for the Pool size when the user picked auto. The Python
+# orchestrator still applies the actual auto_max_workers_per_gpu cap to
+# the GPU-assignment side, so an over-sized Pool just leaves some workers
+# idle — never oversubscribed VRAM.
+if [ "$MAX_WORKERS_PER_GPU" = "auto" ]; then
+    _MWPG_FOR_NUM_JOBS=2
+else
+    _MWPG_FOR_NUM_JOBS="$MAX_WORKERS_PER_GPU"
+fi
 if [ "$GPUS" -eq "0" ]; then
     NUM_JOBS="${NUM_JOBS-1}"
 else
-    NUM_JOBS="${NUM_JOBS-$(( GPUS * MAX_WORKERS_PER_GPU ))}"
+    NUM_JOBS="${NUM_JOBS-$(( GPUS * _MWPG_FOR_NUM_JOBS ))}"
 fi
 echo "Num jobs: $NUM_JOBS (max-workers-per-gpu=$MAX_WORKERS_PER_GPU)"
 # Recycle after a bounded number of tasks so compile is still amortized

--- a/scripts/training/pan_allele_release_exact.sh
+++ b/scripts/training/pan_allele_release_exact.sh
@@ -253,7 +253,16 @@ USE_ENCODING_CACHE="${USE_ENCODING_CACHE:-1}"
 DATALOADER_NUM_WORKERS="${DATALOADER_NUM_WORKERS:-1}"
 CACHE_ARGS=()
 if [ "$USE_ENCODING_CACHE" = "1" ]; then
-    CACHE_ARGS=(--use-encoding-cache)
+    # Place the encoding cache OUTSIDE $MHCFLURRY_OUT so it
+    #   (a) doesn't ride back on the post-run rsync (~7 GB of mmap
+    #       BLOSUM62 we can rebuild locally in seconds), and
+    #   (b) persists across runs on the same box — the second run on a
+    #       reused instance hits a warm cache.
+    # Override with MHCFLURRY_ENCODING_CACHE_DIR=/path/to/dir.
+    ENCODING_CACHE_DIR="${MHCFLURRY_ENCODING_CACHE_DIR:-$HOME/runplz-cache/encoding_cache}"
+    mkdir -p "$ENCODING_CACHE_DIR"
+    CACHE_ARGS=(--use-encoding-cache --encoding-cache-dir "$ENCODING_CACHE_DIR")
+    log_release_event phase_info "encoding cache dir: $ENCODING_CACHE_DIR"
 fi
 
 # Auto-configure OMP / MKL / OPENBLAS thread budget uniformly based on

--- a/scripts/training/release_exact/generate_hyperparameters.py
+++ b/scripts/training/release_exact/generate_hyperparameters.py
@@ -61,6 +61,16 @@ base_hyperparameters = {
         'alignment_method': 'left_pad_centered_right_pad',
         'max_length': 15,
     },
+    # Phase 2 of issue openvax/mhcflurry#268: BLOSUM62 expansion as a
+    # frozen ``nn.Embedding(21, 21)`` layer in the network's forward
+    # pass instead of a numpy lookup at peptide-encoding time.
+    # ``peptides_to_network_input`` returns int8 indices (cheap dict
+    # lookup) and the GPU widens to fp32 BLOSUM62 vectors via the
+    # embedding lookup. Eliminates the ~17 sec/epoch CPU bottleneck
+    # in random-negative regeneration (with random_negative_pool_epochs=1
+    # the CPU encoding fires every epoch). Forward parity vs numpy path
+    # verified by ``test_peptide_amino_acid_encoding_gpu_forward_parity``.
+    'peptide_amino_acid_encoding_gpu': True,
     'peptide_allele_merge_activation': '',
     'peptide_allele_merge_method': 'concatenate',
     'peptide_amino_acid_encoding': 'BLOSUM62',

--- a/test/test_orchestrator_helpers.py
+++ b/test/test_orchestrator_helpers.py
@@ -148,6 +148,97 @@ def test_hoist_torchinductor_sizes_against_num_jobs(monkeypatch):
     assert os.environ["TORCHINDUCTOR_COMPILE_THREADS"] == "1"
 
 
+def test_shm_capacity_check_safe_when_plenty_free(monkeypatch):
+    from mhcflurry import local_parallelism as lp
+
+    # Fake /dev/shm: 256 GB total, 250 GB free.
+    monkeypatch.setattr(lp, "shm_free_gb", lambda *a, **k: 250.0)
+    monkeypatch.setattr(lp, "shm_total_gb", lambda *a, **k: 256.0)
+    result = lp.fit_shm_capacity_check(num_workers=16, per_fit_gb=4.0)
+    # 16 * 4 * 1.5 = 96 GB needed, 250 free.
+    assert result["safe"] is True
+    assert result["estimated_required_gb"] == 96.0
+
+
+def test_shm_capacity_check_unsafe_when_tmpfs_tight(monkeypatch):
+    from mhcflurry import local_parallelism as lp
+
+    # Docker default: 8 GB total, ~7.9 free.
+    monkeypatch.setattr(lp, "shm_free_gb", lambda *a, **k: 7.9)
+    monkeypatch.setattr(lp, "shm_total_gb", lambda *a, **k: 8.0)
+    result = lp.fit_shm_capacity_check(num_workers=16, per_fit_gb=4.0)
+    assert result["safe"] is False
+    assert "TIGHT" in result["message"]
+    assert "shm-size" in result["message"]
+
+
+def test_shm_capacity_check_no_shm_dir_returns_safe(monkeypatch):
+    """macOS / no-/dev/shm platforms should return safe=True."""
+    from mhcflurry import local_parallelism as lp
+
+    monkeypatch.setattr(lp, "shm_free_gb", lambda *a, **k: None)
+    monkeypatch.setattr(lp, "shm_total_gb", lambda *a, **k: None)
+    result = lp.fit_shm_capacity_check(num_workers=8, per_fit_gb=4.0)
+    assert result["safe"] is True
+
+
+def test_preflight_shm_auto_disables_on_tight_tmpfs(monkeypatch, capsys):
+    """When /dev/shm is too small, orchestrator should set
+    MHCFLURRY_FIT_DATALOADER_SHM=0 unless the user has pinned it."""
+    from mhcflurry import train_pan_allele_models_command as cmd
+    from mhcflurry import local_parallelism as lp
+
+    monkeypatch.setattr(lp, "shm_free_gb", lambda *a, **k: 7.0)
+    monkeypatch.setattr(lp, "shm_total_gb", lambda *a, **k: 8.0)
+    monkeypatch.delenv("MHCFLURRY_FIT_DATALOADER_SHM", raising=False)
+
+    args = argparse.Namespace(num_jobs=16)
+    cmd._preflight_shm_capacity(args)
+    assert os.environ.get("MHCFLURRY_FIT_DATALOADER_SHM") == "0"
+    out = capsys.readouterr().out
+    assert "TIGHT" in out and "Auto-disabling Layer-2 SHM" in out
+
+
+def test_preflight_shm_respects_force_pinned_off(monkeypatch, capsys):
+    from mhcflurry import train_pan_allele_models_command as cmd
+    from mhcflurry import local_parallelism as lp
+
+    monkeypatch.setattr(lp, "shm_free_gb", lambda *a, **k: 7.0)
+    monkeypatch.setattr(lp, "shm_total_gb", lambda *a, **k: 8.0)
+    monkeypatch.setenv("MHCFLURRY_FIT_DATALOADER_SHM", "0")
+
+    args = argparse.Namespace(num_jobs=16)
+    cmd._preflight_shm_capacity(args)
+    # User pinned off; orchestrator should leave it.
+    assert os.environ["MHCFLURRY_FIT_DATALOADER_SHM"] == "0"
+
+
+def test_preflight_shm_warns_loud_on_force_pinned_on(monkeypatch, capsys):
+    from mhcflurry import train_pan_allele_models_command as cmd
+    from mhcflurry import local_parallelism as lp
+
+    monkeypatch.setattr(lp, "shm_free_gb", lambda *a, **k: 7.0)
+    monkeypatch.setattr(lp, "shm_total_gb", lambda *a, **k: 8.0)
+    monkeypatch.setenv("MHCFLURRY_FIT_DATALOADER_SHM", "1")
+
+    args = argparse.Namespace(num_jobs=16)
+    cmd._preflight_shm_capacity(args)
+    # User pinned on despite tight tmpfs — env unchanged but loud warn.
+    assert os.environ["MHCFLURRY_FIT_DATALOADER_SHM"] == "1"
+    out = capsys.readouterr().out
+    assert "WARNING" in out and "force-pinned" in out
+
+
+def test_preflight_shm_skipped_for_serial_run(monkeypatch):
+    from mhcflurry import train_pan_allele_models_command as cmd
+
+    monkeypatch.delenv("MHCFLURRY_FIT_DATALOADER_SHM", raising=False)
+    args = argparse.Namespace(num_jobs=0)  # serial
+    cmd._preflight_shm_capacity(args)
+    # Serial run: orchestrator should not touch the env.
+    assert "MHCFLURRY_FIT_DATALOADER_SHM" not in os.environ
+
+
 def test_cluster_l1shm_warns(monkeypatch, capsys):
     """When --cluster-parallelism + --random-negative-shared-pool-dir
     are both passed, the orchestrator must loud-warn that the dir

--- a/test/test_orchestrator_helpers.py
+++ b/test/test_orchestrator_helpers.py
@@ -183,7 +183,8 @@ def test_shm_capacity_check_no_shm_dir_returns_safe(monkeypatch):
 
 
 def test_preflight_shm_auto_disables_on_tight_tmpfs(monkeypatch, capsys):
-    """When /dev/shm is too small, orchestrator should set
+    """When /dev/shm is too small AND the file_descriptor strategy switch
+    is unavailable, the orchestrator should set
     MHCFLURRY_FIT_DATALOADER_SHM=0 unless the user has pinned it."""
     from mhcflurry import train_pan_allele_models_command as cmd
     from mhcflurry import local_parallelism as lp
@@ -191,12 +192,47 @@ def test_preflight_shm_auto_disables_on_tight_tmpfs(monkeypatch, capsys):
     monkeypatch.setattr(lp, "shm_free_gb", lambda *a, **k: 7.0)
     monkeypatch.setattr(lp, "shm_total_gb", lambda *a, **k: 8.0)
     monkeypatch.delenv("MHCFLURRY_FIT_DATALOADER_SHM", raising=False)
+    # Disable the file_descriptor switch so the test exercises the
+    # disable fallback path explicitly.
+    monkeypatch.setenv("MHCFLURRY_TORCH_SHM_AUTO", "0")
 
     args = argparse.Namespace(num_jobs=16)
     cmd._preflight_shm_capacity(args)
     assert os.environ.get("MHCFLURRY_FIT_DATALOADER_SHM") == "0"
     out = capsys.readouterr().out
     assert "TIGHT" in out and "Auto-disabling Layer-2 SHM" in out
+
+
+def test_preflight_shm_prefers_file_descriptor_switch(monkeypatch, capsys):
+    """When /dev/shm is tight AND file_descriptor switch succeeds, the
+    orchestrator should NOT disable Layer-2 SHM — the strategy switch
+    bypasses /dev/shm entirely so L2 SHM stays useful."""
+    import torch.multiprocessing as torch_mp
+    from mhcflurry import train_pan_allele_models_command as cmd
+    from mhcflurry import local_parallelism as lp
+
+    monkeypatch.setattr(lp, "shm_free_gb", lambda *a, **k: 7.0)
+    monkeypatch.setattr(lp, "shm_total_gb", lambda *a, **k: 8.0)
+    monkeypatch.delenv("MHCFLURRY_FIT_DATALOADER_SHM", raising=False)
+    monkeypatch.delenv("MHCFLURRY_TORCH_SHM_AUTO", raising=False)
+
+    def fake_get():
+        return "file_system"
+
+    set_calls = []
+
+    def fake_set(name):
+        set_calls.append(name)
+
+    monkeypatch.setattr(torch_mp, "get_sharing_strategy", fake_get)
+    monkeypatch.setattr(torch_mp, "set_sharing_strategy", fake_set)
+
+    args = argparse.Namespace(num_jobs=16)
+    cmd._preflight_shm_capacity(args)
+    # L2 SHM stays ON because the strategy switch bypassed the /dev/shm
+    # constraint entirely.
+    assert "MHCFLURRY_FIT_DATALOADER_SHM" not in os.environ
+    assert set_calls == ["file_descriptor"]
 
 
 def test_preflight_shm_respects_force_pinned_off(monkeypatch, capsys):
@@ -237,6 +273,92 @@ def test_preflight_shm_skipped_for_serial_run(monkeypatch):
     cmd._preflight_shm_capacity(args)
     # Serial run: orchestrator should not touch the env.
     assert "MHCFLURRY_FIT_DATALOADER_SHM" not in os.environ
+
+
+def test_torch_sharing_strategy_unchanged_when_capacity_safe(monkeypatch):
+    """When /dev/shm is plenty, don't touch torch's sharing strategy."""
+    from mhcflurry import local_parallelism as lp
+
+    monkeypatch.setattr(lp, "shm_free_gb", lambda *a, **k: 250.0)
+    monkeypatch.setattr(lp, "shm_total_gb", lambda *a, **k: 256.0)
+    result = lp.configure_torch_sharing_strategy_for_capacity(
+        num_workers=16, per_fit_gb=4.0
+    )
+    assert result == "unchanged"
+
+
+def test_torch_sharing_strategy_switches_when_tight(monkeypatch):
+    """When /dev/shm is tight, switch to file_descriptor strategy."""
+    import torch.multiprocessing as torch_mp
+    from mhcflurry import local_parallelism as lp
+
+    monkeypatch.setattr(lp, "shm_free_gb", lambda *a, **k: 7.0)
+    monkeypatch.setattr(lp, "shm_total_gb", lambda *a, **k: 8.0)
+
+    set_calls = []
+
+    def fake_get():
+        return "file_system"
+
+    def fake_set(name):
+        set_calls.append(name)
+
+    monkeypatch.setattr(torch_mp, "get_sharing_strategy", fake_get)
+    monkeypatch.setattr(torch_mp, "set_sharing_strategy", fake_set)
+    result = lp.configure_torch_sharing_strategy_for_capacity(
+        num_workers=16, per_fit_gb=4.0
+    )
+    assert result == "file_descriptor"
+    assert set_calls == ["file_descriptor"]
+
+
+def test_torch_sharing_strategy_idempotent(monkeypatch):
+    """Calling twice is a no-op the second time."""
+    import torch.multiprocessing as torch_mp
+    from mhcflurry import local_parallelism as lp
+
+    monkeypatch.setattr(lp, "shm_free_gb", lambda *a, **k: 7.0)
+    monkeypatch.setattr(lp, "shm_total_gb", lambda *a, **k: 8.0)
+
+    set_calls = []
+
+    def fake_get():
+        return "file_descriptor"
+
+    def fake_set(name):
+        set_calls.append(name)
+
+    monkeypatch.setattr(torch_mp, "get_sharing_strategy", fake_get)
+    monkeypatch.setattr(torch_mp, "set_sharing_strategy", fake_set)
+    result = lp.configure_torch_sharing_strategy_for_capacity(
+        num_workers=16, per_fit_gb=4.0
+    )
+    # Already on file_descriptor; helper returns the strategy without
+    # calling set_sharing_strategy again.
+    assert result == "file_descriptor"
+    assert set_calls == []
+
+
+def test_torch_sharing_strategy_failed_falls_through(monkeypatch):
+    """When set_sharing_strategy raises (e.g. macOS), return 'failed'."""
+    import torch.multiprocessing as torch_mp
+    from mhcflurry import local_parallelism as lp
+
+    monkeypatch.setattr(lp, "shm_free_gb", lambda *a, **k: 7.0)
+    monkeypatch.setattr(lp, "shm_total_gb", lambda *a, **k: 8.0)
+
+    def fake_get():
+        return "file_system"
+
+    def fake_set(name):
+        raise AssertionError("file_descriptor not in supported strategies")
+
+    monkeypatch.setattr(torch_mp, "get_sharing_strategy", fake_get)
+    monkeypatch.setattr(torch_mp, "set_sharing_strategy", fake_set)
+    result = lp.configure_torch_sharing_strategy_for_capacity(
+        num_workers=16, per_fit_gb=4.0
+    )
+    assert result == "failed"
 
 
 def test_cluster_l1shm_warns(monkeypatch, capsys):

--- a/test/test_orchestrator_helpers.py
+++ b/test/test_orchestrator_helpers.py
@@ -18,6 +18,17 @@ import inspect
 import os
 
 
+def test_hoist_helper_lives_in_local_parallelism():
+    """``hoist_torchinductor_compile_threads`` belongs in the parallelism
+    module so processing/allele-specific commands can use it without
+    importing from train_pan_allele."""
+    from mhcflurry.local_parallelism import hoist_torchinductor_compile_threads
+    from mhcflurry.train_pan_allele_models_command import (
+        _hoist_torchinductor_compile_threads,
+    )
+    assert _hoist_torchinductor_compile_threads is hoist_torchinductor_compile_threads
+
+
 def test_filter_helper_lives_in_common():
     from mhcflurry.common import filter_canonicalizable_alleles
     from mhcflurry.calibrate_percentile_ranks_command import (
@@ -81,8 +92,8 @@ def test_prebuild_encoding_caches_idempotent(tmp_path):
 
 def test_hoist_torchinductor_no_op_when_compile_disabled(monkeypatch):
     """If MHCFLURRY_TORCH_COMPILE!=1 the hoist must not touch the env."""
-    from mhcflurry.train_pan_allele_models_command import (
-        _hoist_torchinductor_compile_threads,
+    from mhcflurry.local_parallelism import (
+        hoist_torchinductor_compile_threads as _hoist_torchinductor_compile_threads,
     )
     monkeypatch.delenv("MHCFLURRY_TORCH_COMPILE", raising=False)
     monkeypatch.delenv("TORCHINDUCTOR_COMPILE_THREADS", raising=False)
@@ -92,8 +103,8 @@ def test_hoist_torchinductor_no_op_when_compile_disabled(monkeypatch):
 
 
 def test_hoist_torchinductor_respects_user_pin(monkeypatch):
-    from mhcflurry.train_pan_allele_models_command import (
-        _hoist_torchinductor_compile_threads,
+    from mhcflurry.local_parallelism import (
+        hoist_torchinductor_compile_threads as _hoist_torchinductor_compile_threads,
     )
     monkeypatch.setenv("MHCFLURRY_TORCH_COMPILE", "1")
     monkeypatch.setenv("TORCHINDUCTOR_COMPILE_THREADS", "12")
@@ -104,8 +115,8 @@ def test_hoist_torchinductor_respects_user_pin(monkeypatch):
 
 
 def test_hoist_torchinductor_sizes_against_num_jobs(monkeypatch):
-    from mhcflurry.train_pan_allele_models_command import (
-        _hoist_torchinductor_compile_threads,
+    from mhcflurry.local_parallelism import (
+        hoist_torchinductor_compile_threads as _hoist_torchinductor_compile_threads,
     )
     monkeypatch.setenv("MHCFLURRY_TORCH_COMPILE", "1")
     monkeypatch.delenv("TORCHINDUCTOR_COMPILE_THREADS", raising=False)

--- a/test/test_orchestrator_helpers.py
+++ b/test/test_orchestrator_helpers.py
@@ -1,0 +1,154 @@
+"""Unit tests for orchestrator-side helpers added in 2.3.0.
+
+Covers:
+* ``mhcflurry.common.filter_canonicalizable_alleles`` and its
+  back-compat alias.
+* ``mhcflurry.encoding_cache.prebuild_encoding_caches`` and
+  ``deterministic_unique_peptide_list``.
+* ``mhcflurry.train_pan_allele_models_command._hoist_torchinductor_compile_threads``
+* Confirmation that the select commands' source actually invokes the
+  shared filter (cheap regression for the same class of bug as the
+  calibrate pseudogene crash).
+
+All tests are pure-Python; no GPU, no subprocess, no models on disk.
+"""
+
+import argparse
+import inspect
+import os
+
+
+def test_filter_helper_lives_in_common():
+    from mhcflurry.common import filter_canonicalizable_alleles
+    from mhcflurry.calibrate_percentile_ranks_command import (
+        _filter_canonicalizable_alleles,
+    )
+    # back-compat alias preserved for any external import path.
+    assert _filter_canonicalizable_alleles is filter_canonicalizable_alleles
+
+
+def test_filter_select_call_sites():
+    """Both select commands that iterate predictor.supported_alleles
+    must invoke the canonicalization filter. Without coverage at
+    these sites, a pseudogene allele in the input predictor would
+    crash the parallel selection mid-fold the same way calibrate
+    used to."""
+    from mhcflurry import select_pan_allele_models_command as pan_mod
+    from mhcflurry import select_allele_specific_models_command as as_mod
+
+    pan_src = inspect.getsource(pan_mod.run)
+    as_src = inspect.getsource(as_mod.run)
+    assert "filter_canonicalizable_alleles" in pan_src, (
+        "select_pan_allele must filter supported_alleles"
+    )
+    assert "filter_canonicalizable_alleles" in as_src, (
+        "select_allele_specific must filter supported_alleles"
+    )
+
+
+def test_deterministic_unique_peptide_list_preserves_first_seen_order():
+    from mhcflurry.encoding_cache import deterministic_unique_peptide_list
+    raw = ["ABC", "DEF", "ABC", "GHI", "DEF", "JKL"]
+    assert deterministic_unique_peptide_list(raw) == ["ABC", "DEF", "GHI", "JKL"]
+
+
+def test_prebuild_encoding_caches_idempotent(tmp_path):
+    """Calling prebuild twice should be a cheap cache-hit second time."""
+    from mhcflurry.encoding_cache import prebuild_encoding_caches
+
+    peptides = ["SIINFEKL", "GILGFVFTL", "NLVPMVATV"]
+    cfg = [{}]  # default EncodingParams
+
+    log_lines = []
+    prebuild_encoding_caches(
+        cache_dir=str(tmp_path),
+        peptides=peptides,
+        encoding_configs=cfg,
+        label="unit",
+        log=log_lines.append,
+    )
+    # Second call should hit cache for every config.
+    log_lines.clear()
+    prebuild_encoding_caches(
+        cache_dir=str(tmp_path),
+        peptides=peptides,
+        encoding_configs=cfg,
+        label="unit",
+        log=log_lines.append,
+    )
+    assert any("hit" in line for line in log_lines), log_lines
+
+
+def test_hoist_torchinductor_no_op_when_compile_disabled(monkeypatch):
+    """If MHCFLURRY_TORCH_COMPILE!=1 the hoist must not touch the env."""
+    from mhcflurry.train_pan_allele_models_command import (
+        _hoist_torchinductor_compile_threads,
+    )
+    monkeypatch.delenv("MHCFLURRY_TORCH_COMPILE", raising=False)
+    monkeypatch.delenv("TORCHINDUCTOR_COMPILE_THREADS", raising=False)
+    args = argparse.Namespace(num_jobs=8)
+    _hoist_torchinductor_compile_threads(args)
+    assert "TORCHINDUCTOR_COMPILE_THREADS" not in os.environ
+
+
+def test_hoist_torchinductor_respects_user_pin(monkeypatch):
+    from mhcflurry.train_pan_allele_models_command import (
+        _hoist_torchinductor_compile_threads,
+    )
+    monkeypatch.setenv("MHCFLURRY_TORCH_COMPILE", "1")
+    monkeypatch.setenv("TORCHINDUCTOR_COMPILE_THREADS", "12")
+    args = argparse.Namespace(num_jobs=8)
+    _hoist_torchinductor_compile_threads(args)
+    # User-pinned value must survive.
+    assert os.environ["TORCHINDUCTOR_COMPILE_THREADS"] == "12"
+
+
+def test_hoist_torchinductor_sizes_against_num_jobs(monkeypatch):
+    from mhcflurry.train_pan_allele_models_command import (
+        _hoist_torchinductor_compile_threads,
+    )
+    monkeypatch.setenv("MHCFLURRY_TORCH_COMPILE", "1")
+    monkeypatch.delenv("TORCHINDUCTOR_COMPILE_THREADS", raising=False)
+    # 8 jobs on a 64-core box → 64/8=8, capped at 4.
+    monkeypatch.setattr(os, "cpu_count", lambda: 64)
+    args = argparse.Namespace(num_jobs=8)
+    _hoist_torchinductor_compile_threads(args)
+    assert os.environ["TORCHINDUCTOR_COMPILE_THREADS"] == "4"
+
+    # 1 job on 4-core box → 4/1=4, hits cap.
+    monkeypatch.delenv("TORCHINDUCTOR_COMPILE_THREADS", raising=False)
+    monkeypatch.setattr(os, "cpu_count", lambda: 4)
+    args = argparse.Namespace(num_jobs=1)
+    _hoist_torchinductor_compile_threads(args)
+    assert os.environ["TORCHINDUCTOR_COMPILE_THREADS"] == "4"
+
+    # 16 jobs on 32-core box → 32/16=2.
+    monkeypatch.delenv("TORCHINDUCTOR_COMPILE_THREADS", raising=False)
+    monkeypatch.setattr(os, "cpu_count", lambda: 32)
+    args = argparse.Namespace(num_jobs=16)
+    _hoist_torchinductor_compile_threads(args)
+    assert os.environ["TORCHINDUCTOR_COMPILE_THREADS"] == "2"
+
+    # Always at least 1 thread even with absurd over-subscription.
+    monkeypatch.delenv("TORCHINDUCTOR_COMPILE_THREADS", raising=False)
+    monkeypatch.setattr(os, "cpu_count", lambda: 4)
+    args = argparse.Namespace(num_jobs=64)
+    _hoist_torchinductor_compile_threads(args)
+    assert os.environ["TORCHINDUCTOR_COMPILE_THREADS"] == "1"
+
+
+def test_cluster_l1shm_warns(monkeypatch, capsys):
+    """When --cluster-parallelism + --random-negative-shared-pool-dir
+    are both passed, the orchestrator must loud-warn that the dir
+    must be NFS-shared. The message names the absolute pool path so
+    the user can verify it."""
+    from mhcflurry import train_pan_allele_models_command as mod
+
+    src = inspect.getsource(mod.train_models)
+    assert "WARNING" in src and "cluster_parallelism" in src and (
+        "random-negative-shared-pool-dir" in src
+        or "random_negative_shared_pool_dir" in src
+    ), (
+        "train_models must warn when cluster + L1-SHM are combined; "
+        "see docs/orchestrator.md"
+    )

--- a/test/test_pytorch_regressions.py
+++ b/test/test_pytorch_regressions.py
@@ -21,7 +21,6 @@ from mhcflurry.class1_neural_network import (
     _make_fit_dataloader,
 )
 from mhcflurry.shared_memory import (
-    array_nbytes,
     numpy_batch_collate,
     share_like,
     share_tensor,

--- a/test/test_train_pan_allele_encoding_cache.py
+++ b/test/test_train_pan_allele_encoding_cache.py
@@ -7,7 +7,7 @@ in ``train_pan_allele_models_command``:
         EncodableSequences either directly (cache disabled, old behavior)
         or via the pre-built memmap (cache enabled, new behavior).
 
-    _deterministic_unique_peptide_list() — both orchestrator and workers
+    deterministic_unique_peptide_list() — both orchestrator and workers
         must derive identical peptide lists from the same train_data, or
         the cache key won't match.
 
@@ -41,7 +41,7 @@ from mhcflurry.encoding_cache import EncodingCache, EncodingParams
 from mhcflurry.regression_target import from_ic50
 from mhcflurry.train_pan_allele_models_command import (
     _build_train_peptides,
-    _deterministic_unique_peptide_list,
+    deterministic_unique_peptide_list,
     _get_or_build_pretrain_batch_cache,
     _initialize_encoding_cache,
     _pretrain_batch_cache_dir,
@@ -114,11 +114,11 @@ def hyperparameters():
     return {"peptide_encoding": DEFAULT_PEPTIDE_ENCODING}
 
 
-# ---- _deterministic_unique_peptide_list ----
+# ---- deterministic_unique_peptide_list ----
 
 
 def test_unique_peptide_list_is_first_seen_order(train_data):
-    got = _deterministic_unique_peptide_list(train_data.peptide.values)
+    got = deterministic_unique_peptide_list(train_data.peptide.values)
     # Order of first appearance, no duplicates.
     assert got == [
         "SIINFEKL",
@@ -135,8 +135,8 @@ def test_unique_peptide_list_is_first_seen_order(train_data):
 
 def test_unique_peptide_list_stable_across_calls(train_data):
     """Must be deterministic — orchestrator and worker must agree."""
-    first = _deterministic_unique_peptide_list(train_data.peptide.values)
-    second = _deterministic_unique_peptide_list(train_data.peptide.values)
+    first = deterministic_unique_peptide_list(train_data.peptide.values)
+    second = deterministic_unique_peptide_list(train_data.peptide.values)
     assert first == second
 
 
@@ -876,7 +876,7 @@ def test_memmap_reopens_cleanly_in_fresh_encoding_cache(
 
     # Same unique-peptides list as orchestrator would have built.
     df = GLOBAL_DATA["train_data"]
-    unique_peptides = _deterministic_unique_peptide_list(df.peptide.values)
+    unique_peptides = deterministic_unique_peptide_list(df.peptide.values)
 
     # Should be a cache HIT — the entry exists from orchestrator's build.
     entry_dir = worker_cache.entry_path(unique_peptides)
@@ -1026,9 +1026,9 @@ def test_initialize_stashes_unique_peptides_in_global_data(
     assert "encoding_cache_unique_peptides" in GLOBAL_DATA
     stashed = GLOBAL_DATA["encoding_cache_unique_peptides"]
     assert isinstance(stashed, list)
-    # Should equal what _deterministic_unique_peptide_list returns.
+    # Should equal what deterministic_unique_peptide_list returns.
     df = GLOBAL_DATA["train_data"]
-    expected = _deterministic_unique_peptide_list(df.peptide.values)
+    expected = deterministic_unique_peptide_list(df.peptide.values)
     assert stashed == expected
 
 
@@ -1047,16 +1047,16 @@ def test_build_train_peptides_uses_stashed_unique_peptides(
     _initialize_encoding_cache(args, all_work_items)
     constant_data = dict(GLOBAL_DATA)
 
-    # Spy on _deterministic_unique_peptide_list to verify it's NOT called.
+    # Spy on deterministic_unique_peptide_list to verify it's NOT called.
     from mhcflurry import train_pan_allele_models_command as cmd
     calls = []
-    original = cmd._deterministic_unique_peptide_list
+    original = cmd.deterministic_unique_peptide_list
 
     def spy(*a, **kw):
         calls.append(1)
         return original(*a, **kw)
 
-    monkeypatch.setattr(cmd, "_deterministic_unique_peptide_list", spy)
+    monkeypatch.setattr(cmd, "deterministic_unique_peptide_list", spy)
 
     # Call from "worker" side with the pickled constant_data.
     worker_dict = pickle.loads(pickle.dumps(constant_data))
@@ -1121,13 +1121,13 @@ def test_build_train_peptides_fallback_when_stash_absent(
         "encoding_cache_dir": str(cache_dir),
     }
     calls = []
-    original = cmd._deterministic_unique_peptide_list
+    original = cmd.deterministic_unique_peptide_list
 
     def spy(*a, **kw):
         calls.append(1)
         return original(*a, **kw)
 
-    monkeypatch.setattr(cmd, "_deterministic_unique_peptide_list", spy)
+    monkeypatch.setattr(cmd, "deterministic_unique_peptide_list", spy)
 
     got = _build_train_peptides(
         train_data.peptide.values, hyperparameters, constant_data
@@ -1135,7 +1135,7 @@ def test_build_train_peptides_fallback_when_stash_absent(
     assert isinstance(got, EncodableSequences)
     assert len(got.encoding_cache) == 1
     assert len(calls) == 1, (
-        f"expected exactly 1 fallback call to _deterministic_unique_peptide_list, "
+        f"expected exactly 1 fallback call to deterministic_unique_peptide_list, "
         f"got {len(calls)}"
     )
 
@@ -1729,7 +1729,7 @@ def test_pretrain_batch_cache_prebuild_matches_worker_hash(
     }
     all_work_items = [{"hyperparameters": hp}]
 
-    # train_data is only referenced by _deterministic_unique_peptide_list,
+    # train_data is only referenced by deterministic_unique_peptide_list,
     # which just needs a peptide column. Reuse the pretrain peptides.
     GLOBAL_DATA.clear()
     GLOBAL_DATA.update({


### PR DESCRIPTION
## Summary

Final tightening pass on the 2.3.0 orchestrator architecture. Closes
the audit gaps identified after the validation run, harmonizes
shared infrastructure across components, and documents the
locus-of-control story explicitly so future contributors don't have
to reverse-engineer it.

**The shape of the change is small**: each individual recommendation
is 5–30 lines. The total payoff is consistency — every component
that iterates `supported_alleles` now uses one filter; every
orchestrator that forks workers uses the same env-hoist pattern;
every cache-build call site uses the same helper.

## What's in this PR

### 1. Shared allele-canonicalization filter

Promotes `_filter_canonicalizable_alleles` from
`calibrate_percentile_ranks_command.py` to
`mhcflurry.common.filter_canonicalizable_alleles`. Applies it at the
two select-side iteration sites that previously didn't filter:

- `select_pan_allele_models_command.py` (line ~158)
- `select_allele_specific_models_command.py` (line ~206)

Both read `input_predictor.supported_alleles` and would crash mid-fold
on pseudogene/null/questionable annotations the same way calibrate
used to (see #274). The calibrate module retains a
`_filter_canonicalizable_alleles` back-compat alias for any external
import path.

**Why:** one bug, one fix, one helper. A future select-side rewrite
won't accidentally regress the pseudogene crash.

### 2. `TORCHINDUCTOR_COMPILE_THREADS` orchestrator hoist

New `_hoist_torchinductor_compile_threads(args)` in the pan-allele
orchestrator. Runs **before** forking workers; sets
`TORCHINDUCTOR_COMPILE_THREADS = clamp(cpu_count // num_jobs, 1, 4)`
unless the user has pinned the env var explicitly. No-op when
`MHCFLURRY_TORCH_COMPILE != 1`.

**Why:** with N fit() workers each defaulting inductor's compile pool
to `cpu_count()`, an 8-job × 64-core box would spawn 512 compile
threads. The orchestrator owns "how many workers will exist", so it
should size the compile pool to match.

### 3. Generic encoding-cache helpers

Hoists the cache-build inner loop to two helpers in
`mhcflurry/encoding_cache.py`:

- `prebuild_encoding_caches(*, cache_dir, peptides, encoding_configs, label, log)`
- `deterministic_unique_peptide_list(peptide_values)`

Pan-allele orchestrator's `_initialize_encoding_cache` now uses these
(eliminating duplicated cache-build loops between train and pretrain
paths). Processing and allele-specific commands can adopt the helper
with a one-line call from their `run()` when their datasets warrant
it — they don't today, so this PR doesn't wire them.

**Why:** the encoding-cache build is generic, but the pan-allele glue
(folds_df, pretrain CSV, master allele encoding) is not. Splitting
those keeps both clean.

### 4. Cluster + Layer-1 SHM warning

When `--cluster-parallelism` is combined with
`--random-negative-shared-pool-dir`, the orchestrator emits a clear
warning: the mmap pool dir must be on a filesystem reachable from
every cluster worker (typically NFS), or workers silently fall back
to the in-process pool, negating the speedup. The warning names the
absolute pool path so the user can verify their setup.

**Why:** silent fallback is the worst kind of failure mode — looks
fast in the logs, slow in wall time.

### 5. Internals doc — `docs/orchestrator.md`

New 200-line doc documenting:

- The locus-of-control story (orchestrator owns shared resources,
  workers consume them).
- Layered SHM table (Layer 1 vs Layer 2: lifetime, mechanism, who
  builds, who reads, mutability).
- Parallelism backends and which SHM layers work where.
- Coverage matrix: components × stages, what's modernized vs opt-in.
- Env-vs-CLI rule of thumb.
- Recipes for adding new pre-fork resources, env knobs, and filters.

Cross-linked from `RELEASE_NOTES_2.3.0.md`.

**Why:** "minimize cognitive overhead" — read this doc, you understand
the architecture; touch any component without reading it, you'll
re-discover the same patterns from scratch.

## Test plan

- [x] `pytest test/test_orchestrator_helpers.py` — 8 new tests cover
  the new helpers, the back-compat alias, and the cluster warning.
- [x] `pytest test/test_calibrate_percentile_ranks_command.py -k filter`
  — 4 existing filter tests pass with the helper hoisted.
- [x] `pytest test/test_train_pan_allele_encoding_cache.py` — 41
  encoding-cache integration tests pass.
- [x] `pytest test/test_pytorch_regressions.py -k "shared_memory or share or shm"`
  — SHM regression tests still pass.
- [ ] CI on this branch.
- [ ] Validation run on the 2.3.0 stack confirms no regression vs
  the run that motivated the audit.

## Files

| File | Change |
|---|---|
| `mhcflurry/common.py` | Add `filter_canonicalizable_alleles` |
| `mhcflurry/calibrate_percentile_ranks_command.py` | Use shared filter; back-compat alias |
| `mhcflurry/select_pan_allele_models_command.py` | Apply filter |
| `mhcflurry/select_allele_specific_models_command.py` | Apply filter |
| `mhcflurry/encoding_cache.py` | Add `prebuild_encoding_caches`, `deterministic_unique_peptide_list` |
| `mhcflurry/train_pan_allele_models_command.py` | Use new helpers; add compile-threads hoist; cluster warning |
| `mhcflurry/shared_memory.py` | Lint cleanup (unused imports) |
| `mhcflurry/class1_neural_network.py` | Lint cleanup (re-export noqa) |
| `docs/orchestrator.md` | NEW — internals doc |
| `RELEASE_NOTES_2.3.0.md` | Cross-link orchestrator doc |
| `test/test_orchestrator_helpers.py` | NEW — 8 unit tests |
| `test/test_train_pan_allele_encoding_cache.py` | Update spy targets |
| `test/test_pytorch_regressions.py` | Lint cleanup (unused import) |

Targets `codex/release-2.3.0` (the umbrella branch).