### PR TITLE
README cleanup: citation up top, mark rc2, trim niche commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Or scan protein sequences for potential epitopes:
 ```
 $ mhcflurry-predict-scan \
         --sequences MFVFLVLLPLVSSQCVNLTTRTQLPPAYTNSFTRGVYYPDKVFRSSVLHS \
-        --alleles HLA-A*02:01 \
+        --alleles 'HLA-A*02:01' \
         --out /tmp/predictions.csv
 
 Wrote: /tmp/predictions.csv

--- a/README.md
+++ b/README.md
@@ -7,13 +7,23 @@
 prediction package with competitive accuracy and a fast and
 [documented](http://openvax.github.io/mhcflurry/) implementation.
 
+If you find MHCflurry useful in your research please cite:
+
+> T. O'Donnell, A. Rubinsteyn, U. Laserson. "MHCflurry 2.0: Improved pan-allele prediction of MHC I-presented peptides by incorporating antigen processing," *Cell Systems*, 2020. https://doi.org/10.1016/j.cels.2020.06.010
+
+> T. O'Donnell, A. Rubinsteyn, M. Bonsack, A. B. Riemer, U. Laserson, and J. Hammerbacher, "MHCflurry: Open-Source Class I MHC Binding Affinity Prediction," *Cell Systems*, 2018. https://doi.org/10.1016/j.cels.2018.05.014
+
+Please file an issue if you have questions or encounter problems.
+
+Have a bugfix or other contribution? We would love your help. See our [contributing guidelines](CONTRIBUTING.md).
+
 ## 2.3.0 release candidate
 
-2.3.0 is currently a **release candidate** (`2.3.0rc1`), not yet a final
+2.3.0 is currently a **release candidate** (`2.3.0rc2`), not yet a final
 release. It keeps the same API and pre-trained models as 2.2.x. Install it by
 pinning the version:
 
-    pip install mhcflurry==2.3.0rc1
+    pip install mhcflurry==2.3.0rc2
 
 For now, `pip install --upgrade mhcflurry` still installs the latest stable
 release (2.2.x), because pip skips pre-releases unless you pin the version or
@@ -27,34 +37,6 @@ prediction jobs:
 - `mhcflurry-predict`, `mhcflurry-predict-scan`, and `mhcflurry-calibrate-percentile-ranks` use all visible GPUs by default.
 - `mhcflurry-class1-train-pan-allele-models` auto-tunes job and worker counts from the hardware, so the same command runs on a laptop, a single GPU, or an 8×A100 host.
 - `torch.compile`, TF32, and matmul precision are available as flags on the training commands.
-
-Version 2.2.0 switched the neural-network backend from TensorFlow/Keras to
-PyTorch and added Apple Silicon (MPS) support.
-
-MHCflurry implements class I peptide/MHC binding affinity prediction.
-The current version provides pan-MHC I predictors supporting any MHC
-allele of known sequence. MHCflurry runs on Python 3.10+ using the
-[PyTorch](https://pytorch.org/) neural network library.
-It exposes [command-line](http://openvax.github.io/mhcflurry/commandline_tutorial.html)
-and [Python library](http://openvax.github.io/mhcflurry/python_tutorial.html)
-interfaces.
-
-MHCflurry also includes two experimental predictors,
-an "antigen processing" predictor that attempts to model MHC allele-independent
-effects such as proteosomal cleavage and a "presentation" predictor that
-integrates processing predictions with binding affinity predictions to give a
-composite "presentation score." Both models are trained on mass spec-identified
-MHC ligands.
-
-If you find MHCflurry useful in your research please cite:
-
-> T. O'Donnell, A. Rubinsteyn, U. Laserson. "MHCflurry 2.0: Improved pan-allele prediction of MHC I-presented peptides by incorporating antigen processing," *Cell Systems*, 2020. https://doi.org/10.1016/j.cels.2020.06.010
-
-> T. O'Donnell, A. Rubinsteyn, M. Bonsack, A. B. Riemer, U. Laserson, and J. Hammerbacher, "MHCflurry: Open-Source Class I MHC Binding Affinity Prediction," *Cell Systems*, 2018. https://doi.org/10.1016/j.cels.2018.05.014
-
-Please file an issue if you have questions or encounter problems.
-
-Have a bugfix or other contribution? We would love your help. See our [contributing guidelines](CONTRIBUTING.md).
 
 ## Try it now
 
@@ -106,13 +88,6 @@ $ mhcflurry predict \
         --alleles HLA-A0201 HLA-A0301 \
         --peptides SIINFEKL SIINFEKD SIINFEKQ \
         --out /tmp/predictions.csv
-
-$ mhcflurry compare-models \
-        --a results/new_run/ \
-        --b public \
-        --out results/comparison/
-
-$ mhcflurry plot-model-comparison --input results/comparison/
 ```
 
 Every historical command is reachable as a subcommand
@@ -122,9 +97,6 @@ Every historical command is reachable as a subcommand
 same underlying entry point; the legacy `mhcflurry-*` scripts remain
 installed as compat shims and are not changing. `mhcflurry --help`
 lists every available subcommand.
-
-The two new-in-2.3.0 model-comparison tools, `compare-models` and
-`plot-model-comparison`, only have the unified form.
 
 See the [documentation](http://openvax.github.io/mhcflurry/) for more details.
 

--- a/README.md
+++ b/README.md
@@ -19,11 +19,11 @@ Have a bugfix or other contribution? We would love your help. See our [contribut
 
 ## 2.3.0 release candidate
 
-2.3.0 is currently a **release candidate** (`2.3.0rc2`), not yet a final
+2.3.0 is currently a **release candidate** (`2.3.0rc3`), not yet a final
 release. It keeps the same API and pre-trained models as 2.2.x. Install it by
 pinning the version:
 
-    pip install mhcflurry==2.3.0rc2
+    pip install mhcflurry==2.3.0rc3
 
 For now, `pip install --upgrade mhcflurry` still installs the latest stable
 release (2.2.x), because pip skips pre-releases unless you pin the version or
@@ -36,7 +36,7 @@ prediction jobs:
 - Training keeps data on the GPU for the whole fit, avoiding per-batch host/device copies.
 - `mhcflurry-predict`, `mhcflurry-predict-scan`, and `mhcflurry-calibrate-percentile-ranks` use all visible GPUs by default.
 - `mhcflurry-class1-train-pan-allele-models` auto-tunes job and worker counts from the hardware, so the same command runs on a laptop, a single GPU, or an 8×A100 host.
-- `torch.compile`, TF32, and matmul precision are available as flags on the training commands.
+- `torch.compile` and matmul precision (including TF32) are available as flags on the training commands.
 
 ## Try it now
 

--- a/docs/commandline_tutorial.md
+++ b/docs/commandline_tutorial.md
@@ -243,11 +243,11 @@ MHCflurry behavior can be modified using these environment variables:
   if you are running out of memory using the pan-allele models.
 
 `MHCFLURRY_DEFAULT_PREDICT_BATCH_SIZE`
-: For large prediction tasks, it can be helpful to increase the prediction batch
-  size, which is set by this environment variable (default is 4096). This
-  affects both allele-specific and pan-allele predictors. It can have large
-  effects on performance. Alternatively, if you are running out of memory,
-  you can try decreasing the batch size.
+: Prediction batch size. By default this is `auto`, sized at runtime from
+  available GPU memory. Set this environment variable to a fixed integer to
+  pin it (affects both allele-specific and pan-allele predictors). Increasing
+  the batch size can speed up large prediction tasks; decrease it if you run
+  out of memory.
 
 ## Auto-resolved training/calibration knobs
 
@@ -290,12 +290,14 @@ post-mortem is visible in the log.
 
 ## Reproducibility (`--random-seed`, new in 2.3.0)
 
-Every command that involves randomness — `class1-train-pan-allele-models`,
+Every training and calibration command — `class1-train-pan-allele-models`,
 `class1-train-allele-specific-models`, `class1-train-processing-models`,
-`class1-select-allele-specific-models`, and `calibrate-percentile-ranks` —
-takes a single `--random-seed N` that controls **all** of that command's
-randomness (fold assignment, dispatch/data shuffles, weight init, random
-negatives, allele sampling, and the calibration peptide universe).
+`class1-train-presentation-models`, `class1-select-allele-specific-models`,
+and `calibrate-percentile-ranks` — takes a single `--random-seed N` that
+controls **all** of that command's randomness (fold assignment, dispatch/data
+shuffles, weight init, random negatives, allele sampling, and the calibration
+peptide universe). (`class1-train-presentation-models` accepts the flag for
+consistency but has no stochastic step today.)
 
 `--random-seed` defaults to **42**, so training and calibration reproduce
 bit-for-bit out of the box. Pass `--random-seed N` for a different but

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,7 +69,7 @@ logging.getLogger('matplotlib').disabled = True
 import numpy
 import pandas
 import mhcflurry
-pandas.set_option('max_columns', 20)
+pandas.set_option('display.max_columns', 20)
 pandas.set_option('display.expand_frame_repr', False)
 '''
 

--- a/docs/python_tutorial.md
+++ b/docs/python_tutorial.md
@@ -34,7 +34,7 @@ models directory, then it will load that predictor instead.
 ## Predicting for individual peptides
 
 To generate predictions for individual peptides, we can use the
-{meth}`~mhcflurry.Class1AffinityPredictor.predict` method of the {class}`~mhcflurry.Class1PresentationPredictor`,
+{meth}`~mhcflurry.Class1PresentationPredictor.predict` method of the {class}`~mhcflurry.Class1PresentationPredictor`,
 loaded above. This method returns a {class}`pandas.DataFrame` with binding affinity, processing, and presentation
 predictions:
 

--- a/docs/python_tutorial.md
+++ b/docs/python_tutorial.md
@@ -43,9 +43,9 @@ predictions:
 ...     peptides=["SIINFEKL", "NLVPMVATV"],
 ...     alleles=["HLA-A0201", "HLA-A0301"],
 ...     verbose=0)
-     peptide  peptide_num sample_name      affinity best_allele  processing_score  presentation_score
-0   SIINFEKL            0     sample1  12906.786173   HLA-A0201          0.101473            0.012503
-1  NLVPMVATV            1     sample1     15.038358   HLA-A0201          0.676289            0.975463
+     peptide  peptide_num sample_name      affinity best_allele  processing_score  presentation_score  presentation_percentile
+0   SIINFEKL            0     sample1  11927.173394   HLA-A0201          0.264710            0.020690                11.630326
+1  NLVPMVATV            1     sample1     16.570969   HLA-A0201          0.533008            0.970187                 0.018723
 ```
 
 Here, the list of alleles is taken to be an individual's MHC I genotype (i.e. up
@@ -70,11 +70,11 @@ keys are arbitrary sample names:
 ...        "sample2": ["A0101", "A0206", "B5701", "C0202"],
 ...     },
 ...     verbose=0)
-      peptide  peptide_num sample_name      affinity best_allele  processing_score  presentation_score
-0  KSEYMTSWFY            0     sample1  16737.745268       A0301          0.381632            0.026550
-1   NLVPMVATV            1     sample1     15.038358       A0201          0.676289            0.975463
-2  KSEYMTSWFY            0     sample2     62.540779       A0101          0.381632            0.796731
-3   NLVPMVATV            1     sample2     15.765500       A0206          0.676289            0.974439
+      peptide  peptide_num sample_name     affinity best_allele  processing_score  presentation_score  presentation_percentile
+0  KSEYMTSWFY            0     sample1  8292.186793       C0201          0.542474            0.074376                 3.639185
+1   NLVPMVATV            1     sample1    16.570969       A0201          0.533008            0.970187                 0.018723
+2  KSEYMTSWFY            0     sample2    88.898412       A0101          0.542474            0.868106                 0.171848
+3   NLVPMVATV            1     sample2    17.406640       A0206          0.533008            0.968773                 0.021413
 ```
 
 Here the strongest binder for each sample / peptide pair is returned.
@@ -96,11 +96,11 @@ arguments, which give the flanking sequences for the corresponding peptides:
 ...        "sample2": ["A0101", "A0206", "B5701", "C0202"],
 ...     },
 ...     verbose=0)
-      peptide   n_flank   c_flank  peptide_num sample_name      affinity best_allele  processing_score  presentation_score
-0  KSEYMTSWFY   NNNNNNN  CCCCCCCC            0     sample1  16737.745268       A0301          0.605816            0.056190
-1   NLVPMVATV  SSSSSSSS   YYYAAAA            1     sample1     15.038358       A0201          0.824994            0.986719
-2  KSEYMTSWFY   NNNNNNN  CCCCCCCC            0     sample2     62.540779       A0101          0.605816            0.897493
-3   NLVPMVATV  SSSSSSSS   YYYAAAA            1     sample2     15.765500       A0206          0.824994            0.986155
+      peptide   n_flank   c_flank  peptide_num sample_name     affinity best_allele  processing_score  presentation_score  presentation_percentile
+0  KSEYMTSWFY   NNNNNNN  CCCCCCCC            0     sample1  8292.186793       C0201          0.626173            0.097041                 2.991685
+1   NLVPMVATV  SSSSSSSS   YYYAAAA            1     sample1    16.570969       A0201          0.436871            0.956961                 0.036957
+2  KSEYMTSWFY   NNNNNNN  CCCCCCCC            0     sample2    88.898412       A0101          0.626173            0.898967                 0.122663
+3   NLVPMVATV  SSSSSSSS   YYYAAAA            1     sample2    17.406640       A0206          0.436871            0.954945                 0.041168
 ```
 
 ## Scanning protein sequences
@@ -124,17 +124,17 @@ across two sample genotypes and two short peptide sequences.
 ...    comparison_quantity="affinity",
 ...    filter_value=500,
 ...    verbose=0)
-  sequence_name  pos     peptide         n_flank     c_flank sample_name    affinity best_allele  affinity_percentile  processing_score  presentation_score
-0      protein1   13   LLLLVVSNL   MDSKGSSQKGSRL           L     sample1   38.206225       A0201             0.380125          0.017644            0.571060
-1      protein1   14   LLLVVSNLL  MDSKGSSQKGSRLL                 sample1   42.243472       A0201             0.420250          0.090984            0.619213
-2      protein1    5   SSQKGSRLL           MDSKG   LLLVVSNLL     sample2   66.749223       C0202             0.803375          0.383608            0.774468
-3      protein1    6   SQKGSRLLL          MDSKGS    LLVVSNLL     sample2  178.033467       C0202             1.820000          0.275019            0.482206
-4      protein1   13  LLLLVVSNLL   MDSKGSSQKGSRL                 sample1  202.208167       A0201             1.112500          0.058782            0.261320
-5      protein1   12  LLLLLVVSNL    MDSKGSSQKGSR           L     sample1  202.506582       A0201             1.112500          0.010025            0.225648
-6      protein2    0   SSLPTPEDK                    EQAQQTHH     sample1  335.529377       A0301             1.011750          0.010443            0.156798
-7      protein2    0   SSLPTPEDK                    EQAQQTHH     sample2  353.451759       C0202             2.674250          0.010443            0.150753
-8      protein1    8   KGSRLLLLL        MDSKGSSQ      VVSNLL     sample2  410.327286       C0202             2.887000          0.121374            0.194081
-9      protein1    5    SSQKGSRL           MDSKG  LLLLVVSNLL     sample2  477.285937       C0202             3.107375          0.111982            0.168572
+  sequence_name  pos     peptide n_flank c_flank sample_name    affinity best_allele  affinity_percentile  processing_score  presentation_score  presentation_percentile
+0      protein1   14   LLLVVSNLL   GSRLL             sample1   57.180447       A0201             0.398125          0.233159            0.754186                 0.351359
+1      protein1   13   LLLLVVSNL   KGSRL       L     sample1   57.338895       A0201             0.398125          0.030920            0.586465                 0.642908
+2      protein1    5   SSQKGSRLL   MDSKG   LLLVV     sample2  110.778519       C0202             0.781875          0.060995            0.455738                 0.920299
+3      protein1    6   SQKGSRLLL   DSKGS   LLVVS     sample2  254.479925       C0202             1.734875          0.101657            0.303070                 1.356196
+4      protein1   13  LLLLVVSNLL   KGSRL             sample1  260.390251       A0201             1.012500          0.158010            0.345066                 1.214701
+5      protein1   12  LLLLLVVSNL   QKGSR       L     sample1  308.149631       A0201             1.093750          0.015113            0.206176                 1.801603
+6      protein2    0   SSLPTPEDK           EQAQQ     sample2  410.354088       C0202             2.398000          0.003090            0.158057                 2.154946
+7      protein1    5    SSQKGSRL   MDSKG   LLLLV     sample2  444.320680       C0202             2.511750          0.026198            0.159450                 2.137962
+8      protein2    0   SSLPTPEDK           EQAQQ     sample1  459.295763       A0301             0.970625          0.003090            0.143999                 2.292011
+9      protein1    4   GSSQKGSRL    MDSK   LLLLV     sample2  469.052760       C0202             2.594750          0.013744            0.146487                 2.261060
 ```
 
 When using `predict_sequences`, the flanking sequences for each peptide are
@@ -156,9 +156,9 @@ Here's an example:
 >>> from mhcflurry import Class1AffinityPredictor
 >>> predictor = Class1AffinityPredictor.load()
 >>> predictor.predict_to_dataframe(allele="HLA-A0201", peptides=["SIINFEKL", "SIINFEQL"])
-    peptide     allele    prediction  prediction_low  prediction_high  prediction_percentile
-0  SIINFEKL  HLA-A0201  12906.786173     8829.460289     18029.923061               6.566375
-1  SIINFEQL  HLA-A0201  13025.300796     9050.056312     18338.004869               6.623625
+    peptide       allele    prediction  prediction_low  prediction_high  prediction_percentile
+0  SIINFEKL  HLA-A*02:01  11927.160672     6901.075753     18127.365636               6.296000
+1  SIINFEQL  HLA-A*02:01  12070.888207     7362.362111     18465.971144               6.354125
 ```
 
 The `prediction_low` and `prediction_high` fields give the 5-95 percentile

--- a/mhcflurry/version.py
+++ b/mhcflurry/version.py
@@ -1,1 +1,1 @@
-__version__ = "2.3.0rc2"
+__version__ = "2.3.0rc3"


### PR DESCRIPTION
Follow-up README polish:

- Move the citation / issue / contributing block directly under the one-line description.
- Mark the current release candidate as `2.3.0rc2` (was `2.3.0rc1`) and pin install to `==2.3.0rc2`.
- Remove the 2.2.0-backend line and the two descriptive paragraphs (class I intro + experimental predictors).
- De-foreground the niche `compare-models` / `plot-model-comparison` commands; they stay documented in `docs/commandline_tutorial.md`.

`twine check` passes, so the description renders on PyPI. Note: this only reaches PyPI with the next published version (the `2.3.0rc2` page is immutable).