### PR TITLE
README: GitHub [!IMPORTANT] alert, kept PyPI-clean via setup.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,13 @@ Have a bugfix or other contribution? We would love your help. See our [contribut
 
 ## 2.3.0 release candidate
 
-2.3.0 is currently a **release candidate** (`2.3.0rc3`), not yet a final
-release. It keeps the same API and pre-trained models as 2.2.x. Install it by
-pinning the version:
-
-    pip install mhcflurry==2.3.0rc3
-
-For now, `pip install --upgrade mhcflurry` still installs the latest stable
-release (2.2.x), because pip skips pre-releases unless you pin the version or
-pass `--pre`. Once 2.3.0 is released, `pip install --upgrade mhcflurry` will
-upgrade to it as usual.
+> [!IMPORTANT]
+> 2.3.0 is currently a release candidate (`2.3.0rc3`), not yet a final release.
+> It keeps the same public API and pre-trained models as 2.2.x. Install it with
+> `pip install --pre mhcflurry`, or pin the version with
+> `pip install mhcflurry==2.3.0rc3`. A plain `pip install --upgrade mhcflurry`
+> stays on the latest stable release (2.2.x) until 2.3.0 is final, since pip
+> skips pre-releases.
 
 2.3.0 adds speed and tooling for people who train their own models or run large
 prediction jobs:

--- a/mhcflurry/version.py
+++ b/mhcflurry/version.py
@@ -1,1 +1,1 @@
-__version__ = "2.3.0rc3"
+__version__ = "2.3.0rc4"

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,27 @@ except:
     readme = ""
 
 
+def readme_for_pypi(text):
+    # PyPI's Markdown renderer (cmark-gfm) does not support GitHub's
+    # "> [!IMPORTANT]" alert syntax and would display the literal "[!IMPORTANT]"
+    # token. Convert each alert marker line to a bold label so the PyPI
+    # long_description renders as a clean blockquote. GitHub keeps the colored
+    # callout because README.md on disk is unchanged.
+    import re
+    labels = {
+        "NOTE": "Note",
+        "TIP": "Tip",
+        "IMPORTANT": "Important",
+        "WARNING": "Warning",
+        "CAUTION": "Caution",
+    }
+    return re.sub(
+        r"(?m)^(\s*>\s*)\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\][ \t]*$",
+        lambda m: "%s**%s**" % (m.group(1), labels[m.group(2)]),
+        text,
+    )
+
+
 with open("mhcflurry/version.py", "r") as f:
     version = re.search(
         r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]', f.read(), re.MULTILINE
@@ -96,7 +117,7 @@ if __name__ == "__main__":
             "mhcflurry": ["downloads.yml"],
         },
         install_requires=required_packages,
-        long_description=readme,
+        long_description=readme_for_pypi(readme),
         long_description_content_type="text/markdown",
         packages=find_packages(include=["mhcflurry", "mhcflurry.*"]),
     )


### PR DESCRIPTION
Implements the 'option 2' approach so the release-candidate callout shows as a **colored alert on GitHub** while keeping the **PyPI description clean**.

- `README.md`: the RC notice is back inside a `> [!IMPORTANT]` GitHub alert (colored on GitHub). Install line is now `pip install --pre mhcflurry` so it doesn't need re-pinning each rc.
- `setup.py`: `readme_for_pypi()` rewrites `> [!IMPORTANT]` (and other GitHub alert markers) to `> **Important**` for the PyPI `long_description`, because cmark-gfm renders the alert token literally.

Verified against the built wheel's METADATA: no literal `[!IMPORTANT]`, renders as a clean `<blockquote>` with bold **Important**; `README.md` keeps the colored GitHub callout; `twine check` passes.

For rc4 — no release cut here; fold in with other changes.