### PR TITLE
[codex] Fix release-candidate README version

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ Have a bugfix or other contribution? We would love your help. See our [contribut
 ## 2.3.0 release candidate
 
 > [!IMPORTANT]
-> 2.3.0 is currently a release candidate (`2.3.0rc3`), not yet a final release.
+> 2.3.0 is currently a release candidate (`2.3.0rc5`), not yet a final release.
 > It keeps the same public API and pre-trained models as 2.2.x. Install it with
 > `pip install --pre mhcflurry`, or pin the version with
-> `pip install mhcflurry==2.3.0rc3`. A plain `pip install --upgrade mhcflurry`
+> `pip install mhcflurry==2.3.0rc5`. A plain `pip install --upgrade mhcflurry`
 > stays on the latest stable release (2.2.x) until 2.3.0 is final, since pip
 > skips pre-releases.
 

--- a/mhcflurry/version.py
+++ b/mhcflurry/version.py
@@ -1,1 +1,1 @@
-__version__ = "2.3.0rc4"
+__version__ = "2.3.0rc5"


### PR DESCRIPTION
## Summary

Fixes the stale `2.3.0rc3` references in the README release-candidate callout and bumps the package version to `2.3.0rc5` for the follow-up release candidate.

## Root Cause

PR #298 bumped `mhcflurry/version.py` to `2.3.0rc4`, but the README callout still had two explicit `2.3.0rc3` strings.

## Validation

- `rg -n "rc3|RC3" .` returns no matches
- `./lint.sh`
- `pytest test/` (`626 passed, 7 skipped`)
