### PR TITLE
[codex] Clean up amino acid constants for rc7

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ Have a bugfix or other contribution? We would love your help. See our [contribut
 ## 2.3.0 release candidate
 
 > [!IMPORTANT]
-> 2.3.0 is currently a release candidate (`2.3.0rc6`), not yet a final release.
+> 2.3.0 is currently a release candidate (`2.3.0rc7`), not yet a final release.
 > It keeps the same public API and pre-trained models as 2.2.x. Install it with
 > `pip install --pre mhcflurry`, or pin the version with
-> `pip install mhcflurry==2.3.0rc6`. A plain `pip install --upgrade mhcflurry`
+> `pip install mhcflurry==2.3.0rc7`. A plain `pip install --upgrade mhcflurry`
 > stays on the latest stable release (2.2.x) until 2.3.0 is final, since pip
 > skips pre-releases.
 

--- a/mhcflurry/amino_acid.py
+++ b/mhcflurry/amino_acid.py
@@ -17,59 +17,60 @@ vector representations, such as one-hot and BLOSUM62.
 
 import collections
 import warnings
-from copy import copy
 from io import StringIO
 
 import numpy
 import pandas
 
+COMMON_AMINO_ACIDS = collections.OrderedDict(
+    [
+        ("A", "Alanine"),
+        ("C", "Cysteine"),
+        ("D", "Aspartic Acid"),
+        ("E", "Glutamic Acid"),
+        ("F", "Phenylalanine"),
+        ("G", "Glycine"),
+        ("H", "Histidine"),
+        ("I", "Isoleucine"),
+        ("K", "Lysine"),
+        ("L", "Leucine"),
+        ("M", "Methionine"),
+        ("N", "Asparagine"),
+        ("P", "Proline"),
+        ("Q", "Glutamine"),
+        ("R", "Arginine"),
+        ("S", "Serine"),
+        ("T", "Threonine"),
+        ("V", "Valine"),
+        ("W", "Tryptophan"),
+        ("Y", "Tyrosine"),
+    ]
+)
 
-COMMON_AMINO_ACIDS = collections.OrderedDict(sorted({
-    "A": "Alanine",
-    "R": "Arginine",
-    "N": "Asparagine",
-    "D": "Aspartic Acid",
-    "C": "Cysteine",
-    "E": "Glutamic Acid",
-    "Q": "Glutamine",
-    "G": "Glycine",
-    "H": "Histidine",
-    "I": "Isoleucine",
-    "L": "Leucine",
-    "K": "Lysine",
-    "M": "Methionine",
-    "F": "Phenylalanine",
-    "P": "Proline",
-    "S": "Serine",
-    "T": "Threonine",
-    "W": "Tryptophan",
-    "Y": "Tyrosine",
-    "V": "Valine",
-}.items()))
-COMMON_AMINO_ACIDS_WITH_UNKNOWN = copy(COMMON_AMINO_ACIDS)
+COMMON_AMINO_ACIDS_WITH_UNKNOWN = COMMON_AMINO_ACIDS.copy()
 COMMON_AMINO_ACIDS_WITH_UNKNOWN["X"] = "Unknown"
 
-AMINO_ACID_INDEX = dict(
-    (letter, i) for (i, letter) in enumerate(COMMON_AMINO_ACIDS_WITH_UNKNOWN))
+AMINO_ACID_INDEX = {
+    letter: i for i, letter in enumerate(COMMON_AMINO_ACIDS_WITH_UNKNOWN)
+}
 
-for (letter, i) in list(AMINO_ACID_INDEX.items()):
-    AMINO_ACID_INDEX[letter.lower()] = i  # Support lower-case as well.
+for letter, index in list(AMINO_ACID_INDEX.items()):
+    AMINO_ACID_INDEX[letter.lower()] = index  # Support lower-case as well.
 
 AMINO_ACIDS = list(COMMON_AMINO_ACIDS_WITH_UNKNOWN.keys())
 
 # Single canonical letter<->index mapping for the whole codebase. Position
 # of a letter in ``AMINO_ACIDS`` equals ``AMINO_ACID_INDEX[letter]``; X is
 # at index 20. Anything that round-trips between peptide strings and
-# integer index arrays must go through these helpers — that is the
+# integer index arrays must go through these helpers; that is the
 # contract device-resident encoding paths rely on for re-materializing
 # peptides from index tensors.
-
+# Canonical index of the X (unknown) amino acid. This is equal to
+# len(COMMON_AMINO_ACIDS).
 X_INDEX = AMINO_ACID_INDEX["X"]
-"""Canonical index of the X (unknown) amino acid; equal to
-``len(COMMON_AMINO_ACIDS)``."""
 
+# Count of the 20 common amino acids (excludes X).
 NUM_COMMON_AMINO_ACIDS = len(COMMON_AMINO_ACIDS)
-"""Count of the 20 common amino acids (excludes X)."""
 
 
 def peptide_to_indices(peptide, dtype="int8"):
@@ -77,14 +78,14 @@ def peptide_to_indices(peptide, dtype="int8"):
     Convert a peptide string to a 1-D integer index array.
 
     Uppercases the input and uses :data:`AMINO_ACID_INDEX` for the
-    letter→index map so the result matches what
+    letter-to-index map so the result matches what
     :func:`index_encoding` produces for one row.
 
     Parameters
     ----------
     peptide : str
     dtype : numpy dtype, default ``"int8"``
-        Index payloads fit comfortably in int8 (alphabet size 21 ≪ 127).
+        Index payloads fit comfortably in int8 (alphabet size 21 << 127).
 
     Returns
     -------
@@ -104,7 +105,7 @@ def indices_to_peptide(indices):
     Inverse of :func:`peptide_to_indices` for canonical alphabet
     members. Indices at or above the alphabet size raise
     :class:`IndexError`; negative indices wrap (Python list indexing
-    semantics) — no per-element bounds check is added because this is a
+    semantics); no per-element bounds check is added because this is a
     tight per-position loop on a hot re-materialization path.
 
     Parameters
@@ -117,7 +118,10 @@ def indices_to_peptide(indices):
     """
     return "".join(AMINO_ACIDS[int(i)] for i in indices)
 
-BLOSUM62_MATRIX = pandas.read_csv(StringIO("""
+
+BLOSUM62_MATRIX = (
+    pandas.read_csv(
+        StringIO("""
    A  R  N  D  C  Q  E  G  H  I  L  K  M  F  P  S  T  W  Y  V  X
 A  4 -1 -2 -2  0 -1 -1  0 -2 -1 -1 -1 -1 -2 -1  1  0 -3 -2  0  0
 R -1  5  0 -2 -3  1  0 -2  0 -3 -2  2 -1 -3 -2 -1 -1 -3 -2 -3  0
@@ -140,7 +144,12 @@ W -3 -3 -4 -4 -2 -2 -3 -2 -2 -3 -2 -3 -1  1 -4 -3 -2 11  2 -3  0
 Y -2 -2 -2 -3 -2 -1 -2 -3  2 -1 -1 -2 -1  3 -3 -2 -2  2  7 -1  0
 V  0 -3 -3 -3 -1 -2 -2 -3 -3  3  1 -2  1 -1 -2 -2  0 -3 -1  4  0
 X  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  1
-"""), sep=r'\s+').loc[AMINO_ACIDS, AMINO_ACIDS].astype("int8")
+"""),
+        sep=r"\s+",
+    )
+    .loc[AMINO_ACIDS, AMINO_ACIDS]
+    .astype("int8")
+)
 assert (BLOSUM62_MATRIX == BLOSUM62_MATRIX.T).all().all()
 
 
@@ -160,7 +169,9 @@ def _matrix_with_unknown(df, dtype="float32"):
     return result.loc[AMINO_ACIDS, AMINO_ACIDS].astype(dtype)
 
 
-PMBEC_MATRIX = _matrix_with_unknown(pandas.read_csv(StringIO("""
+PMBEC_MATRIX = _matrix_with_unknown(
+    pandas.read_csv(
+        StringIO("""
    A C D E F G H I K L M N P Q R S T V W Y
 A 0.322860152036 0.0113750373506 -0.0156239175966 -0.00259952715456 -0.0508792185716 0.0382679273874 -0.0832539299638 -0.00196691041626 -0.0103729638696 -0.042393907322 -0.0651042403697 -0.0853704925231 0.0757409633086 -0.0483151514798 -0.0136431408498 0.038455041596 0.0520376087986 0.081101427454 -0.125564718844 -0.0747500389698
 C 0.0113750373506 0.100680270274 0.0102951033136 0.0147570340938 0.0345785831581 0.00933463557214 -0.00750101609651 0.00476007239717 -0.0459237939975 -0.0182998264075 -0.0155971113182 0.0021128481374 -0.00860770840682 -0.0309903425175 -0.0482562439545 -0.0217965163697 -0.0227322740574 -0.0154276574266 0.0412325888637 0.00600631739163
@@ -182,7 +193,11 @@ T 0.0520376087986 -0.0227322740574 0.00656101264316 -0.0054830504799 -0.07772923
 V 0.081101427454 -0.0154276574266 -0.0193560886308 -0.00806269508269 -0.015794520965 -0.0127217072682 -0.0870188771708 0.091300054417 -0.0400367780545 0.0449678806271 -0.0120310888206 -0.0436807942705 0.0225294243984 -0.032780800211 -0.0934989556047 -0.00816241136786 0.0493244941272 0.172778293246 -0.0289445753682 -0.0444846240282
 W -0.125564718844 0.0412325888637 0.00415097887978 -0.00791955104235 0.0625957490761 -0.0246539147339 0.0123622841944 0.00138488610169 -0.0598522551401 -0.00754567267671 0.0210041287765 0.0296409813073 -0.0525069717881 -0.0118972341632 -0.0557627605155 -0.0444334801409 -0.0264928932645 -0.0289445753682 0.194048086876 0.0791543436022
 Y -0.0747500389698 0.00600631739163 -0.0191575919464 -0.0231187170833 0.0858189617896 -0.0205094859119 0.0365879336865 -0.0230596885329 -0.00464804635586 -0.0137219703366 0.0126203200265 -0.00205806264345 -0.0890062760945 -0.0487465602402 0.00827128508526 -0.0561239385213 -0.0468623824337 -0.0444846240282 0.0791543436022 0.237788221516
-"""), sep=r"\s+", index_col=0))
+"""),
+        sep=r"\s+",
+        index_col=0,
+    )
+)
 assert numpy.allclose(PMBEC_MATRIX, PMBEC_MATRIX.T)
 
 
@@ -205,7 +220,9 @@ def _lower_triangular_matrix(values, amino_acids):
     return pandas.DataFrame(matrix, index=amino_acids, columns=amino_acids)
 
 
-CONTACT_MATRIX = _matrix_with_unknown(_lower_triangular_matrix("""
+CONTACT_MATRIX = _matrix_with_unknown(
+    _lower_triangular_matrix(
+        """
 -0.06711
 0.06154 -0.08474
 0.09263 -0.15773 -0.17967
@@ -226,7 +243,10 @@ CONTACT_MATRIX = _matrix_with_unknown(_lower_triangular_matrix("""
 0.08732 0.07735 0.00987 0.02263 -0.02572 -0.06867 -0.04921 0.10405 -0.11836 0.03430 -0.06007 0.14702 -0.06644 -0.11108 0.01048 0.01889 0.01650 -0.07522
 0.03904 0.02232 -0.01661 -0.05851 -0.01389 -0.04713 -0.08186 0.04000 -0.03306 0.02135 0.00677 0.06447 -0.00096 -0.02173 -0.05590 0.00139 0.00633 -0.09071 -0.03925
 -0.07279 0.17288 0.10802 0.14779 0.00772 0.11813 0.11895 0.02340 0.07075 -0.13605 -0.06701 0.12223 -0.01508 -0.04855 0.11169 0.03754 0.01024 0.01594 0.03319 -0.10756
-""", list("ARNDCQEGHILKMFPSTWYV")))
+""",
+        list("ARNDCQEGHILKMFPSTWYV"),
+    )
+)
 assert numpy.allclose(CONTACT_MATRIX, CONTACT_MATRIX.T)
 
 # Five Atchley physicochemical factors from Atchley et al. 2005
@@ -235,35 +255,43 @@ assert numpy.allclose(CONTACT_MATRIX, CONTACT_MATRIX.T)
 # molecular size, codon composition, and electrostatic charge. X is
 # represented as zeros, matching the "unknown/no signal" convention
 # used by the BLOSUM62 X row.
-ATCHLEY_FACTORS = pandas.DataFrame.from_dict({
-    "A": [-0.591, -1.302, -0.733, 1.570, -0.146],
-    "R": [1.538, -0.055, 1.502, 0.440, 2.897],
-    "N": [0.945, 0.828, 1.299, -0.169, 0.933],
-    "D": [1.050, 0.302, -3.656, -0.259, -3.242],
-    "C": [-1.343, 0.465, -0.862, -1.020, -0.255],
-    "E": [1.357, -1.453, 1.477, 0.113, -0.837],
-    "Q": [0.931, -0.179, -3.005, -0.503, -1.853],
-    "G": [-0.384, 1.652, 1.330, 1.045, 2.064],
-    "H": [0.336, -0.417, -1.673, -1.474, -0.078],
-    "I": [-1.239, -0.547, 2.131, 0.393, 0.816],
-    "L": [-1.019, -0.987, -1.505, 1.266, -0.912],
-    "K": [1.831, -0.561, 0.533, -0.277, 1.648],
-    "M": [-0.663, -1.524, 2.219, -1.005, 1.212],
-    "F": [-1.006, -0.590, 1.891, -0.397, 0.412],
-    "P": [0.189, 2.081, -1.628, 0.421, -1.392],
-    "S": [-0.228, 1.399, -4.760, 0.670, -2.647],
-    "T": [-0.032, 0.326, 2.213, 0.908, 1.313],
-    "W": [-0.595, 0.009, 0.672, -2.128, -0.184],
-    "Y": [0.260, 0.830, 3.097, -0.838, 1.512],
-    "V": [-1.337, -0.279, -0.544, 1.242, -1.262],
-    "X": [0.0, 0.0, 0.0, 0.0, 0.0],
-}, orient="index", columns=[
-    "atchley_polarity",
-    "atchley_secondary_structure",
-    "atchley_molecular_size",
-    "atchley_codon_composition",
-    "atchley_electrostatic_charge",
-]).loc[AMINO_ACIDS].astype("float32")
+ATCHLEY_FACTORS = (
+    pandas.DataFrame.from_dict(
+        {
+            "A": [-0.591, -1.302, -0.733, 1.570, -0.146],
+            "R": [1.538, -0.055, 1.502, 0.440, 2.897],
+            "N": [0.945, 0.828, 1.299, -0.169, 0.933],
+            "D": [1.050, 0.302, -3.656, -0.259, -3.242],
+            "C": [-1.343, 0.465, -0.862, -1.020, -0.255],
+            "E": [1.357, -1.453, 1.477, 0.113, -0.837],
+            "Q": [0.931, -0.179, -3.005, -0.503, -1.853],
+            "G": [-0.384, 1.652, 1.330, 1.045, 2.064],
+            "H": [0.336, -0.417, -1.673, -1.474, -0.078],
+            "I": [-1.239, -0.547, 2.131, 0.393, 0.816],
+            "L": [-1.019, -0.987, -1.505, 1.266, -0.912],
+            "K": [1.831, -0.561, 0.533, -0.277, 1.648],
+            "M": [-0.663, -1.524, 2.219, -1.005, 1.212],
+            "F": [-1.006, -0.590, 1.891, -0.397, 0.412],
+            "P": [0.189, 2.081, -1.628, 0.421, -1.392],
+            "S": [-0.228, 1.399, -4.760, 0.670, -2.647],
+            "T": [-0.032, 0.326, 2.213, 0.908, 1.313],
+            "W": [-0.595, 0.009, 0.672, -2.128, -0.184],
+            "Y": [0.260, 0.830, 3.097, -0.838, 1.512],
+            "V": [-1.337, -0.279, -0.544, 1.242, -1.262],
+            "X": [0.0, 0.0, 0.0, 0.0, 0.0],
+        },
+        orient="index",
+        columns=[
+            "atchley_polarity",
+            "atchley_secondary_structure",
+            "atchley_molecular_size",
+            "atchley_codon_composition",
+            "atchley_electrostatic_charge",
+        ],
+    )
+    .loc[AMINO_ACIDS]
+    .astype("float32")
+)
 
 
 def _standardize_over_common_amino_acids(df):
@@ -284,47 +312,55 @@ def _standardize_over_common_amino_acids(df):
 # Kyte-Doolittle hydropathy plus Grantham composition, polarity, and volume.
 # The remaining columns are direct side-chain chemistry indicators. X is the
 # neutral/no-signal row, matching the convention used by BLOSUM62.
-_PHYSCHEM_CONTINUOUS_RAW = pandas.DataFrame.from_dict({
-    "A": [1.8, 0.00, 8.1, 31.0],
-    "R": [-4.5, 0.65, 10.5, 124.0],
-    "N": [-3.5, 1.33, 11.6, 56.0],
-    "D": [-3.5, 1.38, 13.0, 54.0],
-    "C": [2.5, 2.75, 5.5, 55.0],
-    "Q": [-3.5, 0.89, 10.5, 85.0],
-    "E": [-3.5, 0.92, 12.3, 83.0],
-    "G": [-0.4, 0.74, 9.0, 3.0],
-    "H": [-3.2, 0.58, 10.4, 96.0],
-    "I": [4.5, 0.00, 5.2, 111.0],
-    "L": [3.8, 0.00, 4.9, 111.0],
-    "K": [-3.9, 0.33, 11.3, 119.0],
-    "M": [1.9, 0.00, 5.7, 105.0],
-    "F": [2.8, 0.00, 5.2, 132.0],
-    "P": [-1.6, 0.39, 8.0, 32.5],
-    "S": [-0.8, 1.42, 9.2, 32.0],
-    "T": [-0.7, 0.71, 8.6, 61.0],
-    "W": [-0.9, 0.13, 5.4, 170.0],
-    "Y": [-1.3, 0.20, 6.2, 136.0],
-    "V": [4.2, 0.00, 5.9, 84.0],
-    "X": [0.0, 0.0, 0.0, 0.0],
-}, orient="index", columns=[
-    "z_kd_hydropathy",
-    "z_grantham_composition",
-    "z_grantham_polarity",
-    "z_grantham_volume",
-]).loc[AMINO_ACIDS]
+_PHYSCHEM_CONTINUOUS_RAW = pandas.DataFrame.from_dict(
+    {
+        "A": [1.8, 0.00, 8.1, 31.0],
+        "R": [-4.5, 0.65, 10.5, 124.0],
+        "N": [-3.5, 1.33, 11.6, 56.0],
+        "D": [-3.5, 1.38, 13.0, 54.0],
+        "C": [2.5, 2.75, 5.5, 55.0],
+        "Q": [-3.5, 0.89, 10.5, 85.0],
+        "E": [-3.5, 0.92, 12.3, 83.0],
+        "G": [-0.4, 0.74, 9.0, 3.0],
+        "H": [-3.2, 0.58, 10.4, 96.0],
+        "I": [4.5, 0.00, 5.2, 111.0],
+        "L": [3.8, 0.00, 4.9, 111.0],
+        "K": [-3.9, 0.33, 11.3, 119.0],
+        "M": [1.9, 0.00, 5.7, 105.0],
+        "F": [2.8, 0.00, 5.2, 132.0],
+        "P": [-1.6, 0.39, 8.0, 32.5],
+        "S": [-0.8, 1.42, 9.2, 32.0],
+        "T": [-0.7, 0.71, 8.6, 61.0],
+        "W": [-0.9, 0.13, 5.4, 170.0],
+        "Y": [-1.3, 0.20, 6.2, 136.0],
+        "V": [4.2, 0.00, 5.9, 84.0],
+        "X": [0.0, 0.0, 0.0, 0.0],
+    },
+    orient="index",
+    columns=[
+        "z_kd_hydropathy",
+        "z_grantham_composition",
+        "z_grantham_polarity",
+        "z_grantham_volume",
+    ],
+).loc[AMINO_ACIDS]
 
-_PHYSCHEM_BINARY = pandas.DataFrame(0.0, index=AMINO_ACIDS, columns=[
-    "side_chain_charge",
-    "aromatic",
-    "sulfur",
-    "hydroxyl",
-    "amide",
-    "acidic",
-    "basic",
-    "aliphatic",
-    "glycine",
-    "proline",
-])
+_PHYSCHEM_BINARY = pandas.DataFrame(
+    0.0,
+    index=AMINO_ACIDS,
+    columns=[
+        "side_chain_charge",
+        "aromatic",
+        "sulfur",
+        "hydroxyl",
+        "amide",
+        "acidic",
+        "basic",
+        "aliphatic",
+        "glycine",
+        "proline",
+    ],
+)
 _PHYSCHEM_BINARY.loc[["D", "E"], "side_chain_charge"] = -1.0
 _PHYSCHEM_BINARY.loc[["K", "R"], "side_chain_charge"] = 1.0
 _PHYSCHEM_BINARY.loc["H", "side_chain_charge"] = 0.1
@@ -338,19 +374,26 @@ _PHYSCHEM_BINARY.loc[["A", "I", "L", "M", "V"], "aliphatic"] = 1.0
 _PHYSCHEM_BINARY.loc["G", "glycine"] = 1.0
 _PHYSCHEM_BINARY.loc["P", "proline"] = 1.0
 
-PHYSICOCHEMICAL_PROPERTIES = pandas.concat([
-    _standardize_over_common_amino_acids(_PHYSCHEM_CONTINUOUS_RAW),
-    _PHYSCHEM_BINARY,
-], axis=1).astype("float32")
+PHYSICOCHEMICAL_PROPERTIES = pandas.concat(
+    [
+        _standardize_over_common_amino_acids(_PHYSCHEM_CONTINUOUS_RAW),
+        _PHYSCHEM_BINARY,
+    ],
+    axis=1,
+).astype("float32")
 assert numpy.isfinite(PHYSICOCHEMICAL_PROPERTIES.values).all()
 assert (PHYSICOCHEMICAL_PROPERTIES.loc["X"].values == 0.0).all()
 
 ENCODING_DATA_FRAMES = {
     "BLOSUM62": BLOSUM62_MATRIX,
-    "one-hot": pandas.DataFrame([
-        [1 if i == j else 0 for i in range(len(AMINO_ACIDS))]
-        for j in range(len(AMINO_ACIDS))
-    ], index=AMINO_ACIDS, columns=AMINO_ACIDS),
+    "one-hot": pandas.DataFrame(
+        [
+            [1 if i == j else 0 for i in range(len(AMINO_ACIDS))]
+            for j in range(len(AMINO_ACIDS))
+        ],
+        index=AMINO_ACIDS,
+        columns=AMINO_ACIDS,
+    ),
     "PMBEC": PMBEC_MATRIX,
     "pmbec": PMBEC_MATRIX,
     "contact": CONTACT_MATRIX,
@@ -408,9 +451,7 @@ def get_vector_encoding_df(name):
             if len(parts) < 2:
                 raise KeyError(name)
             frames = [
-                get_vector_encoding_df(part).loc[AMINO_ACIDS].add_prefix(
-                    "%s:" % part
-                )
+                get_vector_encoding_df(part).loc[AMINO_ACIDS].add_prefix("%s:" % part)
                 for part in parts
             ]
             composite = pandas.concat(
@@ -486,8 +527,9 @@ def vector_encoding_index_table(name):
     paths should both use this helper to keep amino-acid index semantics
     centralized.
     """
-    return get_vector_encoding_df(name).loc[AMINO_ACIDS].to_numpy().astype(
-        numpy.float32)
+    return (
+        get_vector_encoding_df(name).loc[AMINO_ACIDS].to_numpy().astype(numpy.float32)
+    )
 
 
 def index_encoding(sequences, letter_to_index_dict):
@@ -510,10 +552,12 @@ def index_encoding(sequences, letter_to_index_dict):
     """
     df = pandas.DataFrame(iter(s) for s in sequences)
     with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=FutureWarning,
-                                message=".*Downcasting.*")
-        warnings.filterwarnings("ignore", category=DeprecationWarning,
-                                message=".*no_silent_downcasting.*")
+        warnings.filterwarnings(
+            "ignore", category=FutureWarning, message=".*Downcasting.*"
+        )
+        warnings.filterwarnings(
+            "ignore", category=DeprecationWarning, message=".*no_silent_downcasting.*"
+        )
         result = df.replace(letter_to_index_dict).infer_objects()
     return result.values
 
@@ -537,9 +581,8 @@ def fixed_vectors_encoding(index_encoded_sequences, letter_to_vector_df):
     -------
     numpy.array of integers with shape (`n`, `k`, `m`)
     """
-    (num_sequences, sequence_length) = index_encoded_sequences.shape
-    target_shape = (
-        num_sequences, sequence_length, letter_to_vector_df.shape[1])
+    num_sequences, sequence_length = index_encoded_sequences.shape
+    target_shape = (num_sequences, sequence_length, letter_to_vector_df.shape[1])
     result = letter_to_vector_df.iloc[
         index_encoded_sequences.reshape((-1,))  # reshape() avoids copy
     ].values.reshape(target_shape)

--- a/mhcflurry/class1_affinity_predictor.py
+++ b/mhcflurry/class1_affinity_predictor.py
@@ -1408,9 +1408,9 @@ class Class1AffinityPredictor(object):
             DEFAULT_PREDICT_BATCH_SIZE,
             resolve_prediction_batch_size,
         )
-        from .torch_training_loop import (
-            _configure_matmul_precision,
-            _maybe_compile_network,
+        from .pytorch_training import (
+            configure_matmul_precision,
+            maybe_compile_network,
         )
 
         peptides = EncodableSequences.create(peptides)
@@ -1483,10 +1483,10 @@ class Class1AffinityPredictor(object):
         model_obj.set_allele_representations(allele_representations)
 
         device = model_obj.get_device()
-        _configure_matmul_precision(device)
+        configure_matmul_precision(device)
         network = model_obj.network(borrow=True)
         network.to(device)
-        network = _maybe_compile_network(network, device)
+        network = maybe_compile_network(network, device)
         network.eval()
 
         n_peptides = len(peptides)

--- a/mhcflurry/class1_neural_network.py
+++ b/mhcflurry/class1_neural_network.py
@@ -44,13 +44,13 @@ from .random_negative_peptides import (
     supports_device_random_negative_encoding,
 )
 from .class1_affinity_training_data import AffinityDeviceTrainingData
-from .torch_training_loop import (
-    _configure_matmul_precision,
-    _effective_validation_batch_size,
-    _maybe_compile_loss,
-    _maybe_compile_network,
-    _uncompiled_network,
-    _validation_forward_network,
+from .pytorch_training import (
+    configure_matmul_precision,
+    effective_validation_batch_size,
+    maybe_compile_loss,
+    maybe_compile_network,
+    uncompiled_network,
+    validation_forward_network,
 )
 
 
@@ -3424,7 +3424,7 @@ class Class1NeuralNetwork(object):
         phases of a pan-allele fit.
         """
         device = self.get_device()
-        _configure_matmul_precision(device)
+        configure_matmul_precision(device)
 
         # Single-seed control, mirroring fit(): seed up front so weight init
         # and shuffling in this pass are reproducible. See fit() for detail.
@@ -3593,13 +3593,13 @@ class Class1NeuralNetwork(object):
         # burns through the 8-entry cache_size_limit in seconds and falls
         # back to eager. Compiling after gives dynamo a single stable
         # hook state to specialize on.
-        network = _maybe_compile_network(network, device)
-        eager_network = _uncompiled_network(network)
-        # Compile the loss alongside the network — see _maybe_compile_loss
+        network = maybe_compile_network(network, device)
+        eager_network = uncompiled_network(network)
+        # Compile the loss alongside the network; see maybe_compile_loss
         # docstring. MSEWithInequalities eager-dispatches ~10 kernels
         # per step; fusing them matters more as batch size grows (less
         # compute to amortize launch overhead against).
-        loss_obj = _maybe_compile_loss(loss_obj, device)
+        loss_obj = maybe_compile_loss(loss_obj, device)
 
         min_val_loss_iteration = None
         min_val_loss = None
@@ -3710,14 +3710,14 @@ class Class1NeuralNetwork(object):
                 network.eval()
                 with torch.inference_mode():
                     validation_start = _timing_start(device, timing_enabled)
-                    val_batch_size = _effective_validation_batch_size(
+                    val_batch_size = effective_validation_batch_size(
                         device,
                         self.hyperparameters["validation_batch_size"],
                         self.hyperparameters["minibatch_size"],
                     )
                     fit_info["effective_validation_batch_size"] = val_batch_size
                     val_loss = _batched_validation_loss(
-                        network=_validation_forward_network(network, eager_network),
+                        network=validation_forward_network(network, eager_network),
                         eager_network=eager_network,
                         val_peptide=val_peptide_device,
                         val_allele=val_allele_device,
@@ -3988,7 +3988,7 @@ class Class1NeuralNetwork(object):
             bit-identical run-to-run. CPU runs are fully deterministic.
         """
         device = self.get_device()
-        _configure_matmul_precision(device)
+        configure_matmul_precision(device)
 
         # One seed controls every stochastic step in this fit. Seed numpy's
         # and torch's global RNGs up front so weight init, the example
@@ -4420,14 +4420,14 @@ class Class1NeuralNetwork(object):
                 needs_initialization = False
 
             # Compile AFTER LSUV hook churn finishes (see fit_streaming_batches
-            # comment above). Idempotent — _maybe_compile_network returns
+            # comment above). Idempotent: maybe_compile_network returns
             # the OptimizedModule unchanged if ``network`` is already
             # compiled, so it's safe to call every epoch. First epoch's
             # first batch pays the codegen cost; rest runs compiled.
-            network = _maybe_compile_network(network, device)
-            eager_network = _uncompiled_network(network)
+            network = maybe_compile_network(network, device)
+            eager_network = uncompiled_network(network)
             # Same rationale as fit_streaming_batches' loss-compile call.
-            loss_obj = _maybe_compile_loss(loss_obj, device)
+            loss_obj = maybe_compile_loss(loss_obj, device)
 
             # Train indices live on device — train_indices_base is
             # contiguous [0, n_train), so a shuffled view is just
@@ -4567,7 +4567,7 @@ class Class1NeuralNetwork(object):
                         validation_materialize_time += (
                             time.perf_counter() - materialize_start
                         )
-                    val_batch_size = _effective_validation_batch_size(
+                    val_batch_size = effective_validation_batch_size(
                         device,
                         self.hyperparameters["validation_batch_size"],
                         batch_size,
@@ -4575,7 +4575,7 @@ class Class1NeuralNetwork(object):
                     fit_info["effective_validation_batch_size"] = val_batch_size
                     validation_start = _timing_start(device, timing_enabled)
                     val_loss = _batched_validation_loss(
-                        network=_validation_forward_network(network, eager_network),
+                        network=validation_forward_network(network, eager_network),
                         eager_network=eager_network,
                         val_peptide=val_peptide,
                         val_allele=val_allele,
@@ -4778,7 +4778,7 @@ class Class1NeuralNetwork(object):
             return self.prediction_cache[peptides].copy()
 
         device = self.get_device()
-        _configure_matmul_precision(device)
+        configure_matmul_precision(device)
 
         x_dict = {"peptide": self.peptides_to_network_input(peptides)}
 
@@ -4794,7 +4794,7 @@ class Class1NeuralNetwork(object):
             network = self.network(borrow=True)
 
         network.to(device)
-        network = _maybe_compile_network(network, device)
+        network = maybe_compile_network(network, device)
         network.eval()
 
         # Resolve ``"auto"`` once the network is on device so the

--- a/mhcflurry/class1_presentation_predictor.py
+++ b/mhcflurry/class1_presentation_predictor.py
@@ -844,10 +844,16 @@ class Class1PresentationPredictor(object):
         if processing_scores is not None:
             df["processing_score"] = df.peptide_num.map(
                 pandas.Series(processing_scores))
-            if c_flanks is not None:
-                df.insert(1, "c_flank", df.peptide_num.map(pandas.Series(c_flanks)))
             if n_flanks is not None:
-                df.insert(1, "n_flank", df.peptide_num.map(pandas.Series(n_flanks)))
+                flank_df = pandas.DataFrame({
+                    "n_flank": df.peptide_num.map(pandas.Series(n_flanks)),
+                    "c_flank": df.peptide_num.map(pandas.Series(c_flanks)),
+                })
+                leading_columns = [df.columns[0]]
+                df = pandas.concat(
+                    [df[leading_columns], flank_df, df.drop(columns=leading_columns)],
+                    axis=1,
+                )
 
         predict_presentation = (
                 "affinity_score" in df.columns and
@@ -1152,15 +1158,18 @@ class Class1PresentationPredictor(object):
             affinity_model_kwargs=affinity_model_kwargs,
             processing_batch_size=processing_batch_size)
 
-        result_df.insert(
-            0,
-            "sequence_name",
-            result_df.peptide_num.map(pandas.Series(sequence_names)))
-        result_df.insert(
-            1,
-            "pos",
-            result_df.peptide_num.map(pandas.Series(position_in_sequence)))
-        del result_df["peptide_num"]
+        sequence_metadata = pandas.DataFrame({
+            "sequence_name": result_df.peptide_num.map(
+                pandas.Series(sequence_names)
+            ),
+            "pos": result_df.peptide_num.map(
+                pandas.Series(position_in_sequence)
+            ),
+        })
+        result_df = pandas.concat(
+            [sequence_metadata, result_df.drop(columns=["peptide_num"])],
+            axis=1,
+        )
 
         comparison_is_score = comparison_quantity.endswith("score")
 

--- a/mhcflurry/class1_processing_neural_network.py
+++ b/mhcflurry/class1_processing_neural_network.py
@@ -29,12 +29,12 @@ from .hyperparameters import HyperparameterDefaults
 from .class1_neural_network import DEFAULT_PREDICT_BATCH_SIZE, _torch_from_numpy
 from .flanking_encoding import FlankingEncoding
 from .common import get_pytorch_device
-from .torch_training_loop import (
-    _configure_matmul_precision,
-    _maybe_compile_loss,
-    _maybe_compile_network,
-    _uncompiled_network,
-    _validation_forward_network,
+from .pytorch_training import (
+    configure_matmul_precision,
+    maybe_compile_loss,
+    maybe_compile_network,
+    uncompiled_network,
+    validation_forward_network,
 )
 
 
@@ -746,7 +746,7 @@ class Class1ProcessingNeuralNetwork(object):
             ``seed`` so one value can drive both trainers.
         """
         device = self.get_device()
-        _configure_matmul_precision(device)
+        configure_matmul_precision(device)
 
         # One seed controls every stochastic step in this fit. Seed numpy's
         # and torch's global RNGs up front so weight init, the example
@@ -790,8 +790,8 @@ class Class1ProcessingNeuralNetwork(object):
         # fit_streaming_batches()
         # paths so production opt-ins (MHCFLURRY_TORCH_COMPILE=1) light up
         # both trainers.
-        network = _maybe_compile_network(network, device)
-        eager_network = _uncompiled_network(network)
+        network = maybe_compile_network(network, device)
+        eager_network = uncompiled_network(network)
 
         # Setup optimizer
         optimizer = self._create_optimizer(network)
@@ -800,7 +800,7 @@ class Class1ProcessingNeuralNetwork(object):
         # compile gate as affinity losses so processing, affinity pretrain,
         # and affinity finetune use one torch performance policy. Presentation
         # training is a separate model family and does not enter this path.
-        loss_fn = _maybe_compile_loss(nn.BCELoss(reduction='none'), device)
+        loss_fn = maybe_compile_loss(nn.BCELoss(reduction='none'), device)
 
         # Validation split
         val_split = self.hyperparameters["validation_split"]
@@ -884,7 +884,7 @@ class Class1ProcessingNeuralNetwork(object):
 
             # Validation
             if val_split > 0:
-                validation_network = _validation_forward_network(
+                validation_network = validation_forward_network(
                     network, eager_network)
                 validation_network.eval()
                 with torch.no_grad():
@@ -1086,13 +1086,13 @@ class Class1ProcessingNeuralNetwork(object):
             device = self.get_device()
         else:
             device = torch.device(device)
-        _configure_matmul_precision(device)
+        configure_matmul_precision(device)
 
         x_dict = self.network_input_tensors(
             sequences=sequences, device=device, throw=throw)
         network = self.network()
         network.to(device)
-        network = _maybe_compile_network(network, device)
+        network = maybe_compile_network(network, device)
         network.eval()
 
         batch_size = resolve_prediction_batch_size(

--- a/mhcflurry/local_parallelism.py
+++ b/mhcflurry/local_parallelism.py
@@ -863,8 +863,8 @@ def resolve_local_parallelism_args(
     args.workload_plan = plan
 
     # Promote orchestrator-owned tuning knobs from CLI to env so the
-    # existing call sites (torch_training_loop._maybe_compile_network,
-    # _configure_matmul_precision, class1_neural_network._timing_enabled,
+    # existing call sites (pytorch_training.maybe_compile_network,
+    # configure_matmul_precision, class1_neural_network._timing_enabled,
     # hoist_torchinductor_compile_threads) read a single source of truth.
     # Auto -> leave env untouched (preserves backward-compat for env-only
     # deploys); explicit CLI value -> overrides env. Workers inherit
@@ -1421,7 +1421,7 @@ def add_local_parallelism_args(parser):
         default="auto",
         help="Enable torch.compile for training loss modules. 'auto' "
              "(default) reads MHCFLURRY_TORCH_COMPILE_LOSS env; when unset, "
-             "loss compilation defaults on inside _maybe_compile_loss. CUDA "
+             "loss compilation defaults on inside maybe_compile_loss. CUDA "
              "workers run a one-op autograd warmup before compiling losses to "
              "avoid the PyTorch 2.4 / Triton invalid-device-context bug.")
     group.add_argument(

--- a/mhcflurry/motif_summary.py
+++ b/mhcflurry/motif_summary.py
@@ -263,14 +263,20 @@ def motif_summary_chunk_gpu(
     freq_matrices = []
     for cutoff_fraction, k, L, freq_t in freq_tensors:
         freq_arr = freq_t.cpu().numpy()  # (a_size, L, 20)
-        wide = freq_arr.reshape(a_size * L, 20)
-        df = pandas.DataFrame(wide, columns=aa_columns)
-        df.insert(0, "allele", numpy.repeat(batch_alleles_arr, L))
-        df.insert(1, "length", L)
-        df.insert(2, "cutoff_fraction", cutoff_fraction)
-        df.insert(3, "cutoff_count", k)
-        df.insert(
-            4, "position", numpy.tile(numpy.arange(1, L + 1), a_size),
+        row_count = a_size * L
+        wide = freq_arr.reshape(row_count, 20)
+        row_metadata = pandas.DataFrame(
+            {
+                "allele": numpy.repeat(batch_alleles_arr, L),
+                "length": numpy.full(row_count, L, dtype=numpy.int64),
+                "cutoff_fraction": numpy.full(row_count, cutoff_fraction),
+                "cutoff_count": numpy.full(row_count, k, dtype=numpy.int64),
+                "position": numpy.tile(numpy.arange(1, L + 1), a_size),
+            }
+        )
+        df = pandas.concat(
+            [row_metadata, pandas.DataFrame(wide, columns=aa_columns)],
+            axis=1,
         )
         freq_matrices.append(df)
 

--- a/mhcflurry/pytorch_training.py
+++ b/mhcflurry/pytorch_training.py
@@ -10,7 +10,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Shared PyTorch training-loop helpers used by multiple mhcflurry trainers.
+"""Shared PyTorch training helpers used by multiple mhcflurry trainers.
 
 These helpers are model-agnostic: they assume only that the caller has a
 ``torch.nn.Module`` network and a ``torch.device``. The pure-helper subset
@@ -34,7 +34,7 @@ from .local_parallelism import resolve_torchinductor_compile_threads_env
 _TRITON_AUTOGRAD_WARMED_DEVICES = set()
 
 
-def _configure_matmul_precision(device):
+def configure_matmul_precision(device):
     """Optionally enable TF32 + cuDNN benchmark on CUDA Ampere+.
 
     Both are runtime settings with no JIT/startup overhead, but TF32 changes
@@ -90,13 +90,13 @@ def _configure_matmul_precision(device):
         torch.backends.cudnn.benchmark = True
 
 
-def _maybe_compile_network(network, device):
+def maybe_compile_network(network, device):
     """Wrap ``network`` with ``torch.compile`` when the env asks for it.
 
     Gated on ``MHCFLURRY_TORCH_COMPILE=1`` and a CUDA device.
     ``torch.compile`` is heavy: JIT graph capture + kernel fusion + on-
     disk cache + recompile-on-shape-change. The TF32 knob is cheaper
-    and independent — see ``_configure_matmul_precision``.
+    and independent — see ``configure_matmul_precision``.
 
     ``MHCFLURRY_TORCH_COMPILE_MODE`` picks the ``mode=`` kwarg (default,
     reduce-overhead, max-autotune). Default is "default" — codegen time
@@ -141,11 +141,11 @@ def _maybe_compile_network(network, device):
     return torch.compile(network, mode=mode, dynamic=dynamic)
 
 
-def _maybe_compile_loss(loss_obj, device):
+def maybe_compile_loss(loss_obj, device):
     """Wrap a loss module with ``torch.compile`` when the env asks for it.
 
     Gated on ``MHCFLURRY_TORCH_COMPILE=1`` and a CUDA device — same
-    criteria as ``_maybe_compile_network``. ``MSEWithInequalities``
+    criteria as ``maybe_compile_network``. ``MSEWithInequalities``
     issues ~10 small elementwise kernels per step in eager mode
     (reshape → subtract → compare → cast → multiply → compare → cast →
     multiply → square → sum), each with its own launch overhead that
@@ -205,19 +205,19 @@ def _warm_cuda_autograd_for_triton(device):
     _TRITON_AUTOGRAD_WARMED_DEVICES.add(key)
 
 
-def _uncompiled_network(network):
+def uncompiled_network(network):
     """Return the eager module behind ``network``."""
     return network._orig_mod if hasattr(network, "_orig_mod") else network
 
 
-def _validation_forward_network(network, eager_network):
+def validation_forward_network(network, eager_network):
     """Choose the module used for validation forward passes during training."""
     if os.environ.get("MHCFLURRY_TORCH_COMPILE_VALIDATION", "0") == "1":
         return network
     return eager_network
 
 
-def _effective_validation_batch_size(
+def effective_validation_batch_size(
         device, configured_batch_size, minibatch_size):
     """Return the validation batch size to use for the current device.
 

--- a/mhcflurry/version.py
+++ b/mhcflurry/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.3.0rc6"
+__version__ = "2.3.0rc7"

--- a/scripts/training/pan_allele_release_affinity.sh
+++ b/scripts/training/pan_allele_release_affinity.sh
@@ -290,7 +290,7 @@ PARALLELISM_ARGS=(
     # Orchestrator-owned tuning knobs. CLI-resolved values are propagated
     # to env (MHCFLURRY_TORCH_COMPILE / MHCFLURRY_MATMUL_PRECISION /
     # MHCFLURRY_ENABLE_TIMING) inside resolve_local_parallelism_args, so
-    # the existing _maybe_compile_network / _configure_matmul_precision /
+    # the existing maybe_compile_network / configure_matmul_precision /
     # _timing_enabled call sites continue to read env unchanged. Defaults
     # to 'auto' for --torch-compile so an env preset (e.g.
     # MHCFLURRY_TORCH_COMPILE=1 set by the runplz container) still wins

--- a/scripts/training/release_exact/generate_hyperparameters.py
+++ b/scripts/training/release_exact/generate_hyperparameters.py
@@ -66,7 +66,7 @@ base_hyperparameters = {
     # Validation represents a per-epoch GPU-sync barrier that prevents
     # pipelining the next epoch's CPU prep with the current epoch's
     # training tail. With minibatch=16384 the effective val batch is
-    # 4×minibatch=65536 (see ``_effective_validation_batch_size``), so a
+    # 4×minibatch=65536 (see ``effective_validation_batch_size``), so a
     # 244K-row val set is ~4 batches per pass. Early-stop check still
     # fires reliably because patience=20 is far larger than
     # ``validation_interval=5``. A final validation pass is forced

--- a/test/test_class1_processing_neural_network.py
+++ b/test/test_class1_processing_neural_network.py
@@ -221,7 +221,7 @@ def test_fit_uses_eager_network_for_validation_by_default(monkeypatch):
         captured_regularization_parameters.append(tuple(parameters))
         return original_regularization_penalty(parameters, l1=l1, l2=l2)
 
-    monkeypatch.setattr(processing_module, "_maybe_compile_network", fake_compile)
+    monkeypatch.setattr(processing_module, "maybe_compile_network", fake_compile)
     monkeypatch.setattr(
         processing_module.Class1ProcessingNeuralNetwork,
         "_regularization_penalty",

--- a/test/test_pytorch_regressions.py
+++ b/test/test_pytorch_regressions.py
@@ -29,10 +29,7 @@ from mhcflurry.class1_neural_network import (
     Class1NeuralNetworkModel,
     MergedClass1NeuralNetwork,
     _batched_validation_loss,
-    _effective_validation_batch_size,
-    _validation_forward_network,
 )
-from mhcflurry.torch_training_loop import _maybe_compile_loss
 from mhcflurry.class1_processing_neural_network import (
     Class1ProcessingModel,
     Class1ProcessingNeuralNetwork,
@@ -43,6 +40,11 @@ from mhcflurry.pytorch_losses import (
     MSEWithInequalities,
     MultiallelicMassSpecLoss,
     get_pytorch_loss,
+)
+from mhcflurry.pytorch_training import (
+    effective_validation_batch_size,
+    maybe_compile_loss,
+    validation_forward_network,
 )
 from mhcflurry.testing_utils import startup, cleanup
 
@@ -94,11 +96,13 @@ def _plain_or_shared_tensor(value):
 
 
 def test_maybe_compile_loss_defaults_on_with_network_compile_cuda(monkeypatch):
-    from mhcflurry import torch_training_loop as ttl
+    from mhcflurry import pytorch_training as training
 
     monkeypatch.setenv("MHCFLURRY_TORCH_COMPILE", "1")
     monkeypatch.delenv("MHCFLURRY_TORCH_COMPILE_LOSS", raising=False)
-    monkeypatch.setattr(ttl, "_warm_cuda_autograd_for_triton", lambda device: None)
+    monkeypatch.setattr(
+        training, "_warm_cuda_autograd_for_triton", lambda device: None
+    )
     calls = []
 
     def fake_compile(obj, mode=None, dynamic=None):
@@ -108,7 +112,7 @@ def test_maybe_compile_loss_defaults_on_with_network_compile_cuda(monkeypatch):
     monkeypatch.setattr(torch, "compile", fake_compile)
     loss = MSEWithInequalities()
 
-    result = _maybe_compile_loss(loss, torch.device("cuda"))
+    result = maybe_compile_loss(loss, torch.device("cuda"))
 
     assert result == "compiled-loss"
     assert calls == [(loss, "default", True)]
@@ -121,7 +125,7 @@ def test_maybe_compile_loss_can_be_disabled(monkeypatch):
     monkeypatch.setattr(torch, "compile", lambda *a, **k: calls.append((a, k)))
     loss = MSEWithInequalities()
 
-    result = _maybe_compile_loss(loss, torch.device("cuda"))
+    result = maybe_compile_loss(loss, torch.device("cuda"))
 
     assert result is loss
     assert calls == []
@@ -134,7 +138,7 @@ def test_maybe_compile_loss_requires_network_compile(monkeypatch):
     monkeypatch.setattr(torch, "compile", lambda *a, **k: calls.append((a, k)))
     loss = MSEWithInequalities()
 
-    result = _maybe_compile_loss(loss, torch.device("cuda"))
+    result = maybe_compile_loss(loss, torch.device("cuda"))
 
     assert result is loss
     assert calls == []
@@ -185,10 +189,10 @@ def test_fit_validation_interval_default_runs_every_epoch():
 
 
 def test_effective_validation_batch_size_uses_larger_cuda_default():
-    assert _effective_validation_batch_size(torch.device("cuda"), None, 512) == 4096
-    assert _effective_validation_batch_size(torch.device("cuda"), None, 2048) == 8192
-    assert _effective_validation_batch_size(torch.device("cpu"), None, 512) == 2048
-    assert _effective_validation_batch_size(torch.device("cuda"), 123, 512) == 123
+    assert effective_validation_batch_size(torch.device("cuda"), None, 512) == 4096
+    assert effective_validation_batch_size(torch.device("cuda"), None, 2048) == 8192
+    assert effective_validation_batch_size(torch.device("cpu"), None, 512) == 2048
+    assert effective_validation_batch_size(torch.device("cuda"), 123, 512) == 123
 
 
 @pytest.mark.slow
@@ -1231,10 +1235,10 @@ def test_validation_forward_network_uses_eager_by_default(monkeypatch):
     eager = object()
 
     monkeypatch.delenv("MHCFLURRY_TORCH_COMPILE_VALIDATION", raising=False)
-    assert _validation_forward_network(compiled, eager) is eager
+    assert validation_forward_network(compiled, eager) is eager
 
     monkeypatch.setenv("MHCFLURRY_TORCH_COMPILE_VALIDATION", "1")
-    assert _validation_forward_network(compiled, eager) is compiled
+    assert validation_forward_network(compiled, eager) is compiled
 
 
 def test_optimizer_defaults_match_keras():


### PR DESCRIPTION
## Summary

Starts the `2.3.0rc7` cleanup branch with readability/API cleanups:

- Makes the common-amino-acid order in `mhcflurry/amino_acid.py` explicit instead of hiding it behind `sorted(...)`.
- Keeps the existing alphabetic index order and `X` at index 20.
- Replaces assignment-adjacent string literals for `X_INDEX` and `NUM_COMMON_AMINO_ACIDS` with normal comments.
- Renames `mhcflurry/torch_training_loop.py` to `mhcflurry/pytorch_training.py` to match the existing `pytorch_layers.py` / `pytorch_losses.py` naming convention.
- Removes leading underscores from the PyTorch helpers that are imported across modules: `configure_matmul_precision`, `maybe_compile_network`, `maybe_compile_loss`, `uncompiled_network`, `validation_forward_network`, and `effective_validation_batch_size`.
- Leaves the CUDA autograd warmup helper private because it is only used inside `pytorch_training.py`.
- Replaces positional pandas `DataFrame.insert(...)` calls with explicit metadata DataFrames plus `pandas.concat(...)`.
- Bumps README/version references from `2.3.0rc6` to `2.3.0rc7`.

## Notes

The amino-acid assignment string literals were not runtime variable documentation; they were only PEP 257-style attribute docstrings at best. In this context they read as comments, so they are now comments.

A repo-wide AST sweep found no other top-level assignment followed by a string literal.

Exact sweeps found no remaining references to `torch_training_loop` or the old underscored shared-helper names, and no tracked old-RC references for `rc1` through `rc6`.

The only remaining `.insert(...)` calls are non-DataFrame list/path operations: `candidate_strings.insert(...)` and `sys.path.insert(...)`.

## Validation

- `./lint.sh`
- `python -m compileall -q mhcflurry test scripts`
- `pytest test/test_amino_acid.py test/test_random_negative_peptides.py test/test_class1_affinity_training_data.py` (`37 passed`)
- `pytest test/test_pytorch_regressions.py test/test_class1_processing_neural_network.py` (`71 passed`)
- `pytest test/test_calibrate_percentile_ranks_fast.py test/test_class1_presentation_predictor_unit.py test/test_predict_command.py test/test_predict_scan_command.py` (`49 passed, 1 skipped`)
- `pytest test/` (`626 passed, 7 skipped`)
- `python setup.py --version` (`2.3.0rc7`)

Leaving this as draft so additional rc7 complaints can be collected here.
