### PR TITLE
Fix rc12 review cleanup issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ Have a bugfix or other contribution? We would love your help. See our [contribut
 ## 2.3.0 release candidate
 
 > [!IMPORTANT]
-> 2.3.0 is currently a release candidate (`2.3.0rc11`), not yet a final release.
+> 2.3.0 is currently a release candidate (`2.3.0rc12`), not yet a final release.
 > It keeps the same public API and pre-trained models as 2.2.x. Install it with
 > `pip install --pre mhcflurry`, or pin the version with
-> `pip install mhcflurry==2.3.0rc11`. A plain `pip install --upgrade mhcflurry`
+> `pip install mhcflurry==2.3.0rc12`. A plain `pip install --upgrade mhcflurry`
 > stays on the latest stable release (2.2.x) until 2.3.0 is final, since pip
 > skips pre-releases.
 

--- a/docs/2023_retraining_notebook_audit.md
+++ b/docs/2023_retraining_notebook_audit.md
@@ -1,0 +1,137 @@
+# 2023 Retraining Notebook Audit
+
+This audits the copied notebook bundle in `notebooks/2023-retraining/` against
+the maintained release scripts and 2.3.x evaluation commands. The notebooks are
+valuable source material, but they include generated data, checkpoint notebooks,
+old imports, and local paths, so they should be ported into scripts rather than
+committed as the workflow.
+
+## What The Notebooks Cover
+
+- Benchmark assembly: joins `data_evaluation` sample shards into wide
+  monoallelic and multiallelic benchmark tables with MHCflurry, NetMHCpan, and
+  MixMHCpred columns.
+- Accuracy scoring: per-sample and per-length AUC / PPV tables, percent-change
+  columns against NetMHCpan BA, NetMHCpan EL, MixMHCpred, and older MHCflurry.
+- Figure generation: paper-style scatter panels, score bars, processing motifs,
+  processing-vs-affinity correlation plots, and presentation coefficient plots.
+- Supplemental outputs: sample tables, benchmark data files, model-selection
+  accuracy workbook, antigen-processing motif workbook, and supplementary data
+  CSV/XLSX files.
+- Exploratory analyses: novel-allele analysis, proteasome mass-spec analysis,
+  and an immunogenicity experiment depending on external local files.
+
+## Differences From Maintained Workflows
+
+- Data curation is split differently. Current maintained scripts use
+  `downloads-generation/` to build raw downloads and `scripts/training/` to build
+  release models. The notebooks start from already-generated downloads and create
+  analysis artifacts under `notebooks/2023-retraining/artifacts/`.
+- The current `data_evaluation` download generates train-excluded benchmark
+  files and sample shards. The notebooks additionally join those shards into
+  wide analysis tables and include an abandoned no-exclude-train path.
+- The notebooks label recent multiallelic samples using PMIDs `31844290` and
+  `31154438`. Current presentation training excludes `31844290`, `31495665`, and
+  `31154438`; this needs one named holdout policy before new public weights are
+  trained and evaluated.
+- The notebooks use old notebook-era dependencies and names (`keras`,
+  `tensorflow`, `mhcnames` in places). Ports should use the current PyTorch code,
+  `mhcgnomes` / existing allele normalization helpers, and maintained CLI
+  commands.
+- Current `mhcflurry compare-models` covers affinity and presentation regression
+  metrics, and `mhcflurry plot-model-comparison` renders generic plots. It does
+  not yet recreate the paper-style benchmark tables, sample-group comparisons,
+  model-selection workbook, motif workbook, or supplemental figures.
+- The current full training script trains processing `no_flank` and
+  `short_flanks` variants, then uses `short_flanks` as the with-flank processing
+  component for presentation. Older download-generation trained a separate
+  `models.selected.with_flanks` variant. That semantic difference should be
+  resolved explicitly before publishing 2.3.0 weights.
+- Historical runplz files in `jobs/` patched scripts in place for one experiment
+  and called deleted comparison scripts. Remote execution is now represented by
+  maintained scripts instead of patching a remote copy.
+
+## Missing Figure And Table Ports
+
+- Predictor metadata / aesthetics: convert `0 aesthetics.ipynb` into a small
+  `predictor_info.csv` generator with stable labels, colors, and descriptions.
+- Wide benchmark tables: port the monoallelic and multiallelic shard-join logic
+  from `1 prepare benchmark dataset*.ipynb`.
+- Accuracy score tables: port the AUC / PPV / percent-change tables from
+  `2 monoallelic accuracy plots.ipynb` and `2 multiallelic accuracy.ipynb`.
+- Monoallelic figures: BA/EL/MixMHCpred scatter panels, training-count vs AUC,
+  and novel-allele comparison tables / plots.
+- Multiallelic figures: PPV/AUC scatter panels comparing NetMHCpan BA,
+  NetMHCpan EL, MixMHCpred, older MHCflurry, and presentation score variants,
+  including recent-vs-old sample grouping.
+- Model-selection evidence: port the unselected-model held-out decoy AUC workbook
+  and HLA locus score bars.
+- Processing evidence: port antigen-processing motif count/PWM workbook,
+  processing logo figure, and processing-vs-affinity correlation plots.
+- Supplemental outputs: port sample table, supplemental sample table with
+  accuracies, benchmark supplemental CSVs, and proteasome mass-spec additional
+  file generation.
+- Immunogenicity experiment: defer until external source files are located and
+  licensed; do not make this a release gate yet.
+
+## Porting Plan
+
+1. Add `scripts/analysis/` for reusable release-analysis scripts. Keep notebooks
+   out of the maintained path; use them only as references.
+2. Extract shared metric helpers: PPV@N, sign normalization, bootstrap intervals,
+   percent-change calculations, and sample/length grouping.
+3. Add a benchmark-assembly script that consumes a `data_evaluation` directory
+   and writes wide monoallelic/multiallelic analysis CSVs from the group files.
+4. Add an accuracy-table script that writes the notebook-style
+   `accuracy_scores.*.csv` tables from those wide benchmarks.
+5. Add figure scripts that consume the generated tables and produce stable PNG /
+   PDF outputs under a release-analysis directory.
+6. Add processing-motif generation from the presentation benchmark and trained
+   processing predictors. This should be scriptable without `logomaker` unless
+   the logo plot is explicitly requested; the workbook can be generated first.
+7. Decide the 2.3.0 holdout policy in one place: PMIDs, pMHC overlap removal,
+   and whether evaluation data is filtered out of affinity / processing /
+   presentation training. Move any useful logic from `jobs/filter_training...`
+   into maintained scripts after that decision.
+8. Resolve the processing variant naming: either train a real
+   `models.selected.with_flanks` variant again or document and test that
+   `short_flanks` is the canonical with-flank presentation input for 2.3.x.
+9. Make the release gate one command:
+   `scripts/release/retrain_evaluate_deploy.sh` trains, evaluates, plots, and
+   runs deployment validation. It supports local, runplz/Brev, and SSH-backed
+   remote machines.
+
+## Current Single-Command Entry Point
+
+Local:
+
+```bash
+scripts/release/retrain_evaluate_deploy.sh \
+    --run-dir /path/to/release-run \
+    --release 2.3.0 \
+    --backend local \
+    --deploy-mode dry-run
+```
+
+Brev through runplz:
+
+```bash
+scripts/release/retrain_evaluate_deploy.sh \
+    --run-dir /path/to/release-run \
+    --release 2.3.0 \
+    --backend runplz \
+    --deploy-mode dry-run
+```
+
+Generic SSH machine:
+
+```bash
+scripts/release/retrain_evaluate_deploy.sh \
+    --run-dir /path/to/local-copy \
+    --release 2.3.0 \
+    --backend ssh \
+    --remote user@host \
+    --remote-repo /path/to/mhcflurry \
+    --remote-run-dir /path/to/remote-release-run \
+    --deploy-mode dry-run
+```

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,32 @@
+# Development Maintenance
+
+## Private API and Fallback Cleanup
+
+MHCflurry should keep internal helpers movable. Tests and sibling modules should
+not pin underscore-prefixed functions unless the helper is truly private to the
+same module.
+
+1. Promote shared helpers before cross-module use.
+   If a helper is imported by another module or tested directly, give it a
+   public name in its owner module and document the contract in one sentence.
+
+2. Test owner modules, not compatibility facades.
+   Tests for moved helpers should import the helper module directly. Compatibility
+   shim tests should cover public behavior only: old imports still expose the
+   documented entry point and produce the same result.
+
+3. Make fallback paths observable.
+   Fallbacks for missing optional tools or hardware probes may return a safe
+   default. Fallbacks caused by import errors, bad local refactors, or invalid
+   user configuration should fail loudly instead of being caught by broad
+   `except Exception` blocks.
+
+4. Keep compatibility shims thin.
+   Old module paths may re-export public entry points and delegate unknown
+   attributes, but they should not replace `sys.modules` or assert identity with
+   the new implementation module.
+
+5. Track remaining private test hooks.
+   The remaining direct private imports in tests should be triaged into:
+   public helper, same-module implementation detail tested through behavior, or
+   compatibility shim slated for removal after the 2.3 release line stabilizes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,4 +9,5 @@ python_tutorial
 commandline_tools
 api
 testing
+development
 ```

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -25,8 +25,8 @@ orchestrator process               training worker process
 ─────────────────────              ───────────────────────
 
 parse args                         (forked / spawned)
-load training data                  inherit GLOBAL_DATA
-build GLOBAL_DATA           ─┐
+load training data                  inherit WORKER_CONTEXT
+build WORKER_CONTEXT        ─┐
                              │
 hoist env knobs              │
   TORCHINDUCTOR_COMPILE_THREADS
@@ -91,7 +91,7 @@ Two backends, one CLI surface:
   historical CPU-overflow behavior.
 - **Cluster** (`cluster_parallelism.py`): one job per work-item
   submitted via `bsub` / `sbatch` / `sh`. Workers serialize
-  GLOBAL_DATA to NFS and deserialize on the worker side.
+  WORKER_CONTEXT to NFS and deserialize on the worker side.
 
 Worker-side code (`train_model()`, etc.) is identical between
 backends. Only the orchestrator branches on `args.cluster_parallelism`.
@@ -269,7 +269,7 @@ before compiling losses to avoid the PyTorch 2.4 / Triton
 
 1. Add a `_initialize_<name>(args, all_work_items)` helper near the
    existing ones in `train_pan_allele_models_command.py`.
-2. Stash the result in `GLOBAL_DATA["<name>"]`.
+2. Stash the result in `WORKER_CONTEXT["<name>"]`.
 3. Document the lookup key. Workers retrieve via
    `constant_data["<name>"]` (forked workers inherit; spawned/cluster
    workers receive via pickle).

--- a/mhcflurry/affinity/calibration_sizing.py
+++ b/mhcflurry/affinity/calibration_sizing.py
@@ -61,12 +61,52 @@ class CalibrationFastCache(object):
         self.motif_signature = None
         self.motif_state = None
 
+
+def peptide_encoding_feature_dim(model):
+    """Return the raw encoded peptide feature width for ``model`` if known."""
+    enc_shape = getattr(model, "peptide_encoding_shape", None)
+    if enc_shape is None:
+        return None
+    return int(enc_shape[0]) * int(enc_shape[1])
+
+
+def resolve_peptide_feature_dim(model, peptide_feature_dim, peak_bytes):
+    """Resolve the width of cached peptide features used during calibration.
+
+    ``peptide_feature_dim`` is the actual width of
+    ``forward_peptide_stage(...)`` when the caller has probed it. Without a
+    probe, fall back to shape-derived estimates and then to the generic peak
+    memory estimate.
+    """
+    if peptide_feature_dim is not None:
+        return int(peptide_feature_dim)
+
+    sub_networks = getattr(model, "networks", None)
+    if sub_networks is not None and not hasattr(model, "peptide_encoding_shape"):
+        try:
+            sub_dims = []
+            for net in sub_networks:
+                sub_dim = peptide_encoding_feature_dim(net)
+                sub_dims.append(1024 if sub_dim is None else sub_dim)
+            return int(sum(sub_dims))
+        except (AttributeError, TypeError, ValueError, IndexError):
+            pass
+
+    try:
+        feature_dim = peptide_encoding_feature_dim(model)
+    except (AttributeError, TypeError, ValueError, IndexError):
+        feature_dim = None
+    if feature_dim is not None:
+        return feature_dim
+    return int(peak_bytes // 32) if peak_bytes else 1024
+
+
 def auto_size_calibration_batches(
         model, device, n_peptides, n_alleles,
         num_workers_per_gpu=1,
         free_memory_fraction=0.85,
         num_cached_networks=1,
-        peptide_stage_dim=None,
+        peptide_feature_dim=None,
         num_sub_networks=None,
         cuda_overhead_bytes=2 * (1 << 30),
         safety_multiplier=1.3,
@@ -86,7 +126,7 @@ def auto_size_calibration_batches(
         peak = cuda_overhead
              + cache_bytes                # peptide-stage cache,
                                           # ``num_cached_networks ×
-                                          # n_peptides × stage_dim × 4``
+                                          # n_peptides × peptide_feature_dim × 4``
              + cartesian_intermediate     # transient forward
                                           # ``a_size × p_batch ×
                                           # peak_bytes_per_row``
@@ -151,7 +191,9 @@ def auto_size_calibration_batches(
         try:
             props = torch.cuda.get_device_properties(device)
             total_memory = int(props.total_memory)
-        except Exception:
+        except (
+                AssertionError, AttributeError, RuntimeError,
+                TypeError, ValueError):
             # Tests and nonstandard CUDA wrappers may not expose device
             # properties. Fall back to free memory; the explicit reserve
             # still keeps the budget bounded.
@@ -166,49 +208,20 @@ def auto_size_calibration_batches(
         reserved_headroom_budget = int(
             max(free - reserve_bytes, 0) / workers)
         per_worker_budget = min(fraction_budget, reserved_headroom_budget)
-        stage_dim = peptide_stage_dim
         sub_networks = getattr(model, "networks", None)
         if num_sub_networks is None:
             num_sub_networks = (
                 len(sub_networks) if sub_networks is not None else 1
             )
-        if stage_dim is None:
-            # MergedClass1NeuralNetwork: peptide-stage cache is the
-            # concatenation of all sub-networks' stages → sum the
-            # per-sub-network stage dims. The peptide_encoding_shape
-            # heuristic is a *floor* (raw encoded peptide) — actual
-            # stage_dim grows when peptide_dense_layer_sizes or LC
-            # layers are configured. Caller should pass
-            # ``peptide_stage_dim`` from a real probe to avoid
-            # under-counting.
-            if (
-                sub_networks is not None
-                and not hasattr(model, "peptide_encoding_shape")
-            ):
-                try:
-                    sub_dims = []
-                    for net in sub_networks:
-                        sub_enc = getattr(net, "peptide_encoding_shape", None)
-                        if sub_enc is not None:
-                            sub_dims.append(int(sub_enc[0]) * int(sub_enc[1]))
-                        else:
-                            sub_dims.append(1024)
-                    stage_dim = int(sum(sub_dims))
-                except Exception:
-                    stage_dim = None
-            if stage_dim is None:
-                try:
-                    enc_shape = getattr(model, "peptide_encoding_shape", None)
-                    if enc_shape is not None:
-                        stage_dim = int(enc_shape[0]) * int(enc_shape[1])
-                except Exception:
-                    stage_dim = None
-            if stage_dim is None:
-                stage_dim = peak_bytes // 32 if peak_bytes else 1024
+        peptide_feature_dim = resolve_peptide_feature_dim(
+            model,
+            peptide_feature_dim,
+            peak_bytes,
+        )
         cache_bytes = (
             int(num_cached_networks)
             * int(n_peptides)
-            * int(stage_dim)
+            * int(peptide_feature_dim)
             * 4
         )
         # Small-state pad: log-IC50 accumulator, ic50_unique view,
@@ -230,24 +243,43 @@ def auto_size_calibration_batches(
         forward_budget = (
             per_worker_budget - guarded_fixed_overhead
         )
+        log_fields = {
+            "free_gb": free / 1e9,
+            "workers": workers,
+            "total_gb": total_memory / 1e9,
+            "reserve_gb": reserve_bytes / 1e9,
+            "fraction_budget_gb": fraction_budget / 1e9,
+            "per_worker_budget_gb": per_worker_budget / 1e9,
+            "peptide_feature_dim": peptide_feature_dim,
+            "num_sub_networks": num_sub_networks,
+            "num_cached_networks": num_cached_networks,
+            "cache_gb": cache_bytes / 1e9,
+            "cuda_overhead_gb": cuda_overhead_bytes / 1e9,
+            "small_state_gb": small_state_bytes / 1e9,
+            "scratch_safety": fixed_safety_multiplier,
+            "guarded_fixed_gb": guarded_fixed_overhead / 1e9,
+            "forward_budget_gb": forward_budget / 1e9,
+            "peak_bytes_per_row": peak_bytes,
+            "peak_kb_per_row": peak_bytes / 1024,
+        }
         logging.info(
-            "calibrate auto-sizer: free=%.2f GB, workers=%d, "
-            "total=%.2f GB, reserve=%.2f GB, "
-            "fraction_budget=%.2f GB, per_worker_budget=%.2f GB, "
-            "stage_dim=%d "
-            "(sub_networks=%d, num_cached=%d), cache=%.2f GB, "
-            "cuda_overhead=%.2f GB, small_state=%.2f GB, "
-            "scratch_safety=%.2fx, guarded_fixed=%.2f GB "
-            "-> forward_budget=%.2f GB, "
-            "peak_bytes_per_row=%d (≈%.2f KB)",
-            free / 1e9, workers, total_memory / 1e9,
-            reserve_bytes / 1e9, fraction_budget / 1e9,
-            per_worker_budget / 1e9, stage_dim,
-            num_sub_networks, num_cached_networks,
-            cache_bytes / 1e9, cuda_overhead_bytes / 1e9,
-            small_state_bytes / 1e9, fixed_safety_multiplier,
-            guarded_fixed_overhead / 1e9,
-            forward_budget / 1e9, peak_bytes, peak_bytes / 1024,
+            "calibrate auto-sizer: free=%(free_gb).2f GB, "
+            "workers=%(workers)d, total=%(total_gb).2f GB, "
+            "reserve=%(reserve_gb).2f GB, "
+            "fraction_budget=%(fraction_budget_gb).2f GB, "
+            "per_worker_budget=%(per_worker_budget_gb).2f GB, "
+            "peptide_feature_dim=%(peptide_feature_dim)d "
+            "(sub_networks=%(num_sub_networks)d, "
+            "num_cached=%(num_cached_networks)d), "
+            "cache=%(cache_gb).2f GB, "
+            "cuda_overhead=%(cuda_overhead_gb).2f GB, "
+            "small_state=%(small_state_gb).2f GB, "
+            "scratch_safety=%(scratch_safety).2fx, "
+            "guarded_fixed=%(guarded_fixed_gb).2f GB "
+            "-> forward_budget=%(forward_budget_gb).2f GB, "
+            "peak_bytes_per_row=%(peak_bytes_per_row)d "
+            "(≈%(peak_kb_per_row).2f KB)",
+            log_fields,
         )
         if forward_budget < peak_bytes * AUTO_BATCH_MIN_ROWS:
             logging.warning(
@@ -422,10 +454,11 @@ def calibration_stage_cache_signature(encoded_peptides, networks, device):
         str(device),
     )
 
-def probe_peptide_stage_dim(net_obj, encoded_peptides, device):
+def probe_peptide_feature_dim(net_obj, encoded_peptides, device):
     """Run a 1-row forward through ``forward_peptide_stage`` to
-    record the actual feature dimension of the peptide-stage
-    output. The auto-sizer's cache estimate depends on this and
+    record the actual width of the peptide feature tensor.
+
+    The auto-sizer's cache estimate depends on this and
     the encoding-shape heuristic under-counts when the model
     configures ``peptide_dense_layer_sizes`` or LC layers.
 
@@ -454,11 +487,11 @@ def probe_peptide_stage_dim(net_obj, encoded_peptides, device):
         model = net_obj.network(borrow=True)
         model.eval()
         with torch.no_grad():
-            stage = model.forward_peptide_stage(probe_tensor)
-        return int(stage.shape[-1])
+            peptide_features = model.forward_peptide_stage(probe_tensor)
+        return int(peptide_features.shape[-1])
     except (AttributeError, RuntimeError, TypeError, ValueError) as exc:
         logging.warning(
-            "calibrate auto-sizer: peptide_stage_dim probe failed "
+            "calibrate auto-sizer: peptide_feature_dim probe failed "
             "(%s); falling back to encoding-shape heuristic", exc,
         )
         return None

--- a/mhcflurry/affinity/calibration_sizing.py
+++ b/mhcflurry/affinity/calibration_sizing.py
@@ -12,6 +12,7 @@
 
 """Calibration sizing and cache helpers for class I affinity predictors."""
 
+import collections
 import hashlib
 import logging
 
@@ -101,6 +102,207 @@ def resolve_peptide_feature_dim(model, peptide_feature_dim, peak_bytes):
     return int(peak_bytes // 32) if peak_bytes else 1024
 
 
+CalibrationSizingEnv = collections.namedtuple(
+    "CalibrationSizingEnv",
+    [
+        "free_memory_fraction",
+        "reserve_fraction",
+        "reserve_min_bytes",
+        "fixed_safety_multiplier",
+    ],
+)
+
+
+def read_calibration_sizing_env(free_memory_fraction, safety_multiplier):
+    """Resolve the ``MHCFLURRY_CALIBRATE_AUTO_*`` overrides for the sizer.
+
+    ``free_memory_fraction`` and ``safety_multiplier`` are the caller
+    defaults used when the matching env var is unset. Invalid or
+    out-of-range values raise ``ValueError`` (via ``env_float``) rather than
+    being silently ignored. Returns a ``CalibrationSizingEnv``.
+    """
+    from ..workload_planning import env_float
+
+    return CalibrationSizingEnv(
+        free_memory_fraction=env_float(
+            "MHCFLURRY_CALIBRATE_AUTO_FREE_MEMORY_FRACTION",
+            free_memory_fraction,
+            bounds=(0.0, 1.0),
+        ),
+        reserve_fraction=env_float(
+            "MHCFLURRY_CALIBRATE_AUTO_RESERVE_FRACTION", 0.10,
+            bounds=(0.0, 1.0)),
+        reserve_min_bytes=int(
+            env_float(
+                "MHCFLURRY_CALIBRATE_AUTO_RESERVE_GB", 2.0,
+                bounds=(0.0, None))
+            * (1 << 30)
+        ),
+        fixed_safety_multiplier=env_float(
+            "MHCFLURRY_CALIBRATE_AUTO_FIXED_SAFETY_MULTIPLIER",
+            safety_multiplier,
+            bounds=(0.0, None),
+        ),
+    )
+
+
+def cuda_device_memory_bytes(device):
+    """Return best-effort ``(free_bytes, total_bytes)`` for a CUDA device.
+
+    ``free`` comes from the shared ``free_device_memory_bytes`` probe.
+    ``total`` uses ``torch.cuda.get_device_properties`` when available and
+    otherwise falls back to ``free`` -- tests and nonstandard CUDA wrappers
+    may not expose device properties, and the explicit reserve still keeps
+    the budget bounded.
+    """
+    import torch
+
+    from ..pytorch_sizing import free_device_memory_bytes
+
+    free = free_device_memory_bytes(device)
+    total_memory = free
+    try:
+        props = torch.cuda.get_device_properties(device)
+        total_memory = int(props.total_memory)
+    except (
+            AssertionError, AttributeError, RuntimeError,
+            TypeError, ValueError):
+        pass
+    return free, total_memory
+
+
+def cuda_calibration_total_rows(
+        model, device, n_peptides,
+        num_workers_per_gpu,
+        env,
+        num_cached_networks,
+        peptide_feature_dim,
+        num_sub_networks,
+        cuda_overhead_bytes):
+    """Size the cartesian forward row budget on a CUDA device.
+
+    Carves a per-worker VRAM budget out of free memory, subtracts the fixed
+    overhead (the persistent peptide-feature cache plus safety-padded
+    CUDA/runtime scratch and small state), and converts the remaining
+    forward budget into a row count. ``env`` is a ``CalibrationSizingEnv``
+    from ``read_calibration_sizing_env``; see ``auto_size_calibration_batches``
+    for the full peak model. Returns the row budget for
+    ``choose_calibration_batch_shape``.
+    """
+    from ..pytorch_sizing import AUTO_BATCH_MAX_ROWS, AUTO_BATCH_MIN_ROWS
+
+    free_memory_fraction = env.free_memory_fraction
+    reserve_fraction = env.reserve_fraction
+    reserve_min_bytes = env.reserve_min_bytes
+    fixed_safety_multiplier = env.fixed_safety_multiplier
+
+    workers = max(int(num_workers_per_gpu), 1)
+    free, total_memory = cuda_device_memory_bytes(device)
+    peak_bytes = estimate_calibration_peak_bytes_per_row(model)
+    reserve_bytes = max(
+        reserve_min_bytes,
+        int(total_memory * reserve_fraction),
+    )
+    fraction_budget = int(
+        free * float(free_memory_fraction) / workers)
+    reserved_headroom_budget = int(
+        max(free - reserve_bytes, 0) / workers)
+    per_worker_budget = min(fraction_budget, reserved_headroom_budget)
+    sub_networks = getattr(model, "networks", None)
+    if num_sub_networks is None:
+        num_sub_networks = (
+            len(sub_networks) if sub_networks is not None else 1
+        )
+    peptide_feature_dim = resolve_peptide_feature_dim(
+        model,
+        peptide_feature_dim,
+        peak_bytes,
+    )
+    cache_bytes = (
+        int(num_cached_networks)
+        * int(n_peptides)
+        * int(peptide_feature_dim)
+        * 4
+    )
+    # Small-state pad: log-IC50 accumulator, ic50_unique view,
+    # motif-summary state, PercentRankTransform.fit_batch_torch
+    # buffers, allele_idx tensor, etc. Scales with a_size and
+    # n_peptides; a 1 GB constant covers the production ranges
+    # without further accounting. Cheap insurance vs OOM.
+    small_state_bytes = 1 * (1 << 30)
+    # The peptide-stage cache estimate is shape-derived and
+    # persistent, so multiplying it by a fragmentation safety factor
+    # unnecessarily strands several GB on A100-40GB. Keep explicit
+    # global headroom, and safety-pad only CUDA/runtime scratch and
+    # small state whose allocation behavior is less predictable.
+    scratch_state_bytes = int(cuda_overhead_bytes) + small_state_bytes
+    guarded_fixed_overhead = (
+        cache_bytes
+        + int(scratch_state_bytes * fixed_safety_multiplier)
+    )
+    forward_budget = per_worker_budget - guarded_fixed_overhead
+    log_fields = {
+        "free_gb": free / 1e9,
+        "workers": workers,
+        "total_gb": total_memory / 1e9,
+        "reserve_gb": reserve_bytes / 1e9,
+        "fraction_budget_gb": fraction_budget / 1e9,
+        "per_worker_budget_gb": per_worker_budget / 1e9,
+        "peptide_feature_dim": peptide_feature_dim,
+        "num_sub_networks": num_sub_networks,
+        "num_cached_networks": num_cached_networks,
+        "cache_gb": cache_bytes / 1e9,
+        "cuda_overhead_gb": cuda_overhead_bytes / 1e9,
+        "small_state_gb": small_state_bytes / 1e9,
+        "scratch_safety": fixed_safety_multiplier,
+        "guarded_fixed_gb": guarded_fixed_overhead / 1e9,
+        "forward_budget_gb": forward_budget / 1e9,
+        "peak_bytes_per_row": peak_bytes,
+        "peak_kb_per_row": peak_bytes / 1024,
+    }
+    logging.info(
+        "calibrate auto-sizer: free=%(free_gb).2f GB, "
+        "workers=%(workers)d, total=%(total_gb).2f GB, "
+        "reserve=%(reserve_gb).2f GB, "
+        "fraction_budget=%(fraction_budget_gb).2f GB, "
+        "per_worker_budget=%(per_worker_budget_gb).2f GB, "
+        "peptide_feature_dim=%(peptide_feature_dim)d "
+        "(sub_networks=%(num_sub_networks)d, "
+        "num_cached=%(num_cached_networks)d), "
+        "cache=%(cache_gb).2f GB, "
+        "cuda_overhead=%(cuda_overhead_gb).2f GB, "
+        "small_state=%(small_state_gb).2f GB, "
+        "scratch_safety=%(scratch_safety).2fx, "
+        "guarded_fixed=%(guarded_fixed_gb).2f GB "
+        "-> forward_budget=%(forward_budget_gb).2f GB, "
+        "peak_bytes_per_row=%(peak_bytes_per_row)d "
+        "(≈%(peak_kb_per_row).2f KB)",
+        log_fields,
+    )
+    if forward_budget < peak_bytes * AUTO_BATCH_MIN_ROWS:
+        logging.warning(
+            "calibrate auto-sizer: fixed overhead "
+            "(cache %.2f GB + scratch/state %.2f GB × safety %.2fx) "
+            "exceeds per-worker budget %.2f GB "
+            "(%.2f GB free, %.2f GB reserved, %d workers). "
+            "Falling back to minimum batch; reduce "
+            "--max-workers-per-gpu or lower the peptide universe "
+            "size.",
+            cache_bytes / 1e9,
+            scratch_state_bytes / 1e9,
+            fixed_safety_multiplier,
+            per_worker_budget / 1e9,
+            free / 1e9,
+            reserve_bytes / 1e9,
+            workers,
+        )
+        forward_budget = peak_bytes * AUTO_BATCH_MIN_ROWS
+    return max(
+        AUTO_BATCH_MIN_ROWS,
+        min(forward_budget // peak_bytes, AUTO_BATCH_MAX_ROWS),
+    )
+
+
 def auto_size_calibration_batches(
         model, device, n_peptides, n_alleles,
         num_workers_per_gpu=1,
@@ -148,160 +350,31 @@ def auto_size_calibration_batches(
     Returns the chosen ``(peptide_batch, allele_batch)``.
     """
     from ..pytorch_sizing import (
-        AUTO_BATCH_MAX_ROWS,
         AUTO_BATCH_MIN_ROWS,
         compute_prediction_batch_size,
-        free_device_memory_bytes,
     )
-    import torch
-    from ..workload_planning import env_float
 
     if n_peptides == 0 or n_alleles == 0:
         return max(n_peptides, 1), max(n_alleles, 1)
-    free_memory_fraction = env_float(
-        "MHCFLURRY_CALIBRATE_AUTO_FREE_MEMORY_FRACTION",
-        free_memory_fraction,
-        bounds=(0.0, 1.0),
-    )
-    reserve_fraction = env_float(
-        "MHCFLURRY_CALIBRATE_AUTO_RESERVE_FRACTION", 0.10,
-        bounds=(0.0, 1.0))
-    reserve_min_bytes = int(
-        env_float(
-            "MHCFLURRY_CALIBRATE_AUTO_RESERVE_GB", 2.0,
-            bounds=(0.0, None))
-        * (1 << 30)
-    )
-    fixed_safety_multiplier = env_float(
-        "MHCFLURRY_CALIBRATE_AUTO_FIXED_SAFETY_MULTIPLIER",
-        safety_multiplier,
-        bounds=(0.0, None),
-    )
+    env = read_calibration_sizing_env(free_memory_fraction, safety_multiplier)
     if device.type != "cuda":
         total_rows = compute_prediction_batch_size(
             device,
             model=model,
             num_workers_per_gpu=num_workers_per_gpu,
-            free_memory_fraction=free_memory_fraction,
+            free_memory_fraction=env.free_memory_fraction,
         )
     else:
-        workers = max(int(num_workers_per_gpu), 1)
-        free = free_device_memory_bytes(device)
-        total_memory = free
-        try:
-            props = torch.cuda.get_device_properties(device)
-            total_memory = int(props.total_memory)
-        except (
-                AssertionError, AttributeError, RuntimeError,
-                TypeError, ValueError):
-            # Tests and nonstandard CUDA wrappers may not expose device
-            # properties. Fall back to free memory; the explicit reserve
-            # still keeps the budget bounded.
-            pass
-        peak_bytes = estimate_calibration_peak_bytes_per_row(model)
-        reserve_bytes = max(
-            reserve_min_bytes,
-            int(total_memory * reserve_fraction),
-        )
-        fraction_budget = int(
-            free * float(free_memory_fraction) / workers)
-        reserved_headroom_budget = int(
-            max(free - reserve_bytes, 0) / workers)
-        per_worker_budget = min(fraction_budget, reserved_headroom_budget)
-        sub_networks = getattr(model, "networks", None)
-        if num_sub_networks is None:
-            num_sub_networks = (
-                len(sub_networks) if sub_networks is not None else 1
-            )
-        peptide_feature_dim = resolve_peptide_feature_dim(
+        total_rows = cuda_calibration_total_rows(
             model,
-            peptide_feature_dim,
-            peak_bytes,
-        )
-        cache_bytes = (
-            int(num_cached_networks)
-            * int(n_peptides)
-            * int(peptide_feature_dim)
-            * 4
-        )
-        # Small-state pad: log-IC50 accumulator, ic50_unique view,
-        # motif-summary state, PercentRankTransform.fit_batch_torch
-        # buffers, allele_idx tensor, etc. Scales with a_size and
-        # n_peptides; a 1 GB constant covers the production ranges
-        # without further accounting. Cheap insurance vs OOM.
-        small_state_bytes = 1 * (1 << 30)
-        # The peptide-stage cache estimate is shape-derived and
-        # persistent, so multiplying it by a fragmentation safety factor
-        # unnecessarily strands several GB on A100-40GB. Keep explicit
-        # global headroom, and safety-pad only CUDA/runtime scratch and
-        # small state whose allocation behavior is less predictable.
-        scratch_state_bytes = int(cuda_overhead_bytes) + small_state_bytes
-        guarded_fixed_overhead = (
-            cache_bytes
-            + int(scratch_state_bytes * fixed_safety_multiplier)
-        )
-        forward_budget = (
-            per_worker_budget - guarded_fixed_overhead
-        )
-        log_fields = {
-            "free_gb": free / 1e9,
-            "workers": workers,
-            "total_gb": total_memory / 1e9,
-            "reserve_gb": reserve_bytes / 1e9,
-            "fraction_budget_gb": fraction_budget / 1e9,
-            "per_worker_budget_gb": per_worker_budget / 1e9,
-            "peptide_feature_dim": peptide_feature_dim,
-            "num_sub_networks": num_sub_networks,
-            "num_cached_networks": num_cached_networks,
-            "cache_gb": cache_bytes / 1e9,
-            "cuda_overhead_gb": cuda_overhead_bytes / 1e9,
-            "small_state_gb": small_state_bytes / 1e9,
-            "scratch_safety": fixed_safety_multiplier,
-            "guarded_fixed_gb": guarded_fixed_overhead / 1e9,
-            "forward_budget_gb": forward_budget / 1e9,
-            "peak_bytes_per_row": peak_bytes,
-            "peak_kb_per_row": peak_bytes / 1024,
-        }
-        logging.info(
-            "calibrate auto-sizer: free=%(free_gb).2f GB, "
-            "workers=%(workers)d, total=%(total_gb).2f GB, "
-            "reserve=%(reserve_gb).2f GB, "
-            "fraction_budget=%(fraction_budget_gb).2f GB, "
-            "per_worker_budget=%(per_worker_budget_gb).2f GB, "
-            "peptide_feature_dim=%(peptide_feature_dim)d "
-            "(sub_networks=%(num_sub_networks)d, "
-            "num_cached=%(num_cached_networks)d), "
-            "cache=%(cache_gb).2f GB, "
-            "cuda_overhead=%(cuda_overhead_gb).2f GB, "
-            "small_state=%(small_state_gb).2f GB, "
-            "scratch_safety=%(scratch_safety).2fx, "
-            "guarded_fixed=%(guarded_fixed_gb).2f GB "
-            "-> forward_budget=%(forward_budget_gb).2f GB, "
-            "peak_bytes_per_row=%(peak_bytes_per_row)d "
-            "(≈%(peak_kb_per_row).2f KB)",
-            log_fields,
-        )
-        if forward_budget < peak_bytes * AUTO_BATCH_MIN_ROWS:
-            logging.warning(
-                "calibrate auto-sizer: fixed overhead "
-                "(cache %.2f GB + scratch/state %.2f GB × safety %.2fx) "
-                "exceeds per-worker budget %.2f GB "
-                "(%.2f GB free, %.2f GB reserved, %d workers). "
-                "Falling back to minimum batch; reduce "
-                "--max-workers-per-gpu or lower the peptide universe "
-                "size.",
-                cache_bytes / 1e9,
-                scratch_state_bytes / 1e9,
-                fixed_safety_multiplier,
-                per_worker_budget / 1e9,
-                free / 1e9,
-                reserve_bytes / 1e9,
-                workers,
-            )
-            forward_budget = peak_bytes * AUTO_BATCH_MIN_ROWS
-        total_rows = max(
-            AUTO_BATCH_MIN_ROWS,
-            min(forward_budget // peak_bytes, AUTO_BATCH_MAX_ROWS),
+            device,
+            n_peptides,
+            num_workers_per_gpu=num_workers_per_gpu,
+            env=env,
+            num_cached_networks=num_cached_networks,
+            peptide_feature_dim=peptide_feature_dim,
+            num_sub_networks=num_sub_networks,
+            cuda_overhead_bytes=cuda_overhead_bytes,
         )
     return choose_calibration_batch_shape(
         total_rows,

--- a/mhcflurry/affinity/calibration_sizing.py
+++ b/mhcflurry/affinity/calibration_sizing.py
@@ -14,7 +14,6 @@
 
 import hashlib
 import logging
-from os import environ
 
 import numpy
 
@@ -109,38 +108,34 @@ def auto_size_calibration_batches(
     Returns the chosen ``(peptide_batch, allele_batch)``.
     """
     from ..pytorch_sizing import (
+        AUTO_BATCH_MAX_ROWS,
+        AUTO_BATCH_MIN_ROWS,
         compute_prediction_batch_size,
-        _free_device_memory_bytes,
-        _AUTO_BATCH_MAX_ROWS,
-        _AUTO_BATCH_MIN_ROWS,
+        free_device_memory_bytes,
     )
     import torch
-
-    def env_float(name, default):
-        try:
-            return float(environ.get(name, default))
-        except (TypeError, ValueError):
-            logging.warning(
-                "Ignoring invalid %s=%r; using %s",
-                name, environ.get(name), default,
-            )
-            return float(default)
+    from ..workload_planning import env_float
 
     if n_peptides == 0 or n_alleles == 0:
         return max(n_peptides, 1), max(n_alleles, 1)
     free_memory_fraction = env_float(
         "MHCFLURRY_CALIBRATE_AUTO_FREE_MEMORY_FRACTION",
         free_memory_fraction,
+        bounds=(0.0, 1.0),
     )
     reserve_fraction = env_float(
-        "MHCFLURRY_CALIBRATE_AUTO_RESERVE_FRACTION", 0.10)
+        "MHCFLURRY_CALIBRATE_AUTO_RESERVE_FRACTION", 0.10,
+        bounds=(0.0, 1.0))
     reserve_min_bytes = int(
-        env_float("MHCFLURRY_CALIBRATE_AUTO_RESERVE_GB", 2.0)
+        env_float(
+            "MHCFLURRY_CALIBRATE_AUTO_RESERVE_GB", 2.0,
+            bounds=(0.0, None))
         * (1 << 30)
     )
     fixed_safety_multiplier = env_float(
         "MHCFLURRY_CALIBRATE_AUTO_FIXED_SAFETY_MULTIPLIER",
         safety_multiplier,
+        bounds=(0.0, None),
     )
     if device.type != "cuda":
         total_rows = compute_prediction_batch_size(
@@ -151,7 +146,7 @@ def auto_size_calibration_batches(
         )
     else:
         workers = max(int(num_workers_per_gpu), 1)
-        free = _free_device_memory_bytes(device)
+        free = free_device_memory_bytes(device)
         total_memory = free
         try:
             props = torch.cuda.get_device_properties(device)
@@ -254,7 +249,7 @@ def auto_size_calibration_batches(
             guarded_fixed_overhead / 1e9,
             forward_budget / 1e9, peak_bytes, peak_bytes / 1024,
         )
-        if forward_budget < peak_bytes * _AUTO_BATCH_MIN_ROWS:
+        if forward_budget < peak_bytes * AUTO_BATCH_MIN_ROWS:
             logging.warning(
                 "calibrate auto-sizer: fixed overhead "
                 "(cache %.2f GB + scratch/state %.2f GB × safety %.2fx) "
@@ -271,16 +266,16 @@ def auto_size_calibration_batches(
                 reserve_bytes / 1e9,
                 workers,
             )
-            forward_budget = peak_bytes * _AUTO_BATCH_MIN_ROWS
+            forward_budget = peak_bytes * AUTO_BATCH_MIN_ROWS
         total_rows = max(
-            _AUTO_BATCH_MIN_ROWS,
-            min(forward_budget // peak_bytes, _AUTO_BATCH_MAX_ROWS),
+            AUTO_BATCH_MIN_ROWS,
+            min(forward_budget // peak_bytes, AUTO_BATCH_MAX_ROWS),
         )
     return choose_calibration_batch_shape(
         total_rows,
         n_peptides=n_peptides,
         n_alleles=n_alleles,
-        min_peptide_batch=max(_AUTO_BATCH_MIN_ROWS, 2_000),
+        min_peptide_batch=max(AUTO_BATCH_MIN_ROWS, 2_000),
         fixed_peptide_batch=fixed_peptide_batch,
         fixed_allele_batch=fixed_allele_batch,
     )
@@ -295,22 +290,22 @@ def estimate_calibration_peak_bytes_per_row(model):
     before combining them. Hidden-layer peak memory is therefore the max
     sub-network peak, not the sum of every sub-network peak.
     """
-    from ..pytorch_sizing import _estimate_peak_bytes_per_row
+    from ..pytorch_sizing import estimate_peak_bytes_per_row
 
     if model is None:
-        return _estimate_peak_bytes_per_row(model)
+        return estimate_peak_bytes_per_row(model)
 
     sub_networks = getattr(model, "networks", None)
     if sub_networks is None or hasattr(model, "peptide_encoding_shape"):
-        return _estimate_peak_bytes_per_row(model)
+        return estimate_peak_bytes_per_row(model)
 
     try:
         sub_peaks = [
-            _estimate_peak_bytes_per_row(net)
+            estimate_peak_bytes_per_row(net)
             for net in sub_networks
         ]
         if not sub_peaks:
-            return _estimate_peak_bytes_per_row(model)
+            return estimate_peak_bytes_per_row(model)
         output_channels = 0
         for net in sub_networks:
             output_layer = getattr(net, "output_layer", None)
@@ -325,7 +320,7 @@ def estimate_calibration_peak_bytes_per_row(model):
             "falling back to generic estimator: %s",
             exc,
         )
-        return _estimate_peak_bytes_per_row(model)
+        return estimate_peak_bytes_per_row(model)
 
 def choose_calibration_batch_shape(
         total_rows,
@@ -438,7 +433,7 @@ def probe_peptide_stage_dim(net_obj, encoded_peptides, device):
     to the heuristic.
     """
     import torch
-    from .encodable_sequences import EncodableSequences
+    from ..encodable_sequences import EncodableSequences
     try:
         seqs = list(encoded_peptides.sequences)
         if not seqs:
@@ -461,7 +456,7 @@ def probe_peptide_stage_dim(net_obj, encoded_peptides, device):
         with torch.no_grad():
             stage = model.forward_peptide_stage(probe_tensor)
         return int(stage.shape[-1])
-    except Exception as exc:
+    except (AttributeError, RuntimeError, TypeError, ValueError) as exc:
         logging.warning(
             "calibrate auto-sizer: peptide_stage_dim probe failed "
             "(%s); falling back to encoding-shape heuristic", exc,

--- a/mhcflurry/calibrate_percentile_ranks_command.py
+++ b/mhcflurry/calibrate_percentile_ranks_command.py
@@ -12,8 +12,14 @@
 
 """Compatibility wrapper for :mod:`mhcflurry.cli.calibrate_percentile_ranks_command`."""
 
-import sys
-
 from .cli import calibrate_percentile_ranks_command as _impl
 
-sys.modules[__name__] = _impl
+run = _impl.run
+parser = _impl.parser
+
+
+def __getattr__(name):
+    return getattr(_impl, name)
+
+
+__all__ = ["run", "parser"]

--- a/mhcflurry/class1_affinity_predictor.py
+++ b/mhcflurry/class1_affinity_predictor.py
@@ -55,9 +55,6 @@ DEFAULT_CENTRALITY_MEASURE = "mean"
 # Any value > 0 will result in attempting to optimize models after loading.
 OPTIMIZATION_LEVEL = int(environ.get("MHCFLURRY_OPTIMIZATION_LEVEL", 1))
 
-_peptide_sequences_fingerprint = calibration_sizing.peptide_sequences_fingerprint
-_CalibrationFastCache = calibration_sizing.CalibrationFastCache
-
 
 class Class1AffinityPredictor(object):
     """
@@ -1668,77 +1665,6 @@ class Class1AffinityPredictor(object):
             }
         return {}
 
-    @staticmethod
-    @staticmethod
-    def _auto_size_calibration_batches(
-            model, device, n_peptides, n_alleles,
-            num_workers_per_gpu=1,
-            free_memory_fraction=0.85,
-            num_cached_networks=1,
-            peptide_stage_dim=None,
-            num_sub_networks=None,
-            cuda_overhead_bytes=2 * (1 << 30),
-            safety_multiplier=1.3,
-            fixed_peptide_batch=None,
-            fixed_allele_batch=None):
-        return calibration_sizing.auto_size_calibration_batches(
-            model,
-            device,
-            n_peptides,
-            n_alleles,
-            num_workers_per_gpu=num_workers_per_gpu,
-            free_memory_fraction=free_memory_fraction,
-            num_cached_networks=num_cached_networks,
-            peptide_stage_dim=peptide_stage_dim,
-            num_sub_networks=num_sub_networks,
-            cuda_overhead_bytes=cuda_overhead_bytes,
-            safety_multiplier=safety_multiplier,
-            fixed_peptide_batch=fixed_peptide_batch,
-            fixed_allele_batch=fixed_allele_batch,
-        )
-
-    @staticmethod
-    def _estimate_calibration_peak_bytes_per_row(model):
-        return calibration_sizing.estimate_calibration_peak_bytes_per_row(model)
-
-    @staticmethod
-    def _choose_calibration_batch_shape(
-            total_rows,
-            n_peptides,
-            n_alleles,
-            min_peptide_batch,
-            max_allele_batch=256,
-            fixed_peptide_batch=None,
-            fixed_allele_batch=None):
-        return calibration_sizing.choose_calibration_batch_shape(
-            total_rows,
-            n_peptides=n_peptides,
-            n_alleles=n_alleles,
-            min_peptide_batch=min_peptide_batch,
-            max_allele_batch=max_allele_batch,
-            fixed_peptide_batch=fixed_peptide_batch,
-            fixed_allele_batch=fixed_allele_batch,
-        )
-
-    @staticmethod
-    def _calibration_stage_cache_signature(encoded_peptides, networks, device):
-        return calibration_sizing.calibration_stage_cache_signature(
-            encoded_peptides,
-            networks,
-            device,
-        )
-
-    @staticmethod
-    def _probe_peptide_stage_dim(net_obj, encoded_peptides, device):
-        return calibration_sizing.probe_peptide_stage_dim(
-            net_obj,
-            encoded_peptides,
-            device,
-        )
-
-    def _calibration_fast_cache(self):
-        return calibration_sizing.calibration_fast_cache(self)
-
     def clear_calibration_fast_cache(self):
         return calibration_sizing.clear_calibration_fast_cache(self)
 
@@ -1784,7 +1710,7 @@ class Class1AffinityPredictor(object):
         changes.
 
         Caching note: this method memoizes the peptide-stage activations on
-        the predictor instance across calls (see ``_calibration_fast_cache``).
+        the predictor instance across calls.
         That cache is keyed on network identity, not weight content, so do not
         mutate the predictor's network weights in place between calls on the
         same instance without first calling ``clear_calibration_fast_cache()``.
@@ -1891,7 +1817,7 @@ class Class1AffinityPredictor(object):
         # call inside the same worker process and re-builds
         # ``cached_stages`` from scratch even though the peptide universe
         # and the predictor are identical. Cache the built tensors on
-        # ``self._calibration_fast_cache`` and skip the rebuild whenever
+        # ``calibration_sizing.calibration_fast_cache`` and skip the rebuild whenever
         # the signature matches. ``forward_peptide_stage`` runs once per
         # peptide-batch per network, so for the production workload
         # (~400k peptides × many allele chunks/worker) each saved rebuild
@@ -1908,13 +1834,14 @@ class Class1AffinityPredictor(object):
         # Cache validity also assumes the predictor's network weights are not
         # mutated in place between calls on the same instance: the key tracks
         # network *identity*, not weight content (see
-        # ``_calibration_stage_cache_signature`` for why a content fingerprint
-        # is unreliable here), so a caller that re-fits a network in place must
+        # ``calibration_sizing.calibration_stage_cache_signature`` for why a
+        # content fingerprint is unreliable here), so a caller that re-fits a
+        # network in place must
         # call ``clear_calibration_fast_cache()`` to avoid reusing stale
         # stages. Adding/removing/replacing whole models is already safe (new
         # network objects -> new ids -> cache miss).
-        cache = self._calibration_fast_cache()
-        cache_signature = self._calibration_stage_cache_signature(
+        cache = calibration_sizing.calibration_fast_cache(self)
+        cache_signature = calibration_sizing.calibration_stage_cache_signature(
             encoded_peptides, networks, device,
         )
         cache_hit = (
@@ -1931,7 +1858,7 @@ class Class1AffinityPredictor(object):
             probe_net.to(device)
             # Probe the *actual* peptide_stage output dim so the cache
             # estimate doesn't fall back to the encoding-shape floor.
-            probed_stage_dim = self._probe_peptide_stage_dim(
+            probed_stage_dim = calibration_sizing.probe_peptide_stage_dim(
                 probe_net_obj, encoded_peptides, device,
             )
             sub_networks = getattr(probe_net, "networks", None)
@@ -1947,7 +1874,7 @@ class Class1AffinityPredictor(object):
             pinned_allele = (
                 None if allele_batch_size in (None, "auto")
                 else int(allele_batch_size))
-            auto_peptide, auto_allele = self._auto_size_calibration_batches(
+            auto_peptide, auto_allele = calibration_sizing.auto_size_calibration_batches(
                 probe_net, device, n_peptides, len(alleles),
                 num_workers_per_gpu=num_workers_per_gpu,
                 # If the peptide-stage cache is already resident in this

--- a/mhcflurry/class1_affinity_predictor.py
+++ b/mhcflurry/class1_affinity_predictor.py
@@ -1856,10 +1856,12 @@ class Class1AffinityPredictor(object):
             probe_net_obj = networks[0]
             probe_net = probe_net_obj.network(borrow=True)
             probe_net.to(device)
-            # Probe the *actual* peptide_stage output dim so the cache
-            # estimate doesn't fall back to the encoding-shape floor.
-            probed_stage_dim = calibration_sizing.probe_peptide_stage_dim(
-                probe_net_obj, encoded_peptides, device,
+            # Probe the actual peptide feature width so the cache estimate
+            # doesn't fall back to the encoding-shape floor.
+            probed_peptide_feature_dim = (
+                calibration_sizing.probe_peptide_feature_dim(
+                    probe_net_obj, encoded_peptides, device,
+                )
             )
             sub_networks = getattr(probe_net, "networks", None)
             num_sub_networks_probed = (
@@ -1882,7 +1884,7 @@ class Class1AffinityPredictor(object):
                 # by that cache. Counting it again here makes later shards
                 # collapse to tiny fallback batches.
                 num_cached_networks=0 if cache_hit else len(networks),
-                peptide_stage_dim=probed_stage_dim,
+                peptide_feature_dim=probed_peptide_feature_dim,
                 num_sub_networks=num_sub_networks_probed,
                 fixed_peptide_batch=pinned_peptide,
                 fixed_allele_batch=pinned_allele,
@@ -1899,7 +1901,8 @@ class Class1AffinityPredictor(object):
                     f"(workers_per_gpu={num_workers_per_gpu}, "
                     f"cached_networks={len(networks)}, "
                     f"sub_networks={num_sub_networks_probed}, "
-                    f"probed_stage_dim={probed_stage_dim})"
+                    f"probed_peptide_feature_dim="
+                    f"{probed_peptide_feature_dim})"
                 )
         peptide_batch_size = int(peptide_batch_size)
         allele_batch_size = int(allele_batch_size)
@@ -1927,14 +1930,11 @@ class Class1AffinityPredictor(object):
                 model.eval()
                 peptide_input = net_obj.peptides_to_network_input(encoded_peptides)
                 peptide_is_indices = net_obj.uses_peptide_torch_encoding()
-                # Pre-size the cache tensor by probing one row's stage_dim
-                # then write each chunk in-place. The previous build path
-                # used append+torch.cat, which transiently held *both* the
-                # per-chunk parts and the new contiguous tensor at once —
-                # a 2× VRAM peak (~13 GB extra on the production 400k
-                # peptide × 8-subnet ensemble) that pushed --max-workers-
-                # per-gpu auto into OOM territory. Pre-sized fill keeps
-                # the peak at 1× the cache.
+                # Pre-size the cache tensor by probing one row's peptide
+                # feature width, then write each chunk in-place. The previous
+                # append+torch.cat path transiently held both the per-chunk
+                # parts and the new contiguous tensor, a 2x VRAM peak that
+                # pushed --max-workers-per-gpu auto into OOM territory.
                 with torch.no_grad():
                     probe_chunk = peptide_input[:1]
                     probe_keep_int = (
@@ -1948,11 +1948,15 @@ class Class1AffinityPredictor(object):
                         probe_tensor = torch.from_numpy(
                             numpy.asarray(probe_chunk, dtype=numpy.float32),
                         ).to(device)
-                    probe_stage = model.forward_peptide_stage(probe_tensor)
-                    stage_dim_cached = int(probe_stage.shape[-1])
-                    stage_dtype = probe_stage.dtype
+                    probe_peptide_features = model.forward_peptide_stage(
+                        probe_tensor,
+                    )
+                    peptide_feature_dim_cached = int(
+                        probe_peptide_features.shape[-1],
+                    )
+                    stage_dtype = probe_peptide_features.dtype
                 cached_tensor = torch.empty(
-                    n_peptides, stage_dim_cached,
+                    n_peptides, peptide_feature_dim_cached,
                     dtype=stage_dtype, device=device,
                 )
                 with torch.no_grad():
@@ -2038,12 +2042,12 @@ class Class1AffinityPredictor(object):
             )
             ensemble_member_count = 0
 
-            for (_, model, peptide_stage) in cached_stages:
+            for (_, model, peptide_features) in cached_stages:
                 model_member_count = None
                 with torch.no_grad():
                     for start in range(0, n_peptides, peptide_batch_size):
                         end = min(start + peptide_batch_size, n_peptides)
-                        p_chunk = peptide_stage[start:end]  # (chunk_n, d)
+                        p_chunk = peptide_features[start:end]  # (chunk_n, d)
                         network_output = cartesian_network_output(
                             model,
                             p_chunk,

--- a/mhcflurry/class1_neural_network.py
+++ b/mhcflurry/class1_neural_network.py
@@ -63,7 +63,7 @@ from .class1_training import (
     _timing_enabled,
     _timing_start,
     _timing_stop,
-    _torch_from_numpy,
+    torch_from_numpy,
     _update_min_validation_loss,
     _validation_interval_from_hyperparameters,
 )
@@ -78,9 +78,9 @@ from .pytorch_training import (
 
 
 DEFAULT_PREDICT_BATCH_SIZE = pytorch_sizing.DEFAULT_PREDICT_BATCH_SIZE
-_env_workers_per_gpu = pytorch_sizing._env_workers_per_gpu
 check_training_batch_fits = pytorch_sizing.check_training_batch_fits
 compute_prediction_batch_size = pytorch_sizing.compute_prediction_batch_size
+env_workers_per_gpu = pytorch_sizing.env_workers_per_gpu
 resolve_prediction_batch_size = pytorch_sizing.resolve_prediction_batch_size
 
 KERAS_BATCH_NORM_EPSILON = 1e-3
@@ -2517,16 +2517,16 @@ class Class1NeuralNetwork(object):
             _val_peptide_np.ndim == 2
             and numpy.issubdtype(_val_peptide_np.dtype, numpy.integer)
         ):
-            val_peptide_device = _torch_from_numpy(_val_peptide_np).to(device)
+            val_peptide_device = torch_from_numpy(_val_peptide_np).to(device)
         else:
-            val_peptide_device = _torch_from_numpy(
+            val_peptide_device = torch_from_numpy(
                 _val_peptide_np).to(device).float()
         val_allele_device = None
         if "allele" in validation_x_dict:
-            val_allele_device = _torch_from_numpy(
+            val_allele_device = torch_from_numpy(
                 validation_x_dict["allele"]
             ).to(device).float()
-        val_y_device = _torch_from_numpy(
+        val_y_device = torch_from_numpy(
             output.astype(numpy.float32)).to(device)
 
         # Streaming-pretrain batches stay as numpy arrays until the parent
@@ -3195,7 +3195,7 @@ class Class1NeuralNetwork(object):
             _requested_minibatch,
             device,
             network,
-            num_workers_per_gpu=_env_workers_per_gpu(1),
+            num_workers_per_gpu=env_workers_per_gpu(1),
         )
         if _shrunk:
             fit_info["minibatch_size_shrunk_from"] = _requested_minibatch
@@ -3341,21 +3341,21 @@ class Class1NeuralNetwork(object):
                 _val_peptide_np.ndim == 2
                 and numpy.issubdtype(_val_peptide_np.dtype, numpy.integer)
             ):
-                _val_peptide_device = _torch_from_numpy(_val_peptide_np).to(device)
+                _val_peptide_device = torch_from_numpy(_val_peptide_np).to(device)
             else:
-                _val_peptide_device = _torch_from_numpy(
+                _val_peptide_device = torch_from_numpy(
                     _val_peptide_np).float().to(device)
-            _val_y_device = _torch_from_numpy(
+            _val_y_device = torch_from_numpy(
                 y_encoded[val_indices].astype(numpy.float32)
             ).to(device)
             _val_allele_device = None
             if "allele" in x_dict_without_random_negatives:
-                _val_allele_device = _torch_from_numpy(
+                _val_allele_device = torch_from_numpy(
                     x_dict_without_random_negatives["allele"][val_training_indices]
                 ).float().to(device)
             _val_weights_device = None
             if sample_weights_with_negatives is not None:
-                _val_weights_device = _torch_from_numpy(
+                _val_weights_device = torch_from_numpy(
                     sample_weights_with_negatives[val_indices]
                 ).float().to(device)
             _val_device_tensors = (
@@ -3786,7 +3786,7 @@ class Class1NeuralNetwork(object):
             the same CUDA device, pass the worker count so the auto-
             sizer partitions the VRAM budget. Ignored for explicit int
             batch_size. When not passed, falls back to
-            ``_env_workers_per_gpu(1)`` (the ``MHCFLURRY_MAX_WORKERS_PER_GPU``
+            ``env_workers_per_gpu(1)`` (the ``MHCFLURRY_MAX_WORKERS_PER_GPU``
             env var the worker pool sets), mirroring ``fit()``.
 
         Returns
@@ -3794,7 +3794,7 @@ class Class1NeuralNetwork(object):
         numpy.array of nM affinity predictions
         """
         if num_workers_per_gpu is None:
-            num_workers_per_gpu = _env_workers_per_gpu(1)
+            num_workers_per_gpu = env_workers_per_gpu(1)
 
         assert self.prediction_cache is not None
         use_cache = allele_encoding is None and isinstance(peptides, EncodableSequences)

--- a/mhcflurry/class1_presentation_predictor.py
+++ b/mhcflurry/class1_presentation_predictor.py
@@ -31,7 +31,7 @@ from .class1_affinity_predictor import Class1AffinityPredictor
 from .class1_processing_predictor import Class1ProcessingPredictor
 from .pytorch_sizing import (
     DEFAULT_PREDICT_BATCH_SIZE,
-    _env_workers_per_gpu,
+    env_workers_per_gpu,
 )
 from .encodable_sequences import EncodableSequences
 from .regression_target import from_ic50
@@ -275,7 +275,7 @@ class Class1PresentationPredictor(object):
             model_kwargs = dict(model_kwargs)
         affinity_model_kwargs = {
             "batch_size": PREDICT_BATCH_SIZE,
-            "num_workers_per_gpu": _env_workers_per_gpu(1),
+            "num_workers_per_gpu": env_workers_per_gpu(1),
         }
         affinity_model_kwargs.update(model_kwargs)
         predict_cartesian = getattr(

--- a/mhcflurry/class1_processing_neural_network.py
+++ b/mhcflurry/class1_processing_neural_network.py
@@ -26,7 +26,7 @@ import torch.nn.functional as F
 
 from . import amino_acid
 from .hyperparameters import HyperparameterDefaults
-from .class1_training import _torch_from_numpy
+from .class1_training import torch_from_numpy
 from .pytorch_sizing import DEFAULT_PREDICT_BATCH_SIZE
 from .flanking_encoding import FlankingEncoding
 from .common import get_pytorch_device
@@ -815,14 +815,14 @@ class Class1ProcessingNeuralNetwork(object):
         # slicing by `batch_idx` on-device removes the per-step
         # numpy.from_numpy + astype + .to(device) trio that this loop
         # used to do every minibatch.
-        # Route through _torch_from_numpy (copies non-writeable arrays) for
+        # Route through torch_from_numpy (copies non-writeable arrays) for
         # parity with the affinity path; encode_indices returns fresh arrays
         # today, but this guards against a future read-only cache entry.
-        seq_dev = _torch_from_numpy(x_dict["sequence"]).to(device)
-        length_dev = _torch_from_numpy(x_dict["peptide_length"]).to(device)
-        targets_dev = _torch_from_numpy(targets.astype(numpy.float32)).to(device)
+        seq_dev = torch_from_numpy(x_dict["sequence"]).to(device)
+        length_dev = torch_from_numpy(x_dict["peptide_length"]).to(device)
+        targets_dev = torch_from_numpy(targets.astype(numpy.float32)).to(device)
         weights_dev = (
-            _torch_from_numpy(sample_weights.astype(numpy.float32)).to(device)
+            torch_from_numpy(sample_weights.astype(numpy.float32)).to(device)
             if sample_weights is not None
             else None
         )
@@ -1079,7 +1079,7 @@ class Class1ProcessingNeuralNetwork(object):
         numpy for the public API.
         """
         from .pytorch_sizing import (
-            _env_workers_per_gpu,
+            env_workers_per_gpu,
             resolve_prediction_batch_size,
         )
 
@@ -1100,7 +1100,7 @@ class Class1ProcessingNeuralNetwork(object):
             batch_size,
             device,
             model=network,
-            num_workers_per_gpu=_env_workers_per_gpu(1),
+            num_workers_per_gpu=env_workers_per_gpu(1),
         )
 
         n_samples = len(x_dict["sequence"])

--- a/mhcflurry/class1_training.py
+++ b/mhcflurry/class1_training.py
@@ -173,7 +173,7 @@ def _batch_value_to_device(value, device, *, non_blocking, cast_float):
     fp32 via embedding lookup inside the network's forward pass.
     """
     if isinstance(value, numpy.ndarray):
-        value = _torch_from_numpy(value)
+        value = torch_from_numpy(value)
     if cast_float and value.dtype == torch.float64:
         value = value.float()
     value = value.to(device, non_blocking=non_blocking)
@@ -182,7 +182,7 @@ def _batch_value_to_device(value, device, *, non_blocking, cast_float):
     return value
 
 
-def _torch_from_numpy(value):
+def torch_from_numpy(value):
     if not value.flags.writeable:
         value = value.copy()
     return torch.from_numpy(value)

--- a/mhcflurry/cli/calibrate_percentile_ranks_command.py
+++ b/mhcflurry/cli/calibrate_percentile_ranks_command.py
@@ -15,10 +15,8 @@ Calibrate percentile ranks for models. Runs in-place.
 """
 import argparse
 import os
-import signal
 import sys
 import time
-import traceback
 import collections
 from functools import partial
 
@@ -37,6 +35,7 @@ from ..common import (
     configure_pytorch,
     configure_random_seed,
     filter_canonicalizable_alleles,
+    install_sigusr1_stack_trace_handler,
     random_peptides,
     write_generate_sh,
 )
@@ -68,7 +67,7 @@ tqdm.monitor_interval = 0  # see https://github.com/tqdm/tqdm/issues/481
 # stored here before creating the thread pool will be inherited to the child
 # processes upon fork() call, allowing local workers to read the same
 # copy-on-write pages instead of receiving a pickled copy.
-GLOBAL_DATA = {}
+WORKER_CONTEXT = {}
 
 parser = argparse.ArgumentParser(usage=__doc__)
 parser.add_argument(
@@ -232,9 +231,7 @@ def run(argv=sys.argv[1:]):
     args = parser.parse_args(argv)
 
     if not args.list_percent_rank_status:
-        # On sigusr1 print stack trace
-        print("To show stack trace, run:\nkill -s USR1 %d" % os.getpid())
-        signal.signal(signal.SIGUSR1, lambda sig, frame: traceback.print_stack())
+        install_sigusr1_stack_trace_handler()
 
     args.models_dir = os.path.abspath(args.models_dir)
 
@@ -455,23 +452,23 @@ def run_class1_presentation_predictor(args, peptides):
     print("Sampled genotypes: ", list(genotypes))
     print("Num peptides: ", len(peptides))
 
-    GLOBAL_DATA["presentation_models_dir"] = args.models_dir
-    GLOBAL_DATA["presentation_peptides"] = peptides
+    WORKER_CONTEXT["presentation_models_dir"] = args.models_dir
+    WORKER_CONTEXT["presentation_peptides"] = peptides
     affinity_model_kwargs = {"batch_size": args.prediction_batch_size}
     if hasattr(args, "max_workers_per_gpu"):
         affinity_model_kwargs["num_workers_per_gpu"] = (
             num_workers_per_gpu_from_args(args)
         )
-    GLOBAL_DATA["presentation_predict_kwargs"] = {
+    WORKER_CONTEXT["presentation_predict_kwargs"] = {
         "affinity_model_kwargs": affinity_model_kwargs,
         "processing_batch_size": args.prediction_batch_size,
     }
-    GLOBAL_DATA.pop("_presentation_predictor", None)
-    GLOBAL_DATA.pop("_presentation_predictor_models_dir", None)
+    WORKER_CONTEXT.pop("_presentation_predictor", None)
+    WORKER_CONTEXT.pop("_presentation_predictor_models_dir", None)
 
     serial_run = not args.cluster_parallelism and args.num_jobs == 0
     if serial_run:
-        GLOBAL_DATA["_presentation_predictor"] = predictor
+        WORKER_CONTEXT["_presentation_predictor"] = predictor
 
     genotype_items = list(genotypes.items())
     work_items = []
@@ -496,7 +493,7 @@ def run_class1_presentation_predictor(args, peptides):
             args,
             work_function=do_class1_presentation_percent_rank_scores,
             work_items=work_items,
-            constant_data=GLOBAL_DATA,
+            constant_data=WORKER_CONTEXT,
             result_serialization_method="pickle",
             clear_constant_data=True)
     else:
@@ -518,7 +515,7 @@ def run_class1_presentation_predictor(args, peptides):
             # tears the pool down via the finally rather than leaking
             # non-daemon workers.
             attach_constant_data_to_work_items_if_needed(
-                work_items, GLOBAL_DATA, worker_pool
+                work_items, WORKER_CONTEXT, worker_pool
             )
             results = worker_pool.imap_unordered(
                 partial(call_wrapped_kwargs,
@@ -564,18 +561,18 @@ def run_class1_presentation_predictor(args, peptides):
 
 def _presentation_predictor_for_calibration(constant_data):
     cache_key = constant_data["presentation_models_dir"]
-    predictor = GLOBAL_DATA.get("_presentation_predictor")
+    predictor = WORKER_CONTEXT.get("_presentation_predictor")
     if (
             predictor is None
-            or GLOBAL_DATA.get("_presentation_predictor_models_dir") != cache_key):
+            or WORKER_CONTEXT.get("_presentation_predictor_models_dir") != cache_key):
         predictor = Class1PresentationPredictor.load(cache_key)
-        GLOBAL_DATA["_presentation_predictor"] = predictor
-        GLOBAL_DATA["_presentation_predictor_models_dir"] = cache_key
+        WORKER_CONTEXT["_presentation_predictor"] = predictor
+        WORKER_CONTEXT["_presentation_predictor_models_dir"] = cache_key
     return predictor
 
 
 def do_class1_presentation_percent_rank_scores(
-        genotypes, chunk_num=None, constant_data=GLOBAL_DATA):
+        genotypes, chunk_num=None, constant_data=WORKER_CONTEXT):
     del chunk_num
     predictor = _presentation_predictor_for_calibration(constant_data)
     predictions_df = predictor.predict(
@@ -650,10 +647,10 @@ def run_class1_affinity_predictor(args, peptides):
     assert encoded_peptides.encoding_cache  # must have cached the encoding
     print("Finished encoding peptides in %0.2f sec." % (time.time() - start))
 
-    # Store peptides in GLOBAL_DATA so forked local workers inherit the same
+    # Store peptides in WORKER_CONTEXT so forked local workers inherit the same
     # copy-on-write pages instead of receiving a pickled copy.
-    GLOBAL_DATA["calibration_peptides"] = encoded_peptides
-    GLOBAL_DATA["predictor"] = predictor
+    WORKER_CONTEXT["calibration_peptides"] = encoded_peptides
+    WORKER_CONTEXT["predictor"] = predictor
     model_kwargs = {
         'batch_size': args.prediction_batch_size,
     }
@@ -664,7 +661,7 @@ def run_class1_affinity_predictor(args, peptides):
     if hasattr(args, 'max_workers_per_gpu'):
         model_kwargs['num_workers_per_gpu'] = num_workers_per_gpu_from_args(args)
     num_workers_per_gpu = num_workers_per_gpu_from_args(args)
-    GLOBAL_DATA["args"] = {
+    WORKER_CONTEXT["args"] = {
         'motif_summary': args.motif_summary,
         'summary_top_peptide_fractions': args.summary_top_peptide_fraction,
         'verbose': args.verbosity > 0,
@@ -699,7 +696,7 @@ def run_class1_affinity_predictor(args, peptides):
             args,
             work_function=do_class1_affinity_calibrate_percentile_ranks,
             work_items=work_items,
-            constant_data=GLOBAL_DATA,
+            constant_data=WORKER_CONTEXT,
             result_serialization_method="pickle",
             clear_constant_data=True)
     else:
@@ -720,7 +717,7 @@ def run_class1_affinity_predictor(args, peptides):
             # tears the pool down via the finally rather than leaking
             # non-daemon workers.
             attach_constant_data_to_work_items_if_needed(
-                work_items, GLOBAL_DATA, worker_pool
+                work_items, WORKER_CONTEXT, worker_pool
             )
             results = worker_pool.imap_unordered(
                 partial(call_wrapped_kwargs, do_class1_affinity_calibrate_percentile_ranks),
@@ -763,7 +760,7 @@ def run_class1_affinity_predictor(args, peptides):
 
 
 def do_class1_affinity_calibrate_percentile_ranks(
-        alleles, constant_data=GLOBAL_DATA):
+        alleles, constant_data=WORKER_CONTEXT):
 
     if 'predictor' not in constant_data:
         raise ValueError("No predictor provided: " + str(constant_data))

--- a/mhcflurry/cli/compare_models.py
+++ b/mhcflurry/cli/compare_models.py
@@ -239,7 +239,7 @@ def _public_path_for_role(role, release_pin):
         "affinity": ("models_class1_pan", "models.combined"),
         "processing": (
             "models_class1_processing", "models.selected.with_flanks"),
-        "presentation": ("models_class1_presentation", "models.combined"),
+        "presentation": ("models_class1_presentation", "models"),
         "training": (None, None),
     }
     download_name, sub = role_to_download.get(role, (None, None))
@@ -284,6 +284,7 @@ def _probe_run_dir(spec, role):
         return _first_match(candidates, _looks_like_affinity_dir)
     if role == "presentation":
         candidates = [
+            os.path.join(spec, "presentation", "models"),
             os.path.join(spec, "presentation", "models.combined"),
             os.path.join(spec, "presentation"),
             spec,

--- a/mhcflurry/cli/select_allele_specific_models_command.py
+++ b/mhcflurry/cli/select_allele_specific_models_command.py
@@ -15,10 +15,8 @@ Model select class1 single allele models.
 """
 import argparse
 import os
-import signal
 import sys
 import time
-import traceback
 import random
 from functools import partial
 from pprint import pprint
@@ -38,6 +36,7 @@ from ..common import (
     configure_random_seed,
     derive_seed,
     filter_canonicalizable_alleles,
+    install_sigusr1_stack_trace_handler,
     normalize_allele_name,
     random_peptides,
     write_generate_sh,
@@ -58,7 +57,7 @@ tqdm.monitor_interval = 0  # see https://github.com/tqdm/tqdm/issues/481
 # stored here before creating the thread pool will be inherited to the child
 # processes upon fork() call, allowing local workers to read the same
 # copy-on-write pages instead of receiving a pickled copy.
-GLOBAL_DATA = {}
+WORKER_CONTEXT = {}
 
 
 parser = argparse.ArgumentParser(usage=__doc__)
@@ -208,9 +207,7 @@ add_random_seed_arg(parser)
 
 
 def run(argv=sys.argv[1:]):
-    # On sigusr1 print stack trace
-    print("To show stack trace, run:\nkill -s USR1 %d" % os.getpid())
-    signal.signal(signal.SIGUSR1, lambda sig, frame: traceback.print_stack())
+    install_sigusr1_stack_trace_handler()
 
     args = parser.parse_args(argv)
 
@@ -220,7 +217,7 @@ def run(argv=sys.argv[1:]):
 
     # Seed all randomness up front (the allele shuffle below runs in this
     # process). Per-allele scrambling in model_select runs in workers, so we
-    # also stash the master seed in GLOBAL_DATA and reseed per allele there.
+    # also stash the master seed in WORKER_CONTEXT and reseed per allele there.
     master_seed = configure_random_seed(
         args.random_seed, name="select-allele-specific")
 
@@ -356,7 +353,7 @@ def run(argv=sys.argv[1:]):
             args.unselected_accuracy_scorer,
             combined_min_contribution_percent=0.0)[0]
         print("Using unselected accuracy scorer: %s" % unselected_accuracy_scorer)
-    GLOBAL_DATA["unselected_accuracy_scorer"] = unselected_accuracy_scorer
+    WORKER_CONTEXT["unselected_accuracy_scorer"] = unselected_accuracy_scorer
 
     print("Selectors for alleles:")
     allele_to_selector = {}
@@ -374,12 +371,12 @@ def run(argv=sys.argv[1:]):
         allele_to_model_selection_kwargs[allele] = (
             selector_to_model_selection_kwargs[possible_selector])
 
-    GLOBAL_DATA["args"] = args
-    GLOBAL_DATA["input_predictor"] = input_predictor
-    GLOBAL_DATA["unselected_accuracy_scorer"] = unselected_accuracy_scorer
-    GLOBAL_DATA["allele_to_selector"] = allele_to_selector
-    GLOBAL_DATA["allele_to_model_selection_kwargs"] = allele_to_model_selection_kwargs
-    GLOBAL_DATA["seed"] = master_seed
+    WORKER_CONTEXT["args"] = args
+    WORKER_CONTEXT["input_predictor"] = input_predictor
+    WORKER_CONTEXT["unselected_accuracy_scorer"] = unselected_accuracy_scorer
+    WORKER_CONTEXT["allele_to_selector"] = allele_to_selector
+    WORKER_CONTEXT["allele_to_model_selection_kwargs"] = allele_to_model_selection_kwargs
+    WORKER_CONTEXT["seed"] = master_seed
 
     if not os.path.exists(args.out_models_dir):
         print("Attempting to create directory: %s" % args.out_models_dir)
@@ -412,7 +409,7 @@ def run(argv=sys.argv[1:]):
         # Parallel run
         random.shuffle(alleles)
         results = worker_pool.imap_unordered(
-            partial(model_select, constant_data=GLOBAL_DATA),
+            partial(model_select, constant_data=WORKER_CONTEXT),
             alleles,
             chunksize=1)
 
@@ -471,7 +468,7 @@ class ScrambledPredictor(object):
         return self._predictions[peptides].sample(frac=1.0).values
 
 
-def model_select(allele, constant_data=GLOBAL_DATA):
+def model_select(allele, constant_data=WORKER_CONTEXT):
     # Runs in a worker, which reseeds its RNGs from entropy on startup. Reseed
     # from the run's master seed mixed with the allele so the scrambling
     # ``.sample(frac=1.0)`` in the accuracy scorer is reproducible per allele.

--- a/mhcflurry/cli/select_pan_allele_models_command.py
+++ b/mhcflurry/cli/select_pan_allele_models_command.py
@@ -21,10 +21,8 @@ selected models across all folds.
 import argparse
 import os
 import re
-import signal
 import sys
 import time
-import traceback
 import hashlib
 from pprint import pprint
 
@@ -39,6 +37,7 @@ from ..allele_encoding import AlleleEncoding
 from ..common import (
     configure_logging,
     filter_canonicalizable_alleles,
+    install_sigusr1_stack_trace_handler,
     write_generate_sh,
 )
 from ..parallelism import (
@@ -63,7 +62,7 @@ tqdm.monitor_interval = 0  # see https://github.com/tqdm/tqdm/issues/481
 # stored here before creating the thread pool will be inherited to the child
 # processes upon fork() call, allowing local workers to read the same
 # copy-on-write pages instead of receiving a pickled copy.
-GLOBAL_DATA = {}
+WORKER_CONTEXT = {}
 
 
 parser = argparse.ArgumentParser(usage=__doc__)
@@ -155,9 +154,7 @@ def mse(
 
 
 def run(argv=sys.argv[1:]):
-    # On sigusr1 print stack trace
-    print("To show stack trace, run:\nkill -s USR1 %d" % os.getpid())
-    signal.signal(signal.SIGUSR1, lambda sig, frame: traceback.print_stack())
+    install_sigusr1_stack_trace_handler()
 
     args = parser.parse_args(argv)
 
@@ -265,8 +262,8 @@ def run(argv=sys.argv[1:]):
             'max_models': args.max_models_per_fold,
         })
 
-    GLOBAL_DATA["data"] = df
-    GLOBAL_DATA["input_predictor"] = input_predictor
+    WORKER_CONTEXT["data"] = df
+    WORKER_CONTEXT["input_predictor"] = input_predictor
 
     if not os.path.exists(args.out_models_dir):
         print("Attempting to create directory: %s" % args.out_models_dir)
@@ -292,7 +289,7 @@ def run(argv=sys.argv[1:]):
             args,
             work_function=model_select,
             work_items=work_items,
-            constant_data=GLOBAL_DATA,
+            constant_data=WORKER_CONTEXT,
             result_serialization_method="pickle")
     else:
         worker_pool = worker_pool_with_gpu_assignments_from_args(args)
@@ -303,7 +300,7 @@ def run(argv=sys.argv[1:]):
         assert not serial_run
 
         attach_constant_data_to_work_items_if_needed(
-            work_items, GLOBAL_DATA, worker_pool
+            work_items, WORKER_CONTEXT, worker_pool
         )
         # Parallel run
         results = worker_pool.imap_unordered(
@@ -350,14 +347,14 @@ def run(argv=sys.argv[1:]):
         args.out_models_dir))
 
 
-def do_model_select_task(item, constant_data=GLOBAL_DATA):
+def do_model_select_task(item, constant_data=WORKER_CONTEXT):
     if 'constant_data' in item:
         constant_data = item.pop('constant_data')
     return model_select(constant_data=constant_data, **item)
 
 
 def model_select(
-        fold_num, models, min_models, max_models, constant_data=GLOBAL_DATA):
+        fold_num, models, min_models, max_models, constant_data=WORKER_CONTEXT):
     """
     Model select for a fold.
 

--- a/mhcflurry/cli/select_processing_models_command.py
+++ b/mhcflurry/cli/select_processing_models_command.py
@@ -21,10 +21,8 @@ selected models across all folds. AUC is used as the metric.
 import argparse
 import os
 import re
-import signal
 import sys
 import time
-import traceback
 import hashlib
 from pprint import pprint
 
@@ -36,7 +34,11 @@ import tqdm  # progress bar
 
 from ..class1_processing_predictor import Class1ProcessingPredictor
 from ..flanking_encoding import FlankingEncoding
-from ..common import configure_logging, write_generate_sh
+from ..common import (
+    configure_logging,
+    install_sigusr1_stack_trace_handler,
+    write_generate_sh,
+)
 from ..parallelism import (
     resolve_local_parallelism_args,
     worker_pool_with_gpu_assignments_from_args,
@@ -57,7 +59,7 @@ tqdm.monitor_interval = 0  # see https://github.com/tqdm/tqdm/issues/481
 # stored here before creating the thread pool will be inherited to the child
 # processes upon fork() call, allowing local workers to read the same
 # copy-on-write pages instead of receiving a pickled copy.
-GLOBAL_DATA = {}
+WORKER_CONTEXT = {}
 
 
 parser = argparse.ArgumentParser(usage=__doc__)
@@ -103,9 +105,7 @@ add_cluster_parallelism_args(parser)
 
 
 def run(argv=sys.argv[1:]):
-    # On sigusr1 print stack trace
-    print("To show stack trace, run:\nkill -s USR1 %d" % os.getpid())
-    signal.signal(signal.SIGUSR1, lambda sig, frame: traceback.print_stack())
+    install_sigusr1_stack_trace_handler()
 
     args = parser.parse_args(argv)
 
@@ -170,8 +170,8 @@ def run(argv=sys.argv[1:]):
             'max_models': args.max_models_per_fold,
         })
 
-    GLOBAL_DATA["data"] = df
-    GLOBAL_DATA["input_predictor"] = input_predictor
+    WORKER_CONTEXT["data"] = df
+    WORKER_CONTEXT["input_predictor"] = input_predictor
 
     if not os.path.exists(args.out_models_dir):
         print("Attempting to create directory: %s" % args.out_models_dir)
@@ -196,7 +196,7 @@ def run(argv=sys.argv[1:]):
             args,
             work_function=model_select,
             work_items=work_items,
-            constant_data=GLOBAL_DATA,
+            constant_data=WORKER_CONTEXT,
             result_serialization_method="pickle")
     else:
         worker_pool = worker_pool_with_gpu_assignments_from_args(args)
@@ -251,12 +251,12 @@ def run(argv=sys.argv[1:]):
         len(result_predictor.models), args.out_models_dir))
 
 
-def do_model_select_task(item, constant_data=GLOBAL_DATA):
+def do_model_select_task(item, constant_data=WORKER_CONTEXT):
     return model_select(constant_data=constant_data, **item)
 
 
 def model_select(
-        fold_num, models, min_models, max_models, constant_data=GLOBAL_DATA):
+        fold_num, models, min_models, max_models, constant_data=WORKER_CONTEXT):
     """
     Model select for a fold.
 

--- a/mhcflurry/cli/train_allele_specific_models_command.py
+++ b/mhcflurry/cli/train_allele_specific_models_command.py
@@ -15,10 +15,8 @@ Train Class1 single allele models.
 """
 import argparse
 import os
-import signal
 import sys
 import time
-import traceback
 import random
 from functools import partial
 
@@ -36,6 +34,7 @@ from ..common import (
     configure_logging,
     configure_random_seed,
     derive_seed,
+    install_sigusr1_stack_trace_handler,
     write_generate_sh,
 )
 from ..parallelism import (
@@ -60,7 +59,7 @@ tqdm.monitor_interval = 0  # see https://github.com/tqdm/tqdm/issues/481
 # stored here before creating the thread pool will be inherited to the child
 # processes upon fork() call, allowing local workers to read the same
 # copy-on-write pages instead of receiving a pickled copy.
-GLOBAL_DATA = {}
+WORKER_CONTEXT = {}
 
 # Note on parallelization:
 # When running in parallel, avoid using the neural network backend in the main
@@ -160,9 +159,7 @@ TRAIN_DATA_HYPERPARAMETER_DEFAULTS = HyperparameterDefaults(
 
 
 def run(argv=sys.argv[1:]):
-    # On sigusr1 print stack trace
-    print("To show stack trace, run:\nkill -s USR1 %d" % os.getpid())
-    signal.signal(signal.SIGUSR1, lambda sig, frame: traceback.print_stack())
+    install_sigusr1_stack_trace_handler()
 
     args = parser.parse_args(argv)
 
@@ -248,12 +245,12 @@ def run(argv=sys.argv[1:]):
 
     print("Training data: %s" % (str(df.shape)))
 
-    GLOBAL_DATA["train_data"] = df
-    GLOBAL_DATA["args"] = args
+    WORKER_CONTEXT["train_data"] = df
+    WORKER_CONTEXT["args"] = args
     # Persist the resolved master seed so workers (which reseed from entropy
     # in worker_init) can derive a stable per-fit seed via derive_seed. The
     # main-process global seeding above doesn't reach worker fits.
-    GLOBAL_DATA["seed"] = master_seed
+    WORKER_CONTEXT["seed"] = master_seed
     resolve_local_parallelism_args(
         args,
         workload_name=WORKLOAD_AFFINITY_TRAINING,
@@ -293,7 +290,7 @@ def run(argv=sys.argv[1:]):
                 hyperparameters.get('train_data', {})))
 
         if hyperparameters['train_data']['pretrain_min_points'] and (
-                'allele_similarity_matrix' not in GLOBAL_DATA):
+                'allele_similarity_matrix' not in WORKER_CONTEXT):
             print("Generating allele similarity matrix.")
             if not args.allele_sequences:
                 parser.error(
@@ -316,7 +313,7 @@ def run(argv=sys.argv[1:]):
                     blosum_encoding.reshape((len(allele_sequences), -1))),
                 index=allele_sequences.index.values,
                 columns=allele_sequences.index.values)
-            GLOBAL_DATA['allele_similarity_matrix'] = allele_similarity_matrix
+            WORKER_CONTEXT['allele_similarity_matrix'] = allele_similarity_matrix
             print("Computed allele similarity matrix")
             print(allele_similarity_matrix)
 
@@ -361,7 +358,7 @@ def run(argv=sys.argv[1:]):
 
         assert worker_pool is not None
         attach_constant_data_to_work_items_if_needed(
-            work_items, GLOBAL_DATA, worker_pool
+            work_items, WORKER_CONTEXT, worker_pool
         )
         results_generator = worker_pool.imap_unordered(
             partial(call_wrapped_kwargs, train_model),
@@ -435,7 +432,7 @@ def run(argv=sys.argv[1:]):
 
 
 def alleles_by_similarity(allele):
-    allele_similarity = GLOBAL_DATA['allele_similarity_matrix']
+    allele_similarity = WORKER_CONTEXT['allele_similarity_matrix']
     if allele not in allele_similarity.columns:
         # Use random alleles
         print("No similar alleles for: %s" % allele)
@@ -460,7 +457,7 @@ def train_model(
         progress_print_interval,
         predictor,
         save_to,
-        constant_data=GLOBAL_DATA):
+        constant_data=WORKER_CONTEXT):
 
     if predictor is None:
         predictor = Class1AffinityPredictor()

--- a/mhcflurry/cli/train_pan_allele_models_command.py
+++ b/mhcflurry/cli/train_pan_allele_models_command.py
@@ -16,10 +16,8 @@ Train Class1 pan-allele models.
 import argparse
 import os
 from os.path import join
-import signal
 import sys
 import time
-import traceback
 import random
 import pprint
 import hashlib
@@ -42,6 +40,7 @@ from ..common import (
     configure_random_seed,
     configure_logging,
     derive_seed,
+    install_sigusr1_stack_trace_handler,
     normalize_allele_name,
     write_generate_sh,
 )
@@ -76,7 +75,7 @@ tqdm.monitor_interval = 0  # see https://github.com/tqdm/tqdm/issues/481
 # stored here before creating the thread pool will be inherited to the child
 # processes upon fork() call, allowing local workers to read the same
 # copy-on-write pages instead of receiving a pickled copy.
-GLOBAL_DATA = {}
+WORKER_CONTEXT = {}
 
 # Note on parallelization:
 # When running in parallel, avoid using the neural network backend in the main
@@ -459,9 +458,7 @@ def pretrain_network_input_iterator(
 
 
 def run(argv=sys.argv[1:]):
-    # On sigusr1 print stack trace
-    print("To show stack trace, run:\nkill -s USR1 %d" % os.getpid())
-    signal.signal(signal.SIGUSR1, lambda sig, frame: traceback.print_stack())
+    install_sigusr1_stack_trace_handler()
 
     args = parser.parse_args(argv)
 
@@ -537,7 +534,7 @@ def initialize_training(args):
     # wall times:
     #   start               — argparse + validation done; before any I/O
     #   data_loaded         — train_data CSV parsed + filtered + folded
-    #   setup_done          — pool + all GLOBAL_DATA
+    #   setup_done          — pool + all WORKER_CONTEXT
     #   training_done       — all work items finished
     # Extract deltas by grepping stdout for ``TIMING_MARKER``.
     print(f"TIMING_MARKER start {time.time():.3f}")
@@ -714,10 +711,10 @@ def train_models(args):
     print("Loaded predictor with %d networks" % len(predictor.neural_networks))
 
     with open(join(args.out_models_dir, "training_init_info.pkl"), "rb") as fd:
-        GLOBAL_DATA.update(pickle.load(fd))
+        WORKER_CONTEXT.update(pickle.load(fd))
     print("Loaded training init info.")
 
-    all_work_items = GLOBAL_DATA["work_items"]
+    all_work_items = WORKER_CONTEXT["work_items"]
 
     apply_resolved_training_hyperparameters_to_work_items(all_work_items, args)
 
@@ -739,7 +736,7 @@ def train_models(args):
     # order is reproducible (per-fit results don't depend on order — each
     # fit reseeds from its own work-item seed — but this keeps the whole
     # run deterministic).
-    master_seed = GLOBAL_DATA.get("seed")
+    master_seed = WORKER_CONTEXT.get("seed")
     random.Random(master_seed).shuffle(work_items)
     for (work_item_num, item) in enumerate(work_items):
         item['work_item_num'] = work_item_num
@@ -771,14 +768,14 @@ def train_models(args):
             args,
             work_function=train_model,
             work_items=work_items,
-            constant_data=GLOBAL_DATA,
+            constant_data=WORKER_CONTEXT,
             result_serialization_method="save_predictor")
     else:
         run_single_worker_torch_compile_warmup(
             args,
             work_items,
             train_model,
-            constant_data=GLOBAL_DATA,
+            constant_data=WORKER_CONTEXT,
         )
 
         worker_pool = worker_pool_with_gpu_assignments_from_args(args)
@@ -797,7 +794,7 @@ def train_models(args):
             # tears the pool down via the finally rather than leaking
             # non-daemon workers.
             attach_constant_data_to_work_items_if_needed(
-                work_items, GLOBAL_DATA, worker_pool
+                work_items, WORKER_CONTEXT, worker_pool
             )
             results_generator = worker_pool.imap_unordered(
                 partial(call_wrapped_kwargs, train_model),
@@ -833,7 +830,7 @@ def train_models(args):
     # We want the final predictor to support all alleles with sequences, not
     # just those we actually used for model training.
     predictor.allele_to_sequence = (
-        GLOBAL_DATA['full_allele_encoding'].allele_to_sequence)
+        WORKER_CONTEXT['full_allele_encoding'].allele_to_sequence)
     predictor.clear_cache()
     predictor.save(args.out_models_dir)
     write_generate_sh(args.out_models_dir)
@@ -932,7 +929,7 @@ def train_model(
         predictor,
         save_to,
         compile_warmup_only=False,
-        constant_data=GLOBAL_DATA):
+        constant_data=WORKER_CONTEXT):
 
     if compile_warmup_only:
         _run_compile_warmup(hyperparameters, fold_num, constant_data)

--- a/mhcflurry/cli/train_presentation_models_command.py
+++ b/mhcflurry/cli/train_presentation_models_command.py
@@ -15,17 +15,16 @@ Train Class1 presentation models.
 """
 import argparse
 import os
-import signal
 import sys
 import time
-import traceback
 from functools import partial
 
 import numpy
 import pandas
 import tqdm  # progress bar
 
-from ..pytorch_sizing import _estimate_peak_bytes_per_row
+from ..affinity.calibration_sizing import estimate_calibration_peak_bytes_per_row
+from ..pytorch_sizing import estimate_peak_bytes_per_row
 from ..class1_processing_predictor import Class1ProcessingPredictor
 from ..class1_affinity_predictor import Class1AffinityPredictor
 from ..class1_presentation_predictor import Class1PresentationPredictor
@@ -33,6 +32,7 @@ from ..common import (
     add_random_seed_arg,
     configure_logging,
     configure_random_seed,
+    install_sigusr1_stack_trace_handler,
     write_generate_sh,
 )
 from ..parallelism import (
@@ -49,7 +49,7 @@ from ..workload_planning import (
 
 tqdm.monitor_interval = 0  # see https://github.com/tqdm/tqdm/issues/481
 
-GLOBAL_DATA = {}
+WORKER_CONTEXT = {}
 
 # Presentation feature workers keep affinity + processing predictors resident
 # and then run one model family at a time in auto-sized prediction batches.
@@ -117,9 +117,7 @@ add_local_parallelism_args(parser)
 add_random_seed_arg(parser)
 
 def run(argv=sys.argv[1:]):
-    # On sigusr1 print stack trace
-    print("To show stack trace, run:\nkill -s USR1 %d" % os.getpid())
-    signal.signal(signal.SIGUSR1, lambda sig, frame: traceback.print_stack())
+    install_sigusr1_stack_trace_handler()
 
     args = parser.parse_args(argv)
 
@@ -381,10 +379,8 @@ def presentation_network_peak_bytes_per_row(network):
     """Estimate forward peak memory for a presentation feature network."""
     sub_networks = getattr(network, "networks", None)
     if sub_networks is not None and not hasattr(network, "peptide_encoding_shape"):
-        return Class1AffinityPredictor._estimate_calibration_peak_bytes_per_row(
-            network
-        )
-    return _estimate_peak_bytes_per_row(network)
+        return estimate_calibration_peak_bytes_per_row(network)
+    return estimate_peak_bytes_per_row(network)
 
 
 def predict_features_parallel(args, predictor, df, experiment_to_alleles):
@@ -420,8 +416,8 @@ def predict_features_parallel(args, predictor, df, experiment_to_alleles):
         item["include_without_flanks"] = include_without_flanks
         item["include_with_flanks"] = include_with_flanks
 
-    GLOBAL_DATA.clear()
-    GLOBAL_DATA.update({
+    WORKER_CONTEXT.clear()
+    WORKER_CONTEXT.update({
         "predictor": predictor,
         "data": df,
         "experiment_to_alleles": experiment_to_alleles,
@@ -433,7 +429,7 @@ def predict_features_parallel(args, predictor, df, experiment_to_alleles):
         print("Worker pool", worker_pool)
         assert worker_pool is not None
         attach_constant_data_to_work_items_if_needed(
-            work_items, GLOBAL_DATA, worker_pool
+            work_items, WORKER_CONTEXT, worker_pool
         )
 
         affinity = numpy.empty(len(df), dtype="float64")
@@ -504,7 +500,7 @@ def predict_feature_chunk(
         sample_name,
         include_without_flanks,
         include_with_flanks,
-        constant_data=GLOBAL_DATA):
+        constant_data=WORKER_CONTEXT):
     predictor = constant_data["predictor"]
     df = constant_data["data"].iloc[start:end]
     experiment_to_alleles = constant_data["experiment_to_alleles"]

--- a/mhcflurry/cli/train_processing_models_command.py
+++ b/mhcflurry/cli/train_processing_models_command.py
@@ -16,10 +16,8 @@ Train Class1 processing models.
 import argparse
 import os
 from os.path import join
-import signal
 import sys
 import time
-import traceback
 import random
 import pprint
 import hashlib
@@ -35,14 +33,15 @@ import tqdm  # progress bar
 from ..class1_processing_predictor import Class1ProcessingPredictor
 from ..class1_processing_neural_network import Class1ProcessingNeuralNetwork
 from ..pytorch_sizing import (
-    _TRAINING_PEAK_MULTIPLIER,
-    _estimate_peak_bytes_per_row,
+    TRAINING_PEAK_MULTIPLIER,
+    estimate_peak_bytes_per_row,
 )
 from ..common import (
     add_random_seed_arg,
     configure_random_seed,
     configure_logging,
     derive_seed,
+    install_sigusr1_stack_trace_handler,
     write_generate_sh,
 )
 from ..parallelism import (
@@ -67,7 +66,7 @@ tqdm.monitor_interval = 0  # see https://github.com/tqdm/tqdm/issues/481
 # stored here before creating the thread pool will be inherited to the child
 # processes upon fork() call, allowing local workers to read the same
 # copy-on-write pages instead of receiving a pickled copy.
-GLOBAL_DATA = {}
+WORKER_CONTEXT = {}
 
 _PROCESSING_WORKER_RUNTIME_FLOOR_GB = 2.0
 _PROCESSING_WORKER_SAFETY_FACTOR = 1.3
@@ -192,9 +191,7 @@ def assign_folds(df, num_folds, held_out_samples, seed=None):
 
 
 def run(argv=sys.argv[1:]):
-    # On sigusr1 print stack trace
-    print("To show stack trace, run:\nkill -s USR1 %d" % os.getpid())
-    signal.signal(signal.SIGUSR1, lambda sig, frame: traceback.print_stack())
+    install_sigusr1_stack_trace_handler()
 
     args = parser.parse_args(argv)
 
@@ -278,7 +275,7 @@ def estimate_processing_worker_gb(args):
             )
             max_forward_bytes_per_row = max(
                 max_forward_bytes_per_row,
-                _estimate_peak_bytes_per_row(network),
+                estimate_peak_bytes_per_row(network),
             )
             max_minibatch_size = max(
                 max_minibatch_size,
@@ -292,7 +289,7 @@ def estimate_processing_worker_gb(args):
         training_batch_bytes = (
             max_minibatch_size
             * max_forward_bytes_per_row
-            * _TRAINING_PEAK_MULTIPLIER
+            * TRAINING_PEAK_MULTIPLIER
         )
         runtime_bytes = int(_PROCESSING_WORKER_RUNTIME_FLOOR_GB * (1 << 30))
         estimate_gb = (
@@ -426,10 +423,10 @@ def train_models(args):
     print("Loaded predictor with %d networks" % len(predictor.models))
 
     with open(join(args.out_models_dir, "training_init_info.pkl"), "rb") as fd:
-        GLOBAL_DATA.update(pickle.load(fd))
+        WORKER_CONTEXT.update(pickle.load(fd))
     print("Loaded training init info.")
 
-    all_work_items = GLOBAL_DATA["work_items"]
+    all_work_items = WORKER_CONTEXT["work_items"]
     complete_work_item_names = [
         network.fit_info[-1]["training_info"]["work_item_name"]
         for network in predictor.models
@@ -448,7 +445,7 @@ def train_models(args):
     # order is reproducible (per-fit results don't depend on order — each
     # fit reseeds from its own work-item seed — but this keeps the whole
     # run deterministic).
-    master_seed = GLOBAL_DATA.get("seed")
+    master_seed = WORKER_CONTEXT.get("seed")
     random.Random(master_seed).shuffle(work_items)
     for (work_item_num, item) in enumerate(work_items):
         item['work_item_num'] = work_item_num
@@ -479,14 +476,14 @@ def train_models(args):
             args,
             work_function=train_model,
             work_items=work_items,
-            constant_data=GLOBAL_DATA,
+            constant_data=WORKER_CONTEXT,
             result_serialization_method="pickle")
     else:
         run_single_worker_torch_compile_warmup(
             args,
             work_items,
             train_model,
-            constant_data=GLOBAL_DATA,
+            constant_data=WORKER_CONTEXT,
         )
 
         worker_pool = worker_pool_with_gpu_assignments_from_args(args)
@@ -505,7 +502,7 @@ def train_models(args):
             # tears the pool down via the finally rather than leaking
             # non-daemon workers.
             attach_constant_data_to_work_items_if_needed(
-                work_items, GLOBAL_DATA, worker_pool
+                work_items, WORKER_CONTEXT, worker_pool
             )
             results_generator = worker_pool.imap_unordered(
                 partial(call_wrapped_kwargs, train_model),
@@ -620,7 +617,7 @@ def train_model(
         predictor,
         save_to,
         compile_warmup_only=False,
-        constant_data=GLOBAL_DATA):
+        constant_data=WORKER_CONTEXT):
 
     from sklearn.metrics import roc_auc_score
     from mhcflurry.flanking_encoding import FlankingEncoding

--- a/mhcflurry/cluster_parallelism.py
+++ b/mhcflurry/cluster_parallelism.py
@@ -15,11 +15,9 @@ Simple, relatively naive parallel map implementation for HPC clusters.
 
 Used for training MHCflurry models.
 """
-import traceback
 import sys
 import os
 import time
-import signal
 import argparse
 import pickle
 import subprocess
@@ -31,6 +29,7 @@ from .parallelism import (
     configure_cluster_worker_torch_compile_threads,
 )
 from .class1_affinity_predictor import Class1AffinityPredictor
+from .common import install_sigusr1_stack_trace_handler
 
 
 def add_cluster_parallelism_args(parser):
@@ -396,9 +395,7 @@ def worker_entry_point(argv=sys.argv[1:]):
     ----------
     argv : list of string
     """
-    # On sigusr1 print stack trace
-    print("To show stack trace, run:\nkill -s USR1 %d" % os.getpid())
-    signal.signal(signal.SIGUSR1, lambda sig, frame: traceback.print_stack())
+    install_sigusr1_stack_trace_handler()
 
     args = parser.parse_args(argv)
 

--- a/mhcflurry/common.py
+++ b/mhcflurry/common.py
@@ -78,6 +78,19 @@ def configure_random_seed(seed=None, name="mhcflurry"):
     return resolved
 
 
+def install_sigusr1_stack_trace_handler():
+    """Install a SIGUSR1 handler that prints this process's stack trace."""
+    import signal
+    import traceback
+
+    signum = getattr(signal, "SIGUSR1", None)
+    if signum is None:
+        return False
+    print("To show stack trace, run:\nkill -s USR1 %d" % os.getpid())
+    signal.signal(signum, lambda _signum, _frame: traceback.print_stack())
+    return True
+
+
 def derive_seed(master_seed, *parts):
     """Derive a stable sub-seed from a master seed and identity ``parts``.
 

--- a/mhcflurry/downloads_command.py
+++ b/mhcflurry/downloads_command.py
@@ -12,8 +12,14 @@
 
 """Compatibility wrapper for :mod:`mhcflurry.cli.downloads_command`."""
 
-import sys
-
 from .cli import downloads_command as _impl
 
-sys.modules[__name__] = _impl
+run = _impl.run
+parser = _impl.parser
+
+
+def __getattr__(name):
+    return getattr(_impl, name)
+
+
+__all__ = ["run", "parser"]

--- a/mhcflurry/local_parallelism.py
+++ b/mhcflurry/local_parallelism.py
@@ -12,8 +12,12 @@
 
 """Compatibility wrapper for :mod:`mhcflurry.parallelism`."""
 
-import sys
-
 from . import parallelism as _parallelism
+from .parallelism import *  # noqa: F401,F403
 
-sys.modules[__name__] = _parallelism
+
+def __getattr__(name):
+    return getattr(_parallelism, name)
+
+
+__all__ = _parallelism.__all__

--- a/mhcflurry/parallelism/planning.py
+++ b/mhcflurry/parallelism/planning.py
@@ -103,7 +103,7 @@ _AUTO_DATALOADER_RAM_BASELINE_PER_FIT_GB = 2.0
 # queue, two physical cores per child is a comfortable upper bound.
 _AUTO_DATALOADER_CORES_PER_CHILD = 2
 
-def _cuda_visible_devices_from_env():
+def cuda_visible_devices_from_env():
     """Return CUDA_VISIBLE_DEVICES entries, or ``None`` when unset."""
     value = os.environ.get("CUDA_VISIBLE_DEVICES")
     if value is None:
@@ -118,7 +118,7 @@ def _cuda_visible_devices_from_env():
         return []
     return devices
 
-def _free_vram_per_gpu_override_gb(num_gpus):
+def free_vram_per_gpu_override_gb(num_gpus):
     """Return env-pinned free VRAM in GB as a per-GPU list, or ``None``.
 
     ``MHCFLURRY_AUTO_MAX_WORKERS_PER_GPU_FREE_VRAM_GB`` accepts either one
@@ -146,13 +146,13 @@ def _free_vram_per_gpu_override_gb(num_gpus):
     return vals[:max(int(num_gpus), 1)]
 
 
-def _free_vram_override_gb(num_gpus):
+def free_vram_override_gb(num_gpus):
     """Minimum env-pinned free VRAM in GB, or ``None``."""
-    vals = _free_vram_per_gpu_override_gb(num_gpus)
+    vals = free_vram_per_gpu_override_gb(num_gpus)
     return min(vals) if vals else None
 
 
-def _detect_num_cuda_devices_no_torch():
+def detect_num_cuda_devices_no_torch():
     """Return the number of visible CUDA devices without importing torch.
 
     ``CUDA_VISIBLE_DEVICES`` is authoritative when set by a scheduler or
@@ -160,7 +160,7 @@ def _detect_num_cuda_devices_no_torch():
     worker pool without initializing CUDA in the parent process. Returns 0
     when nvidia-smi is unavailable or no GPUs are visible.
     """
-    cuda_visible_devices = _cuda_visible_devices_from_env()
+    cuda_visible_devices = cuda_visible_devices_from_env()
     if cuda_visible_devices is not None:
         return len(cuda_visible_devices)
 
@@ -193,13 +193,13 @@ def _free_vram_per_gpu_from_nvidia_smi_gb(num_gpus):
     Returns ``None`` if ``nvidia-smi`` is unavailable or returns nothing. The
     per-GPU list (not collapsed to a scalar) lets capacity diagnostics see
     heterogeneous / partially-occupied cards; the worker-count math separately
-    takes the ``min`` via ``_free_vram_from_nvidia_smi_gb``.
+    takes the ``min`` via ``free_vram_from_nvidia_smi_gb``.
 
     This is intentionally a subprocess call instead of ``torch.cuda`` so the
     orchestrator can size a fork-based worker pool without initializing CUDA in
     the parent process.
     """
-    cuda_visible_devices = _cuda_visible_devices_from_env()
+    cuda_visible_devices = cuda_visible_devices_from_env()
     if cuda_visible_devices is not None:
         cuda_visible_devices = cuda_visible_devices[:max(int(num_gpus), 1)]
         if not cuda_visible_devices:
@@ -239,7 +239,7 @@ def _free_vram_per_gpu_from_nvidia_smi_gb(num_gpus):
     return vals[:max(int(num_gpus), 1)]
 
 
-def _free_vram_from_nvidia_smi_gb(num_gpus):
+def free_vram_from_nvidia_smi_gb(num_gpus):
     """Minimum free VRAM (GB) across visible GPUs, or ``None``."""
     vals = _free_vram_per_gpu_from_nvidia_smi_gb(num_gpus)
     return min(vals) if vals else None
@@ -253,7 +253,7 @@ def detect_free_vram_per_gpu_gb(num_gpus):
     math, this preserves the per-GPU values so capacity warnings can flag
     small or uneven cards.
     """
-    override = _free_vram_per_gpu_override_gb(num_gpus)
+    override = free_vram_per_gpu_override_gb(num_gpus)
     if override is not None:
         return override
     return _free_vram_per_gpu_from_nvidia_smi_gb(num_gpus)
@@ -312,11 +312,11 @@ def auto_max_workers_per_gpu(
 
     # Honor an explicit env override even when it resolves to 0.0 (falsy);
     # only fall through to nvidia-smi when no override was set at all.
-    free_vram_override = _free_vram_override_gb(num_gpus)
+    free_vram_override = free_vram_override_gb(num_gpus)
     free_vram_gb = (
         free_vram_override
         if free_vram_override is not None
-        else _free_vram_from_nvidia_smi_gb(num_gpus)
+        else free_vram_from_nvidia_smi_gb(num_gpus)
     )
 
     free_vram_gb_used = (
@@ -652,7 +652,7 @@ def auto_random_negative_pool_epochs(
     return min(by_memory, max(1, int(hard_cap)))
 
 
-def _resolved_int(value, name):
+def resolved_int(value, name):
     if isinstance(value, str) and value.strip().lower() == "auto":
         raise ValueError(
             "%s must be resolved to an int before use; got 'auto'" % name
@@ -670,7 +670,7 @@ def auto_num_jobs(num_gpus, max_workers_per_gpu):
     """
     if not num_gpus or int(num_gpus) <= 0:
         return 0
-    max_workers_per_gpu = _resolved_int(
+    max_workers_per_gpu = resolved_int(
         max_workers_per_gpu, "max_workers_per_gpu")
     return int(num_gpus) * max_workers_per_gpu
 
@@ -728,7 +728,7 @@ def num_workers_per_gpu_from_args(args):
             "resolve_local_parallelism_args before using it as "
             "num_workers_per_gpu."
         )
-    return _resolved_int(value, "max_workers_per_gpu")
+    return resolved_int(value, "max_workers_per_gpu")
 
 
 def resolve_local_parallelism_args(
@@ -748,7 +748,7 @@ def resolve_local_parallelism_args(
         per_worker_gb=per_worker_gb,
         cap_auto_num_jobs=cap_auto_num_jobs,
         normalize_backend=normalize_pytorch_backend,
-        detect_num_cuda_devices=_detect_num_cuda_devices_no_torch,
+        detect_num_cuda_devices=detect_num_cuda_devices_no_torch,
         auto_max_workers_per_gpu=auto_max_workers_per_gpu,
         auto_num_jobs=auto_num_jobs,
         resolve_dataloader_num_workers=resolve_dataloader_num_workers,

--- a/mhcflurry/parallelism/worker_pool.py
+++ b/mhcflurry/parallelism/worker_pool.py
@@ -25,7 +25,7 @@ import numpy
 
 from ..common import configure_pytorch, normalize_pytorch_backend
 from ..workload_planning import WORKLOAD_GENERIC
-from .planning import _cuda_visible_devices_from_env, resolve_local_parallelism_args
+from .planning import cuda_visible_devices_from_env, resolve_local_parallelism_args
 from .worker_runtime import worker_init, worker_init_entry_point
 
 
@@ -263,12 +263,12 @@ def attach_constant_data_to_work_items_if_needed(
         log = print
     if worker_pool_uses_fork(worker_pool):
         log(
-            "Local Pool uses fork; workers inherit GLOBAL_DATA without "
+            "Local Pool uses fork; workers inherit WORKER_CONTEXT without "
             "per-task pickle payloads."
         )
         return False
     log(
-        "Local Pool does not use fork; attaching GLOBAL_DATA to each work "
+        "Local Pool does not use fork; attaching WORKER_CONTEXT to each work "
         "item for worker delivery."
     )
     for item in work_items:
@@ -398,7 +398,7 @@ def worker_init_kwargs_for_scheduler(
             for _ in range(num_jobs)
         ]
 
-    cuda_visible_devices = _cuda_visible_devices_from_env()
+    cuda_visible_devices = cuda_visible_devices_from_env()
     if cuda_visible_devices is None:
         gpu_device_nums = list(range(num_gpus))
     else:

--- a/mhcflurry/parallelism/worker_runtime.py
+++ b/mhcflurry/parallelism/worker_runtime.py
@@ -23,7 +23,7 @@ from multiprocessing.util import Finalize
 import numpy
 
 from ..common import configure_pytorch
-from .planning import _resolved_int
+from .planning import resolved_int
 
 
 def worker_init_entry_point(
@@ -89,7 +89,7 @@ def worker_init(
     # multiple fit()/predict() calls are co-resident on one GPU.
     if max_workers_per_gpu is not None:
         os.environ["MHCFLURRY_MAX_WORKERS_PER_GPU"] = str(
-            _resolved_int(max_workers_per_gpu, "max_workers_per_gpu"))
+            resolved_int(max_workers_per_gpu, "max_workers_per_gpu"))
 
 
 # Solution suggested in https://bugs.python.org/issue13831

--- a/mhcflurry/predict_command.py
+++ b/mhcflurry/predict_command.py
@@ -12,8 +12,14 @@
 
 """Compatibility wrapper for :mod:`mhcflurry.cli.predict_command`."""
 
-import sys
-
 from .cli import predict_command as _impl
 
-sys.modules[__name__] = _impl
+run = _impl.run
+parser = _impl.parser
+
+
+def __getattr__(name):
+    return getattr(_impl, name)
+
+
+__all__ = ["run", "parser"]

--- a/mhcflurry/predict_scan_command.py
+++ b/mhcflurry/predict_scan_command.py
@@ -12,8 +12,14 @@
 
 """Compatibility wrapper for :mod:`mhcflurry.cli.predict_scan_command`."""
 
-import sys
-
 from .cli import predict_scan_command as _impl
 
-sys.modules[__name__] = _impl
+run = _impl.run
+parser = _impl.parser
+
+
+def __getattr__(name):
+    return getattr(_impl, name)
+
+
+__all__ = ["run", "parser"]

--- a/mhcflurry/pytorch_sizing.py
+++ b/mhcflurry/pytorch_sizing.py
@@ -16,10 +16,10 @@ import logging
 import os
 
 DEFAULT_PREDICT_BATCH_SIZE = "auto"
-_AUTO_BATCH_MAX_ROWS = 1_000_000  # cap past which kernel-launch savings flatten
-_AUTO_BATCH_MIN_ROWS = 1024  # floor: avoid pathologically tiny batches
-_AUTO_BATCH_CPU_FALLBACK = 32_768  # CPU: large batches thrash L3; stay modest
-_AUTO_BATCH_FREE_FRACTION = 0.5  # half of free VRAM is the working-set budget
+AUTO_BATCH_MAX_ROWS = 1_000_000  # cap past which kernel-launch savings flatten
+AUTO_BATCH_MIN_ROWS = 1024  # floor: avoid pathologically tiny batches
+AUTO_BATCH_CPU_FALLBACK = 32_768  # CPU: large batches thrash L3; stay modest
+AUTO_BATCH_FREE_FRACTION = 0.5  # half of free VRAM is the working-set budget
 _MPS_PSUTIL_WARNED = False  # one-shot warning if psutil is missing on MPS
 if os.environ.get("MHCFLURRY_DEFAULT_PREDICT_BATCH_SIZE"):
     DEFAULT_PREDICT_BATCH_SIZE = int(os.environ["MHCFLURRY_DEFAULT_PREDICT_BATCH_SIZE"])
@@ -28,7 +28,7 @@ if os.environ.get("MHCFLURRY_DEFAULT_PREDICT_BATCH_SIZE"):
     )
 
 
-def _estimate_peak_bytes_per_row(model):
+def estimate_peak_bytes_per_row(model):
     """Worst-case peak activation bytes per sample during a forward.
 
     Walks the model's configured layers and returns the maximum hidden-
@@ -76,7 +76,7 @@ def _estimate_peak_bytes_per_row(model):
     if sub_networks is not None and not hasattr(model, "peptide_encoding_shape"):
         try:
             return int(sum(
-                _estimate_peak_bytes_per_row(net) for net in sub_networks
+                estimate_peak_bytes_per_row(net) for net in sub_networks
             ))
         except (AttributeError, TypeError) as exc:
             logging.warning(
@@ -118,7 +118,7 @@ def _estimate_peak_bytes_per_row(model):
     return int(peak * 4 * 2 * 4)  # fp32 × 2 buffers × 4x safety
 
 
-def _free_device_memory_bytes(device):
+def free_device_memory_bytes(device):
     """Best-effort free-memory query. Returns a conservative value when
     the device doesn't expose a direct free-memory API.
 
@@ -194,10 +194,10 @@ def compute_prediction_batch_size(
         device,
         model=None,
         num_workers_per_gpu=1,
-        free_memory_fraction=_AUTO_BATCH_FREE_FRACTION,
-        max_rows=_AUTO_BATCH_MAX_ROWS,
-        min_rows=_AUTO_BATCH_MIN_ROWS,
-        cpu_fallback=_AUTO_BATCH_CPU_FALLBACK):
+        free_memory_fraction=AUTO_BATCH_FREE_FRACTION,
+        max_rows=AUTO_BATCH_MAX_ROWS,
+        min_rows=AUTO_BATCH_MIN_ROWS,
+        cpu_fallback=AUTO_BATCH_CPU_FALLBACK):
     """Auto-size a prediction batch for ``device`` and ``model``.
 
     Divides free VRAM by the per-row peak activation estimate for the
@@ -210,8 +210,8 @@ def compute_prediction_batch_size(
     """
     if device.type == "cpu":
         return cpu_fallback
-    peak_bytes = _estimate_peak_bytes_per_row(model)
-    free = _free_device_memory_bytes(device)
+    peak_bytes = estimate_peak_bytes_per_row(model)
+    free = free_device_memory_bytes(device)
     workers = max(int(num_workers_per_gpu), 1)
     budget = int(free * float(free_memory_fraction) / workers)
     budget = max(budget, peak_bytes * min_rows)
@@ -219,7 +219,7 @@ def compute_prediction_batch_size(
     return int(max(min_rows, min(rows, max_rows)))
 
 
-def _env_workers_per_gpu(default=1):
+def env_workers_per_gpu(default=1):
     """Read the ``MHCFLURRY_MAX_WORKERS_PER_GPU`` env var.
 
     The local parallelism pool sets this in each training worker so
@@ -257,7 +257,7 @@ def resolve_prediction_batch_size(
 # plus gradients and optimizer state. RMSProp/Adam each store 1-2x weights in
 # moving averages on top, so 4x the inference peak is a conservative floor that
 # leaves headroom for cuDNN workspace and Python-side torch overhead.
-_TRAINING_PEAK_MULTIPLIER = 4
+TRAINING_PEAK_MULTIPLIER = 4
 
 
 def check_training_batch_fits(
@@ -272,7 +272,7 @@ def check_training_batch_fits(
 
     Training peak memory = activations kept alive across the forward
     pass (for backward), plus gradients, plus optimizer state. That's
-    roughly ``4 × _estimate_peak_bytes_per_row`` (inference peak).
+    roughly ``4 × estimate_peak_bytes_per_row`` (inference peak).
 
     Returns ``(effective_batch_size, shrunk: bool)``. When the
     requested batch is too large for the available VRAM — partitioned
@@ -288,8 +288,8 @@ def check_training_batch_fits(
     import sys
     if device.type == "cpu" or requested_batch_size <= min_batch:
         return int(requested_batch_size), False
-    peak_bytes = _estimate_peak_bytes_per_row(model) * _TRAINING_PEAK_MULTIPLIER
-    free = _free_device_memory_bytes(device)
+    peak_bytes = estimate_peak_bytes_per_row(model) * TRAINING_PEAK_MULTIPLIER
+    free = free_device_memory_bytes(device)
     workers = max(int(num_workers_per_gpu), 1)
     budget = int(free * float(free_memory_fraction) / workers)
     max_rows = max(budget // peak_bytes, min_batch)

--- a/mhcflurry/select_allele_specific_models_command.py
+++ b/mhcflurry/select_allele_specific_models_command.py
@@ -12,8 +12,14 @@
 
 """Compatibility wrapper for :mod:`mhcflurry.cli.select_allele_specific_models_command`."""
 
-import sys
-
 from .cli import select_allele_specific_models_command as _impl
 
-sys.modules[__name__] = _impl
+run = _impl.run
+parser = _impl.parser
+
+
+def __getattr__(name):
+    return getattr(_impl, name)
+
+
+__all__ = ["run", "parser"]

--- a/mhcflurry/select_pan_allele_models_command.py
+++ b/mhcflurry/select_pan_allele_models_command.py
@@ -12,8 +12,14 @@
 
 """Compatibility wrapper for :mod:`mhcflurry.cli.select_pan_allele_models_command`."""
 
-import sys
-
 from .cli import select_pan_allele_models_command as _impl
 
-sys.modules[__name__] = _impl
+run = _impl.run
+parser = _impl.parser
+
+
+def __getattr__(name):
+    return getattr(_impl, name)
+
+
+__all__ = ["run", "parser"]

--- a/mhcflurry/select_processing_models_command.py
+++ b/mhcflurry/select_processing_models_command.py
@@ -12,8 +12,14 @@
 
 """Compatibility wrapper for :mod:`mhcflurry.cli.select_processing_models_command`."""
 
-import sys
-
 from .cli import select_processing_models_command as _impl
 
-sys.modules[__name__] = _impl
+run = _impl.run
+parser = _impl.parser
+
+
+def __getattr__(name):
+    return getattr(_impl, name)
+
+
+__all__ = ["run", "parser"]

--- a/mhcflurry/train_allele_specific_models_command.py
+++ b/mhcflurry/train_allele_specific_models_command.py
@@ -12,8 +12,14 @@
 
 """Compatibility wrapper for :mod:`mhcflurry.cli.train_allele_specific_models_command`."""
 
-import sys
-
 from .cli import train_allele_specific_models_command as _impl
 
-sys.modules[__name__] = _impl
+run = _impl.run
+parser = _impl.parser
+
+
+def __getattr__(name):
+    return getattr(_impl, name)
+
+
+__all__ = ["run", "parser"]

--- a/mhcflurry/train_pan_allele_models_command.py
+++ b/mhcflurry/train_pan_allele_models_command.py
@@ -12,8 +12,14 @@
 
 """Compatibility wrapper for :mod:`mhcflurry.cli.train_pan_allele_models_command`."""
 
-import sys
-
 from .cli import train_pan_allele_models_command as _impl
 
-sys.modules[__name__] = _impl
+run = _impl.run
+parser = _impl.parser
+
+
+def __getattr__(name):
+    return getattr(_impl, name)
+
+
+__all__ = ["run", "parser"]

--- a/mhcflurry/train_presentation_models_command.py
+++ b/mhcflurry/train_presentation_models_command.py
@@ -12,8 +12,14 @@
 
 """Compatibility wrapper for :mod:`mhcflurry.cli.train_presentation_models_command`."""
 
-import sys
-
 from .cli import train_presentation_models_command as _impl
 
-sys.modules[__name__] = _impl
+run = _impl.run
+parser = _impl.parser
+
+
+def __getattr__(name):
+    return getattr(_impl, name)
+
+
+__all__ = ["run", "parser"]

--- a/mhcflurry/train_processing_models_command.py
+++ b/mhcflurry/train_processing_models_command.py
@@ -12,8 +12,14 @@
 
 """Compatibility wrapper for :mod:`mhcflurry.cli.train_processing_models_command`."""
 
-import sys
-
 from .cli import train_processing_models_command as _impl
 
-sys.modules[__name__] = _impl
+run = _impl.run
+parser = _impl.parser
+
+
+def __getattr__(name):
+    return getattr(_impl, name)
+
+
+__all__ = ["run", "parser"]

--- a/mhcflurry/version.py
+++ b/mhcflurry/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.3.0rc11"
+__version__ = "2.3.0rc12"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -11,6 +11,8 @@ belong.
 - **`scripts/training/`** — the production training pipeline. Stage scripts
   (`pan_allele_release_*.sh`, `presentation_from_affinity.sh`) and the
   sweep + plot tools that publish artifacts. See its own README.
+- **`scripts/release/`** — packaging and deployment helpers for trained
+  model artifacts, plus the end-to-end release workflow entry point.
 - **`scripts/dev/`** — developer ergonomic helpers (e.g. relocating
   large run-output dirs outside the rsync source tree). Not invoked by
   CI or release.
@@ -42,6 +44,18 @@ belong.
 - **`validate_presentation_with_flanks.py`** — fixed 10-peptide regression
   set including SLLQHLIGL (PRAME) with real flanks; rank correlation vs
   public release. Cheap acceptance test before publishing a new bundle.
+
+## Current audit
+
+The maintained scripts are generally well scoped: release training lives
+under `training/`, development helpers live under `dev/`, and the
+top-level validation tools are narrow checks. The main gap was that Brev
+training and model-asset deployment were living outside this maintained
+surface. `scripts/training/runplz_release_full.py` is now the reusable
+Brev/runplz training entry point, and
+`scripts/release/retrain_evaluate_deploy.sh` is the single maintained
+workflow for training, evaluating, plotting, and deployment validation.
+
 ## What used to live here (deleted)
 
 - TF→PyTorch parity scripts (`compare_tf_pytorch_random_outputs.py`,

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -1,0 +1,39 @@
+# scripts/release/
+
+Maintainer helpers for packaging and publishing trained model artifacts. These
+scripts operate on completed training runs; they do not train or evaluate models.
+
+## Model deployment
+
+```bash
+scripts/release/deploy_trained_models.sh \
+    --run-dir /path/to/release-run \
+    --release 2.3.0 \
+    --github-release 2.3.0 \
+    --mode dry-run
+```
+
+Use `--mode draft` to build archives and upload them to a draft GitHub release.
+Use `--mode publish` only after the GitHub release already exists; this script
+does not publish the release itself because publishing also triggers package
+release workflows.
+
+The script writes the tarballs, `SHA256SUMS`, and a `downloads.yml` snippet under
+`<run-dir>/release-assets/` by default. After upload, commit the corresponding
+`mhcflurry/downloads.yml` update in the package release PR.
+
+## End-to-end release workflow
+
+```bash
+scripts/release/retrain_evaluate_deploy.sh \
+    --run-dir /path/to/release-run \
+    --release 2.3.0 \
+    --backend local \
+    --deploy-mode dry-run
+```
+
+Use `--backend runplz` for the maintained Brev/runplz path or `--backend ssh`
+with `--remote`, `--remote-repo`, and `--remote-run-dir` for a generic remote
+machine. The script runs training, `mhcflurry compare-models`,
+`mhcflurry plot-model-comparison`, and deployment validation in order; each
+stage has a `--skip-*` flag for resuming.

--- a/scripts/release/deploy_trained_models.sh
+++ b/scripts/release/deploy_trained_models.sh
@@ -1,0 +1,315 @@
+#!/usr/bin/env bash
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Package trained MHCflurry release models and upload them to GitHub.
+
+Usage:
+  scripts/release/deploy_trained_models.sh \
+      --run-dir /path/to/release-run \
+      --release 2.3.0 \
+      --github-release 2.3.0 \
+      [--date YYYYMMDD] \
+      [--assets-dir /path/to/assets] \
+      [--dry-run | --draft | --publish | --mode MODE]
+
+Modes:
+  --dry-run   Validate paths and print planned assets. This is the default.
+  --draft     Build assets and upload them to a draft GitHub release, creating
+              the draft if needed.
+  --publish   Build assets and upload them to an existing GitHub release. This
+              script does not publish a release because publishing also triggers
+              package-release workflows.
+
+Expected run layout:
+  <run-dir>/affinity/models.combined
+  <run-dir>/processing/models.selected.no_flank
+  <run-dir>/processing/models.selected.short_flanks
+  <run-dir>/presentation/models
+
+The script writes SHA256SUMS and a downloads.yml snippet beside the assets.
+Commit the downloads.yml update after the GitHub assets are uploaded and their
+final URLs are known.
+EOF
+}
+
+die() {
+    echo "ERROR: $*" >&2
+    exit 2
+}
+
+warn() {
+    echo "WARNING: $*" >&2
+}
+
+note() {
+    echo "$*" >&2
+}
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 || die "Required command not found: $1"
+}
+
+require_dir() {
+    [ -d "$1" ] || die "Missing directory: $1"
+}
+
+require_file() {
+    [ -f "$1" ] || die "Missing file: $1"
+}
+
+require_one_file() {
+    local label=$1
+    shift
+    local candidate
+    for candidate in "$@"; do
+        if [ -f "$candidate" ]; then
+            return 0
+        fi
+    done
+    die "Missing ${label}; tried: $*"
+}
+
+checksum_assets() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$@"
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$@"
+    else
+        die "Required command not found: sha256sum or shasum"
+    fi
+}
+
+quote_cmd() {
+    local arg
+    printf '+'
+    for arg in "$@"; do
+        printf ' %q' "$arg"
+    done
+    printf '\n'
+}
+
+RUN_DIR=
+RELEASE=
+GITHUB_RELEASE=
+ASSETS_DIR=
+ASSET_DATE=$(date -u +%Y%m%d)
+MODE=dry-run
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --run-dir)
+            RUN_DIR=$2
+            shift 2
+            ;;
+        --release)
+            RELEASE=$2
+            shift 2
+            ;;
+        --github-release)
+            GITHUB_RELEASE=$2
+            shift 2
+            ;;
+        --assets-dir)
+            ASSETS_DIR=$2
+            shift 2
+            ;;
+        --date)
+            ASSET_DATE=$2
+            shift 2
+            ;;
+        --dry-run)
+            MODE=dry-run
+            shift
+            ;;
+        --draft)
+            MODE=draft
+            shift
+            ;;
+        --publish)
+            MODE=publish
+            shift
+            ;;
+        --mode)
+            case "$2" in
+                dry-run|draft|publish)
+                    MODE=$2
+                    ;;
+                *)
+                    die "--mode must be one of: dry-run, draft, publish"
+                    ;;
+            esac
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            die "Unknown argument: $1"
+            ;;
+    esac
+done
+
+[ -n "$RUN_DIR" ] || die "--run-dir is required"
+[ -n "$RELEASE" ] || die "--release is required"
+if [ -z "$GITHUB_RELEASE" ]; then
+    GITHUB_RELEASE=$RELEASE
+fi
+if [ -z "$ASSETS_DIR" ]; then
+    ASSETS_DIR="$RUN_DIR/release-assets"
+fi
+
+require_dir "$RUN_DIR"
+RUN_DIR=$(cd "$RUN_DIR" && pwd)
+case "$ASSETS_DIR" in
+    /*) ;;
+    *) ASSETS_DIR="$(pwd)/$ASSETS_DIR" ;;
+esac
+ASSETS_DIR=${ASSETS_DIR%/}
+
+AFFINITY_DIR="$RUN_DIR/affinity"
+PROCESSING_DIR="$RUN_DIR/processing"
+PRESENTATION_DIR="$RUN_DIR/presentation"
+AFFINITY_MODELS="$AFFINITY_DIR/models.combined"
+PROCESSING_NO_FLANK="$PROCESSING_DIR/models.selected.no_flank"
+PROCESSING_SHORT_FLANKS="$PROCESSING_DIR/models.selected.short_flanks"
+PROCESSING_WITH_FLANKS="$PROCESSING_DIR/models.selected.with_flanks"
+PRESENTATION_MODELS="$PRESENTATION_DIR/models"
+
+PAN_ASSET="models_class1_pan.selected.${ASSET_DATE}.tar.bz2"
+PROCESSING_ASSET="models_class1_processing.selected.${ASSET_DATE}.tar.bz2"
+PRESENTATION_ASSET="models_class1_presentation.${ASSET_DATE}.tar.bz2"
+SHA_FILE="SHA256SUMS"
+SNIPPET_FILE="downloads.${RELEASE}.snippet.yml"
+
+require_command tar
+if [ "$MODE" != "dry-run" ]; then
+    require_command gh
+fi
+
+require_dir "$AFFINITY_MODELS"
+require_file "$AFFINITY_MODELS/manifest.csv"
+require_one_file "affinity percent ranks" \
+    "$AFFINITY_MODELS/percent_ranks.csv" \
+    "$AFFINITY_MODELS/percent_ranks.csv.bz2"
+
+require_dir "$PROCESSING_NO_FLANK"
+require_file "$PROCESSING_NO_FLANK/manifest.csv"
+require_dir "$PROCESSING_SHORT_FLANKS"
+require_file "$PROCESSING_SHORT_FLANKS/manifest.csv"
+if [ ! -d "$PROCESSING_WITH_FLANKS" ]; then
+    warn "Processing models.selected.with_flanks is absent."
+    warn "The archive will contain no_flank and short_flanks only."
+fi
+
+require_dir "$PRESENTATION_MODELS"
+require_file "$PRESENTATION_MODELS/weights.csv"
+require_one_file "presentation percent ranks" \
+    "$PRESENTATION_MODELS/percent_ranks.csv" \
+    "$PRESENTATION_MODELS/percent_ranks.csv.bz2"
+
+note "Release:          $RELEASE"
+note "GitHub release:   $GITHUB_RELEASE"
+note "Run directory:    $RUN_DIR"
+note "Assets directory: $ASSETS_DIR"
+note "Mode:             $MODE"
+note ""
+note "Assets:"
+note "  $PAN_ASSET"
+note "  $PROCESSING_ASSET"
+note "  $PRESENTATION_ASSET"
+
+if [ "$MODE" = "dry-run" ]; then
+    note ""
+    note "Dry run only. Commands that would run:"
+    quote_cmd mkdir -p "$ASSETS_DIR"
+    quote_cmd tar -C "$AFFINITY_DIR" -cjf "$ASSETS_DIR/$PAN_ASSET" models.combined
+    if [ -d "$PROCESSING_WITH_FLANKS" ]; then
+        quote_cmd tar -C "$PROCESSING_DIR" -cjf "$ASSETS_DIR/$PROCESSING_ASSET" \
+            models.selected.no_flank models.selected.short_flanks \
+            models.selected.with_flanks
+    else
+        quote_cmd tar -C "$PROCESSING_DIR" -cjf "$ASSETS_DIR/$PROCESSING_ASSET" \
+            models.selected.no_flank models.selected.short_flanks
+    fi
+    quote_cmd tar -C "$PRESENTATION_DIR" -cjf "$ASSETS_DIR/$PRESENTATION_ASSET" models
+    quote_cmd gh release upload "$GITHUB_RELEASE" \
+        "$ASSETS_DIR/$PAN_ASSET" \
+        "$ASSETS_DIR/$PROCESSING_ASSET" \
+        "$ASSETS_DIR/$PRESENTATION_ASSET" \
+        "$ASSETS_DIR/$SHA_FILE" \
+        --clobber
+    exit 0
+fi
+
+mkdir -p "$ASSETS_DIR"
+tar -C "$AFFINITY_DIR" -cjf "$ASSETS_DIR/$PAN_ASSET" models.combined
+if [ -d "$PROCESSING_WITH_FLANKS" ]; then
+    tar -C "$PROCESSING_DIR" -cjf "$ASSETS_DIR/$PROCESSING_ASSET" \
+        models.selected.no_flank models.selected.short_flanks \
+        models.selected.with_flanks
+else
+    tar -C "$PROCESSING_DIR" -cjf "$ASSETS_DIR/$PROCESSING_ASSET" \
+        models.selected.no_flank models.selected.short_flanks
+fi
+tar -C "$PRESENTATION_DIR" -cjf "$ASSETS_DIR/$PRESENTATION_ASSET" models
+
+(
+    cd "$ASSETS_DIR"
+    checksum_assets "$PAN_ASSET" "$PROCESSING_ASSET" "$PRESENTATION_ASSET" \
+        > "$SHA_FILE"
+)
+
+cat > "$ASSETS_DIR/$SNIPPET_FILE" <<EOF
+  ${RELEASE}:
+    compatibility-version: 2
+    downloads:
+      - name: models_class1_pan
+        url: https://github.com/openvax/mhcflurry/releases/download/${GITHUB_RELEASE}/${PAN_ASSET}
+        default: false
+
+      - name: models_class1_processing
+        url: https://github.com/openvax/mhcflurry/releases/download/${GITHUB_RELEASE}/${PROCESSING_ASSET}
+        default: false
+
+      - name: models_class1_presentation
+        url: https://github.com/openvax/mhcflurry/releases/download/${GITHUB_RELEASE}/${PRESENTATION_ASSET}
+        default: true
+EOF
+
+if [ "$MODE" = "draft" ]; then
+    if ! gh release view "$GITHUB_RELEASE" >/dev/null 2>&1; then
+        gh release create "$GITHUB_RELEASE" --draft --title "MHCflurry $RELEASE"
+    fi
+elif [ "$MODE" = "publish" ]; then
+    gh release view "$GITHUB_RELEASE" >/dev/null 2>&1 || \
+        die "--publish requires an existing GitHub release: $GITHUB_RELEASE"
+else
+    die "Unsupported mode: $MODE"
+fi
+
+gh release upload "$GITHUB_RELEASE" \
+    "$ASSETS_DIR/$PAN_ASSET" \
+    "$ASSETS_DIR/$PROCESSING_ASSET" \
+    "$ASSETS_DIR/$PRESENTATION_ASSET" \
+    "$ASSETS_DIR/$SHA_FILE" \
+    --clobber
+
+note ""
+note "Wrote:"
+note "  $ASSETS_DIR/$SHA_FILE"
+note "  $ASSETS_DIR/$SNIPPET_FILE"

--- a/scripts/release/retrain_evaluate_deploy.sh
+++ b/scripts/release/retrain_evaluate_deploy.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Run the release retraining workflow from one maintained entry point.
+
+Usage:
+  scripts/release/retrain_evaluate_deploy.sh \
+      --run-dir /path/to/release-run \
+      --release 2.3.0 \
+      [--backend local|runplz|ssh] \
+      [--skip-train] [--skip-eval] [--skip-plots] [--skip-deploy] \
+      [--deploy-mode dry-run|draft|publish]
+
+Backends:
+  local   Run scripts/training/pan_allele_release_full.sh in this checkout.
+  runplz  Launch scripts/training/runplz_release_full.py. This is the Brev
+          path when runplz is configured for Brev instances.
+  ssh     Run the local training script on a remote host, then rsync the remote
+          run directory back. Requires --remote, --remote-repo, and
+          --remote-run-dir.
+
+Evaluation:
+  After training, the script runs:
+      mhcflurry compare-models --a RUN_DIR --b public
+      mhcflurry plot-model-comparison --input RUN_DIR/eval_comparison
+
+Deployment:
+  The final step calls deploy_trained_models.sh. The default deploy mode is
+  dry-run, so the script validates and prints release assets without uploading.
+EOF
+}
+
+die() {
+    echo "ERROR: $*" >&2
+    exit 2
+}
+
+note() {
+    echo "$*" >&2
+}
+
+require_command() {
+    command -v "$1" >/dev/null 2>&1 || die "Required command not found: $1"
+}
+
+run_cmd() {
+    printf '+'
+    local arg
+    for arg in "$@"; do
+        printf ' %q' "$arg"
+    done
+    printf '\n'
+    if [ "$DRY_RUN" != "1" ]; then
+        "$@"
+    fi
+}
+
+RUN_DIR=
+RELEASE=
+GITHUB_RELEASE=
+BACKEND=local
+REMOTE=
+REMOTE_REPO=
+REMOTE_RUN_DIR=
+SYNC_REMOTE_OUTPUT=1
+SKIP_TRAIN=0
+SKIP_EVAL=0
+SKIP_PLOTS=0
+SKIP_DEPLOY=0
+DEPLOY_MODE=dry-run
+DATA_DIR=
+COMPARE_INCLUDE=affinity,presentation
+PRESENTATION_MODES=with_flanks,without_flanks
+RUN_LABEL=new
+DRY_RUN=0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --run-dir)
+            RUN_DIR=$2
+            shift 2
+            ;;
+        --release)
+            RELEASE=$2
+            shift 2
+            ;;
+        --github-release)
+            GITHUB_RELEASE=$2
+            shift 2
+            ;;
+        --backend)
+            BACKEND=$2
+            shift 2
+            ;;
+        --remote)
+            REMOTE=$2
+            shift 2
+            ;;
+        --remote-repo)
+            REMOTE_REPO=$2
+            shift 2
+            ;;
+        --remote-run-dir)
+            REMOTE_RUN_DIR=$2
+            shift 2
+            ;;
+        --no-sync-remote-output)
+            SYNC_REMOTE_OUTPUT=0
+            shift
+            ;;
+        --skip-train)
+            SKIP_TRAIN=1
+            shift
+            ;;
+        --skip-eval)
+            SKIP_EVAL=1
+            shift
+            ;;
+        --skip-plots)
+            SKIP_PLOTS=1
+            shift
+            ;;
+        --skip-deploy)
+            SKIP_DEPLOY=1
+            shift
+            ;;
+        --deploy-mode)
+            DEPLOY_MODE=$2
+            shift 2
+            ;;
+        --data-dir)
+            DATA_DIR=$2
+            shift 2
+            ;;
+        --compare-include)
+            COMPARE_INCLUDE=$2
+            shift 2
+            ;;
+        --presentation-modes)
+            PRESENTATION_MODES=$2
+            shift 2
+            ;;
+        --run-label)
+            RUN_LABEL=$2
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            die "Unknown argument: $1"
+            ;;
+    esac
+done
+
+[ -n "$RUN_DIR" ] || die "--run-dir is required"
+[ -n "$RELEASE" ] || die "--release is required"
+if [ -z "$GITHUB_RELEASE" ]; then
+    GITHUB_RELEASE=$RELEASE
+fi
+case "$BACKEND" in
+    local|runplz|ssh) ;;
+    *) die "--backend must be one of: local, runplz, ssh" ;;
+esac
+case "$DEPLOY_MODE" in
+    dry-run|draft|publish) ;;
+    *) die "--deploy-mode must be one of: dry-run, draft, publish" ;;
+esac
+
+case "$RUN_DIR" in
+    /*) ;;
+    *) RUN_DIR="$(pwd)/$RUN_DIR" ;;
+esac
+RUN_DIR=${RUN_DIR%/}
+
+note "Run directory: $RUN_DIR"
+note "Release:       $RELEASE"
+note "Backend:       $BACKEND"
+
+if [ "$SKIP_TRAIN" != "1" ]; then
+    case "$BACKEND" in
+        local)
+            run_cmd mkdir -p "$RUN_DIR"
+            run_cmd env \
+                "MHCFLURRY_OUT=$RUN_DIR" \
+                "REPO=$REPO" \
+                bash "$REPO/scripts/training/pan_allele_release_full.sh"
+            ;;
+        runplz)
+            require_command runplz
+            run_cmd mkdir -p "$RUN_DIR"
+            run_cmd env \
+                "MHCFLURRY_OUT=$RUN_DIR" \
+                "REPO=$REPO" \
+                runplz --outputs-dir "$RUN_DIR" \
+                "$REPO/scripts/training/runplz_release_full.py"
+            ;;
+        ssh)
+            require_command ssh
+            [ -n "$REMOTE" ] || die "--remote is required for --backend ssh"
+            [ -n "$REMOTE_REPO" ] || die "--remote-repo is required for --backend ssh"
+            [ -n "$REMOTE_RUN_DIR" ] || \
+                die "--remote-run-dir is required for --backend ssh"
+            REMOTE_COMMAND="cd '$REMOTE_REPO'"
+            REMOTE_COMMAND="$REMOTE_COMMAND && MHCFLURRY_OUT='$REMOTE_RUN_DIR'"
+            REMOTE_COMMAND="$REMOTE_COMMAND REPO='$REMOTE_REPO'"
+            REMOTE_COMMAND="$REMOTE_COMMAND bash"
+            REMOTE_COMMAND="$REMOTE_COMMAND scripts/training/pan_allele_release_full.sh"
+            run_cmd ssh "$REMOTE" \
+                "$REMOTE_COMMAND"
+            if [ "$SYNC_REMOTE_OUTPUT" = "1" ]; then
+                require_command rsync
+                run_cmd mkdir -p "$RUN_DIR"
+                run_cmd rsync -a "$REMOTE:$REMOTE_RUN_DIR/" "$RUN_DIR/"
+            fi
+            ;;
+    esac
+else
+    note "Skipping training."
+fi
+
+if [ "$SKIP_EVAL" != "1" ]; then
+    EVAL_OUT="$RUN_DIR/eval_comparison"
+    run_cmd mkdir -p "$EVAL_OUT"
+    if [ -z "$DATA_DIR" ]; then
+        require_command mhcflurry-downloads
+        run_cmd mhcflurry-downloads fetch data_evaluation models_class1_pan \
+            models_class1_presentation
+        if [ "$DRY_RUN" = "1" ]; then
+            DATA_DIR='<mhcflurry-downloads path data_evaluation>'
+        else
+            DATA_DIR="$(mhcflurry-downloads path data_evaluation)"
+        fi
+    fi
+    run_cmd mhcflurry compare-models \
+        --a "$RUN_DIR" \
+        --a-label "$RUN_LABEL" \
+        --b public \
+        --data-dir "$DATA_DIR" \
+        --include "$COMPARE_INCLUDE" \
+        --presentation-modes "$PRESENTATION_MODES" \
+        --out "$EVAL_OUT"
+else
+    note "Skipping evaluation."
+fi
+
+if [ "$SKIP_PLOTS" != "1" ]; then
+    run_cmd mhcflurry plot-model-comparison --input "$RUN_DIR/eval_comparison"
+else
+    note "Skipping plots."
+fi
+
+if [ "$SKIP_DEPLOY" != "1" ]; then
+    run_cmd "$SCRIPT_DIR/deploy_trained_models.sh" \
+        --run-dir "$RUN_DIR" \
+        --release "$RELEASE" \
+        --github-release "$GITHUB_RELEASE" \
+        --mode "$DEPLOY_MODE"
+else
+    note "Skipping deploy step."
+fi

--- a/scripts/training/README.md
+++ b/scripts/training/README.md
@@ -16,6 +16,18 @@ one-off tuning runs do not belong here.
   predictor on top. Use this as a tail-on after a sweep.
 - **`pan_allele_release_full.sh`** — Composition wrapper that runs Stage
   1 then inlines Stages 2–3. The full release in one invocation.
+- **`runplz_release_full.py`** — Brev/runplz launcher for the same full
+  release pipeline. Use this when training remotely; keep machine-
+  specific patching or interrupted-run recovery in ignored `jobs/`.
+
+For Brev/runplz execution:
+
+```bash
+runplz --outputs-dir /path/to/output scripts/training/runplz_release_full.py
+```
+
+For the full release gate (training, comparison, plots, and deployment
+validation), prefer `scripts/release/retrain_evaluate_deploy.sh`.
 
 ## Hyperparameter generation (consumed by the release scripts)
 

--- a/scripts/training/release_exact/make_train_data.processing.py
+++ b/scripts/training/release_exact/make_train_data.processing.py
@@ -51,7 +51,7 @@ from mhcflurry.cluster_parallelism import (
 # stored here before creating the thread pool will be inherited to the child
 # processes upon fork() call, allowing local workers to read the same
 # copy-on-write pages instead of receiving a pickled copy.
-GLOBAL_DATA = {}
+WORKER_CONTEXT = {}
 
 
 parser = argparse.ArgumentParser(usage=__doc__)
@@ -124,7 +124,7 @@ def do_process_samples(samples, constant_data=None):
     ]
 
     if constant_data is None:
-        constant_data = GLOBAL_DATA
+        constant_data = WORKER_CONTEXT
 
     args = constant_data['args']
     lengths = constant_data['lengths']
@@ -315,13 +315,13 @@ def run():
 
     print("Selecting decoys.")
 
-    GLOBAL_DATA['args'] = args
-    GLOBAL_DATA['lengths'] = [8, 9, 10, 11]
-    GLOBAL_DATA['all_peptides_by_length'] = all_peptides_by_length
-    GLOBAL_DATA['proteome_sequences'] = proteome_sequences
-    GLOBAL_DATA['flanking_length'] = flanking_length
-    GLOBAL_DATA['sample_table'] = sample_table
-    GLOBAL_DATA['hit_df'] = hit_df
+    WORKER_CONTEXT['args'] = args
+    WORKER_CONTEXT['lengths'] = [8, 9, 10, 11]
+    WORKER_CONTEXT['all_peptides_by_length'] = all_peptides_by_length
+    WORKER_CONTEXT['proteome_sequences'] = proteome_sequences
+    WORKER_CONTEXT['flanking_length'] = flanking_length
+    WORKER_CONTEXT['sample_table'] = sample_table
+    WORKER_CONTEXT['hit_df'] = hit_df
 
     worker_pool = None
     start = time.time()
@@ -341,7 +341,7 @@ def run():
             args,
             work_function=do_process_samples,
             work_items=tasks,
-            constant_data=GLOBAL_DATA,
+            constant_data=WORKER_CONTEXT,
             input_serialization_method="dill",
             result_serialization_method="pickle",
             clear_constant_data=False)
@@ -351,7 +351,7 @@ def run():
         assert worker_pool is not None
         attach_constant_data_to_work_items_if_needed(
             tasks,
-            GLOBAL_DATA,
+            WORKER_CONTEXT,
             worker_pool,
         )
         results = worker_pool.imap_unordered(

--- a/scripts/training/runplz_release_full.py
+++ b/scripts/training/runplz_release_full.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Launch the full pan-allele release training pipeline on Brev through runplz.
+
+This is the maintained remote wrapper for pan_allele_release_full.sh. Local runs
+should call that shell script directly.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+try:
+    from runplz import App, Image
+    from runplz.config import BrevConfig
+except ImportError as e:
+    raise SystemExit(
+        "runplz is required for this launcher. Install it with "
+        "`pip install runplz` or run pan_allele_release_full.sh locally."
+    ) from e
+
+
+APP_NAME = os.environ.get("RUNPLZ_APP_NAME", "mhcflurry-release-full")
+GPU_TYPE = os.environ.get("RUNPLZ_GPU", "A100")
+NUM_GPUS = int(os.environ.get("RUNPLZ_NUM_GPUS", "4"))
+MIN_GPU_MEMORY = int(os.environ.get("RUNPLZ_MIN_GPU_MEMORY", "35"))
+MIN_CPU = int(os.environ.get("RUNPLZ_MIN_CPU", "32"))
+MIN_MEMORY = int(os.environ.get("RUNPLZ_MIN_MEMORY", "300"))
+MIN_DISK = int(os.environ.get("RUNPLZ_MIN_DISK", "1000"))
+DEFAULT_OUT = os.environ.get("MHCFLURRY_OUT", "/root/mhcflurry-release-run")
+
+
+image = (
+    Image.from_registry(
+        os.environ.get(
+            "RUNPLZ_IMAGE",
+            "pytorch/pytorch:2.4.0-cuda12.1-cudnn9-runtime",
+        )
+    )
+    .apt_install(
+        "python-is-python3",
+        "bzip2",
+        "wget",
+        "rsync",
+        "build-essential",
+        "git",
+        "libhdf5-dev",
+        "libxml2-dev",
+        "libxslt1-dev",
+        "procps",
+    )
+    .pip_install("runplz>=3.11.0")
+    .pip_install_local_dir(".", editable=True)
+)
+
+app = App(
+    APP_NAME,
+    brev_config=BrevConfig(
+        auto_create_instances=False,
+        mode="container",
+        on_finish="leave",
+        ssh_ready_wait_seconds=2400,
+    ),
+)
+
+
+@app.function(
+    image=image,
+    gpu=GPU_TYPE,
+    num_gpus=NUM_GPUS,
+    min_gpu_memory=MIN_GPU_MEMORY,
+    min_cpu=MIN_CPU,
+    min_memory=MIN_MEMORY,
+    min_disk=MIN_DISK,
+    timeout=60 * 60 * 24 * 14,
+    env={
+        "DATALOADER_NUM_WORKERS": os.environ.get("DATALOADER_NUM_WORKERS", "auto"),
+        "MAX_TASKS_PER_WORKER": os.environ.get("MAX_TASKS_PER_WORKER", "12"),
+        "MAX_WORKERS_PER_GPU": os.environ.get("MAX_WORKERS_PER_GPU", "auto"),
+        "MHCFLURRY_ENABLE_TIMING": os.environ.get("MHCFLURRY_ENABLE_TIMING", "1"),
+        "MHCFLURRY_TORCH_COMPILE": os.environ.get("MHCFLURRY_TORCH_COMPILE", "1"),
+        "MHCFLURRY_TORCH_COMPILE_LOSS": os.environ.get(
+            "MHCFLURRY_TORCH_COMPILE_LOSS", "1"
+        ),
+        "MHCFLURRY_MATMUL_PRECISION": os.environ.get(
+            "MHCFLURRY_MATMUL_PRECISION", "high"
+        ),
+        "MATMUL_PRECISION": os.environ.get("MATMUL_PRECISION", "high"),
+        "MATMUL_PRECISION_CLI": os.environ.get("MATMUL_PRECISION_CLI", "high"),
+        "TORCHINDUCTOR_COMPILE_THREADS": os.environ.get(
+            "TORCHINDUCTOR_COMPILE_THREADS", "auto"
+        ),
+    },
+)
+def train_release_full():
+    """Run the maintained full release training script."""
+    repo = Path.cwd()
+    out = Path(
+        os.environ.get("RUNPLZ_OUT")
+        or os.environ.get("MHCFLURRY_OUT")
+        or DEFAULT_OUT
+    ).resolve()
+    env = os.environ.copy()
+    env.update({"MHCFLURRY_OUT": str(out), "REPO": str(repo)})
+    subprocess.run(
+        ["bash", "scripts/training/pan_allele_release_full.sh"],
+        check=True,
+        cwd=repo,
+        env=env,
+    )
+
+
+@app.local_entrypoint()
+def main():
+    train_release_full.remote()

--- a/test/test_api_compat_shims.py
+++ b/test/test_api_compat_shims.py
@@ -31,7 +31,6 @@ def test_old_local_parallelism_import_matches_new_parallelism_package():
         worker_runtime,
     )
 
-    assert old_module is new_package
     assert old_module.worker_init is worker_runtime.worker_init
     assert old_module.add_local_parallelism_args is cli_args.add_local_parallelism_args
     assert old_module.resolve_local_parallelism_args is planning.resolve_local_parallelism_args
@@ -43,6 +42,7 @@ def test_old_local_parallelism_import_matches_new_parallelism_package():
         old_module.resolve_torchinductor_compile_threads_env
         is torch_compile.resolve_torchinductor_compile_threads_env
     )
+    assert old_module.__all__ == new_package.__all__
 
 
 def test_class1_neural_network_public_helpers_remain_importable():
@@ -63,17 +63,6 @@ def test_class1_neural_network_public_helpers_remain_importable():
         old_module.peptide_sequences_to_network_input
         is encoding.peptide_sequences_to_network_input
     )
-
-
-def test_class1_affinity_predictor_helper_imports_remain_compatible():
-    import mhcflurry.class1_affinity_predictor as old_module
-    from mhcflurry.affinity import calibration_sizing
-
-    assert (
-        old_module._peptide_sequences_fingerprint
-        is calibration_sizing.peptide_sequences_fingerprint
-    )
-    assert old_module._CalibrationFastCache is calibration_sizing.CalibrationFastCache
 
 
 def test_legacy_configure_tensorflow_entry_point():

--- a/test/test_calibrate_percentile_ranks_command.py
+++ b/test/test_calibrate_percentile_ranks_command.py
@@ -175,7 +175,7 @@ def test_percent_rank_status_helpers_count_sequence_equivalent_calibration():
 
 def test_list_percent_rank_status_stdout_starts_with_csv_header(
         monkeypatch, tmp_path, capsys):
-    from mhcflurry import calibrate_percentile_ranks_command as mod
+    import mhcflurry.cli.calibrate_percentile_ranks_command as mod
 
     def fake_status(args):
         print("allele,normalized_allele")

--- a/test/test_calibrate_percentile_ranks_fast.py
+++ b/test/test_calibrate_percentile_ranks_fast.py
@@ -707,7 +707,7 @@ def test_calibrate_auto_size_uses_reserved_headroom_not_cache_safety(monkeypatch
             n_alleles=30,
             num_workers_per_gpu=1,
             num_cached_networks=8,
-            peptide_stage_dim=7560,
+            peptide_feature_dim=7560,
             num_sub_networks=8,
         )
     )
@@ -759,7 +759,7 @@ def test_calibrate_auto_size_still_floors_when_cache_does_not_fit(
                 n_alleles=30,
                 num_workers_per_gpu=1,
                 num_cached_networks=8,
-                peptide_stage_dim=7560,
+                peptide_feature_dim=7560,
                 num_sub_networks=8,
             )
         )
@@ -804,7 +804,7 @@ def test_calibrate_auto_size_honors_lower_fraction_budget(monkeypatch):
             n_alleles=100,
             num_workers_per_gpu=1,
             num_cached_networks=0,
-            peptide_stage_dim=1024,
+            peptide_feature_dim=1024,
             num_sub_networks=1,
         )
     )
@@ -818,7 +818,7 @@ def test_calibrate_auto_size_honors_lower_fraction_budget(monkeypatch):
             n_alleles=100,
             num_workers_per_gpu=1,
             num_cached_networks=0,
-            peptide_stage_dim=1024,
+            peptide_feature_dim=1024,
             num_sub_networks=1,
         )
     )
@@ -863,7 +863,7 @@ def test_calibrate_auto_size_honors_lower_reserved_headroom(monkeypatch):
             n_alleles=100,
             num_workers_per_gpu=1,
             num_cached_networks=0,
-            peptide_stage_dim=1024,
+            peptide_feature_dim=1024,
             num_sub_networks=1,
         )
     )
@@ -877,7 +877,7 @@ def test_calibrate_auto_size_honors_lower_reserved_headroom(monkeypatch):
             n_alleles=100,
             num_workers_per_gpu=1,
             num_cached_networks=0,
-            peptide_stage_dim=1024,
+            peptide_feature_dim=1024,
             num_sub_networks=1,
         )
     )
@@ -931,7 +931,7 @@ def test_calibrate_auto_size_reused_cache_uses_current_free_memory(
                 n_alleles=30,
                 num_workers_per_gpu=1,
                 num_cached_networks=0,
-                peptide_stage_dim=8505,
+                peptide_feature_dim=8505,
                 num_sub_networks=9,
             )
         )

--- a/test/test_calibrate_percentile_ranks_fast.py
+++ b/test/test_calibrate_percentile_ranks_fast.py
@@ -27,6 +27,7 @@ import pytest
 
 from mhcflurry import Class1AffinityPredictor
 from mhcflurry import common
+from mhcflurry.affinity import calibration_sizing
 from mhcflurry.common import positional_frequency_matrix, random_peptides
 from mhcflurry.class1_neural_network import cartesian_output_log_ic50_sum
 from mhcflurry.motif_summary import (
@@ -435,8 +436,8 @@ def test_check_training_batch_fits_shrinks_loudly_on_oom(caplog):
 
     from mhcflurry.pytorch_sizing import (
         check_training_batch_fits,
-        _TRAINING_PEAK_MULTIPLIER,
-        _estimate_peak_bytes_per_row,
+        TRAINING_PEAK_MULTIPLIER,
+        estimate_peak_bytes_per_row,
     )
 
     class FakeCUDA:
@@ -446,11 +447,11 @@ def test_check_training_batch_fits_shrinks_loudly_on_oom(caplog):
         def __str__(self):
             return "cuda:0"
 
-    # Swap out _free_device_memory_bytes for the duration of this test.
+    # Swap out free_device_memory_bytes for the duration of this test.
     from mhcflurry import pytorch_sizing
-    saved = pytorch_sizing._free_device_memory_bytes
+    saved = pytorch_sizing.free_device_memory_bytes
     try:
-        pytorch_sizing._free_device_memory_bytes = lambda device: 8 * (1 << 30)
+        pytorch_sizing.free_device_memory_bytes = lambda device: 8 * (1 << 30)
 
         class TinyModel:
             # Pretend peak row = 1 KB; 8 GB / 2 workers / 2 (0.5 fraction)
@@ -465,7 +466,7 @@ def test_check_training_batch_fits_shrinks_loudly_on_oom(caplog):
             dense_layers = [_Layer]
 
         model = TinyModel()
-        peak = _estimate_peak_bytes_per_row(model) * _TRAINING_PEAK_MULTIPLIER
+        peak = estimate_peak_bytes_per_row(model) * TRAINING_PEAK_MULTIPLIER
         assert peak > 0
         device = FakeCUDA()
 
@@ -491,7 +492,7 @@ def test_check_training_batch_fits_shrinks_loudly_on_oom(caplog):
         assert "TRAINING BATCH WILL NOT FIT" in joined
         assert "CHANGES TRAINING DYNAMICS" in joined
     finally:
-        pytorch_sizing._free_device_memory_bytes = saved
+        pytorch_sizing.free_device_memory_bytes = saved
 
 
 @pytest.mark.parametrize(
@@ -516,11 +517,11 @@ def test_fit_end_to_end_shrinks_minibatch_when_vram_too_small(
     from mhcflurry.common import random_peptides
 
     # Override accelerator free-memory to be tiny so the shrink fires.
-    saved_free = pytorch_sizing._free_device_memory_bytes
+    saved_free = pytorch_sizing.free_device_memory_bytes
     old_backend = common._pytorch_backend
     try:
         common.configure_pytorch(backend=backend)
-        pytorch_sizing._free_device_memory_bytes = lambda device: (
+        pytorch_sizing.free_device_memory_bytes = lambda device: (
             128 * (1 << 20) if device.type == device_type else saved_free(device)
         )
 
@@ -571,7 +572,7 @@ def test_fit_end_to_end_shrinks_minibatch_when_vram_too_small(
             "config would no longer reflect the user's configured value"
         )
     finally:
-        pytorch_sizing._free_device_memory_bytes = saved_free
+        pytorch_sizing.free_device_memory_bytes = saved_free
         common.configure_pytorch(backend=old_backend)
 
 
@@ -627,19 +628,19 @@ def test_compute_prediction_batch_size_scales_with_memory_and_workers():
     workers-per-GPU partition."""
     from mhcflurry.pytorch_sizing import (
         compute_prediction_batch_size,
-        _AUTO_BATCH_CPU_FALLBACK,
-        _AUTO_BATCH_MAX_ROWS,
-        _AUTO_BATCH_MIN_ROWS,
+        AUTO_BATCH_CPU_FALLBACK,
+        AUTO_BATCH_MAX_ROWS,
+        AUTO_BATCH_MIN_ROWS,
     )
 
     cpu = torch.device("cpu")
     # CPU short-circuit: fixed fallback regardless of workers / memory.
     # Large batches on CPU thrash L3 and don't help the small networks
     # mhcflurry trains.
-    assert compute_prediction_batch_size(cpu) == _AUTO_BATCH_CPU_FALLBACK
+    assert compute_prediction_batch_size(cpu) == AUTO_BATCH_CPU_FALLBACK
     assert compute_prediction_batch_size(
         cpu, num_workers_per_gpu=16,
-    ) == _AUTO_BATCH_CPU_FALLBACK
+    ) == AUTO_BATCH_CPU_FALLBACK
 
     # Model=None (fallback estimate) still produces a within-bounds
     # batch on MPS/CUDA if either is available locally.
@@ -650,8 +651,8 @@ def test_compute_prediction_batch_size_scales_with_memory_and_workers():
         )
         single = compute_prediction_batch_size(dev)
         shared = compute_prediction_batch_size(dev, num_workers_per_gpu=8)
-        assert _AUTO_BATCH_MIN_ROWS <= single <= _AUTO_BATCH_MAX_ROWS
-        assert _AUTO_BATCH_MIN_ROWS <= shared <= _AUTO_BATCH_MAX_ROWS
+        assert AUTO_BATCH_MIN_ROWS <= single <= AUTO_BATCH_MAX_ROWS
+        assert AUTO_BATCH_MIN_ROWS <= shared <= AUTO_BATCH_MAX_ROWS
         # Sharing the GPU with 8 workers partitions the budget — each
         # worker's batch is no larger than the unshared case. Equality
         # is allowed because the min_rows floor clamps both cases
@@ -694,12 +695,12 @@ def test_calibrate_auto_size_uses_reserved_headroom_not_cache_safety(monkeypatch
     monkeypatch.delenv(
         "MHCFLURRY_CALIBRATE_AUTO_FIXED_SAFETY_MULTIPLIER", raising=False)
     monkeypatch.setattr(
-        pytorch_sizing, "_free_device_memory_bytes",
+        pytorch_sizing, "free_device_memory_bytes",
         lambda device: int(28.63 * (1 << 30)),
     )
 
     peptide_batch, allele_batch = (
-        Class1AffinityPredictor._auto_size_calibration_batches(
+        calibration_sizing.auto_size_calibration_batches(
             Merged(),
             FakeCUDA(),
             n_peptides=50_000,
@@ -745,13 +746,13 @@ def test_calibrate_auto_size_still_floors_when_cache_does_not_fit(
         networks = [SubNet() for _ in range(8)]
 
     monkeypatch.setattr(
-        pytorch_sizing, "_free_device_memory_bytes",
+        pytorch_sizing, "free_device_memory_bytes",
         lambda device: int(16 * (1 << 30)),
     )
 
     with caplog.at_level(logging.WARNING, logger="root"):
         peptide_batch, allele_batch = (
-            Class1AffinityPredictor._auto_size_calibration_batches(
+            calibration_sizing.auto_size_calibration_batches(
                 Merged(),
                 FakeCUDA(),
                 n_peptides=50_000,
@@ -791,12 +792,12 @@ def test_calibrate_auto_size_honors_lower_fraction_budget(monkeypatch):
     monkeypatch.setenv("MHCFLURRY_CALIBRATE_AUTO_RESERVE_FRACTION", "0.10")
     monkeypatch.setenv("MHCFLURRY_CALIBRATE_AUTO_RESERVE_GB", "1.0")
     monkeypatch.setattr(
-        pytorch_sizing, "_free_device_memory_bytes",
+        pytorch_sizing, "free_device_memory_bytes",
         lambda device: int(40 * (1 << 30)),
     )
 
     low_fraction_batch = (
-        Class1AffinityPredictor._auto_size_calibration_batches(
+        calibration_sizing.auto_size_calibration_batches(
             Model(),
             FakeCUDA(),
             n_peptides=50_000,
@@ -810,7 +811,7 @@ def test_calibrate_auto_size_honors_lower_fraction_budget(monkeypatch):
 
     monkeypatch.setenv("MHCFLURRY_CALIBRATE_AUTO_FREE_MEMORY_FRACTION", "0.85")
     default_fraction_batch = (
-        Class1AffinityPredictor._auto_size_calibration_batches(
+        calibration_sizing.auto_size_calibration_batches(
             Model(),
             FakeCUDA(),
             n_peptides=50_000,
@@ -850,12 +851,12 @@ def test_calibrate_auto_size_honors_lower_reserved_headroom(monkeypatch):
     monkeypatch.setenv("MHCFLURRY_CALIBRATE_AUTO_FREE_MEMORY_FRACTION", "0.95")
     monkeypatch.setenv("MHCFLURRY_CALIBRATE_AUTO_RESERVE_GB", "20.0")
     monkeypatch.setattr(
-        pytorch_sizing, "_free_device_memory_bytes",
+        pytorch_sizing, "free_device_memory_bytes",
         lambda device: int(40 * (1 << 30)),
     )
 
     high_reserve_batch = (
-        Class1AffinityPredictor._auto_size_calibration_batches(
+        calibration_sizing.auto_size_calibration_batches(
             Model(),
             FakeCUDA(),
             n_peptides=50_000,
@@ -869,7 +870,7 @@ def test_calibrate_auto_size_honors_lower_reserved_headroom(monkeypatch):
 
     monkeypatch.setenv("MHCFLURRY_CALIBRATE_AUTO_RESERVE_GB", "1.0")
     low_reserve_batch = (
-        Class1AffinityPredictor._auto_size_calibration_batches(
+        calibration_sizing.auto_size_calibration_batches(
             Model(),
             FakeCUDA(),
             n_peptides=50_000,
@@ -917,13 +918,13 @@ def test_calibrate_auto_size_reused_cache_uses_current_free_memory(
         networks = [SubNet() for _ in range(9)]
 
     monkeypatch.setattr(
-        pytorch_sizing, "_free_device_memory_bytes",
+        pytorch_sizing, "free_device_memory_bytes",
         lambda device: int(18.79 * (1 << 30)),
     )
 
     with caplog.at_level(logging.WARNING, logger="root"):
         peptide_batch, allele_batch = (
-            Class1AffinityPredictor._auto_size_calibration_batches(
+            calibration_sizing.auto_size_calibration_batches(
                 Merged(),
                 FakeCUDA(),
                 n_peptides=400_000,
@@ -950,36 +951,24 @@ def test_peptide_sequences_fingerprint_distinguishes_middle_changes():
     boundary peptides matched. Reusing a stale peptide-stage cache in
     that case silently produced wrong PercentRankTransforms.
     """
-    from mhcflurry.class1_affinity_predictor import (
-        _peptide_sequences_fingerprint,
-    )
-
-    a = _peptide_sequences_fingerprint(["AAAA", "BBBB", "CCCC"])
-    b = _peptide_sequences_fingerprint(["AAAA", "XXXX", "CCCC"])
+    a = calibration_sizing.peptide_sequences_fingerprint(["AAAA", "BBBB", "CCCC"])
+    b = calibration_sizing.peptide_sequences_fingerprint(["AAAA", "XXXX", "CCCC"])
     assert a != b
 
 
 def test_peptide_sequences_fingerprint_length_prefix_prevents_concat_collision():
     """Length prefixing prevents the trivial concatenation collision."""
-    from mhcflurry.class1_affinity_predictor import (
-        _peptide_sequences_fingerprint,
-    )
-
     assert (
-        _peptide_sequences_fingerprint(["AB", "C"])
-        != _peptide_sequences_fingerprint(["A", "BC"])
+        calibration_sizing.peptide_sequences_fingerprint(["AB", "C"])
+        != calibration_sizing.peptide_sequences_fingerprint(["A", "BC"])
     )
 
 
 def test_peptide_sequences_fingerprint_order_sensitive():
     """Reordering the same peptides must change the fingerprint."""
-    from mhcflurry.class1_affinity_predictor import (
-        _peptide_sequences_fingerprint,
-    )
-
     assert (
-        _peptide_sequences_fingerprint(["A", "B"])
-        != _peptide_sequences_fingerprint(["B", "A"])
+        calibration_sizing.peptide_sequences_fingerprint(["A", "B"])
+        != calibration_sizing.peptide_sequences_fingerprint(["B", "A"])
     )
 
 
@@ -987,10 +976,10 @@ def test_calibration_stage_cache_signature_omits_build_batch_size():
     """The peptide-stage cache is independent of the fill chunk size."""
     encoded = EncodableSequences.create(["AAAA", "CCCC"])
     networks = [object()]
-    first = Class1AffinityPredictor._calibration_stage_cache_signature(
+    first = calibration_sizing.calibration_stage_cache_signature(
         encoded, networks, torch.device("cpu"),
     )
-    second = Class1AffinityPredictor._calibration_stage_cache_signature(
+    second = calibration_sizing.calibration_stage_cache_signature(
         encoded, networks, torch.device("cpu"),
     )
 
@@ -999,18 +988,13 @@ def test_calibration_stage_cache_signature_omits_build_batch_size():
 
 
 def test_calibration_fast_cache_state_lifecycle():
-    """``_calibration_fast_cache`` is lazy and ``clear`` releases it."""
-    from mhcflurry.class1_affinity_predictor import (
-        Class1AffinityPredictor,
-        _CalibrationFastCache,
-    )
-
+    """The fast-calibration cache is lazy and ``clear`` releases it."""
     predictor = Class1AffinityPredictor()
     assert getattr(predictor, "_calibration_fast_cache_state", None) is None
 
-    cache = predictor._calibration_fast_cache()
-    assert isinstance(cache, _CalibrationFastCache)
-    assert predictor._calibration_fast_cache() is cache  # idempotent
+    cache = calibration_sizing.calibration_fast_cache(predictor)
+    assert isinstance(cache, calibration_sizing.CalibrationFastCache)
+    assert calibration_sizing.calibration_fast_cache(predictor) is cache
 
     cache.cached_stages = ["sentinel"]
     cache.stage_signature = ("sig",)
@@ -1064,7 +1048,7 @@ def test_calibrate_fast_cache_signature_cleared_if_rebuild_fails():
         class1_pan_allele_models=[FailingNetwork()],
         allele_to_sequence={"A": "AAAAAAAA"},
     )
-    cache = predictor._calibration_fast_cache()
+    cache = calibration_sizing.calibration_fast_cache(predictor)
     cache.stage_signature = ("old-signature",)
     cache.cached_stages = ["old-cache"]
 

--- a/test/test_class1_presentation_predictor_unit.py
+++ b/test/test_class1_presentation_predictor_unit.py
@@ -17,7 +17,7 @@ import pandas
 import torch
 
 import mhcflurry.class1_presentation_predictor as presentation_module
-import mhcflurry.train_presentation_models_command as train_presentation
+import mhcflurry.cli.train_presentation_models_command as train_presentation
 from mhcflurry.class1_presentation_predictor import Class1PresentationPredictor
 
 
@@ -243,8 +243,8 @@ def test_presentation_feature_chunks_use_global_data():
         (3, 5, "s2"),
     ]
 
-    train_presentation.GLOBAL_DATA.clear()
-    train_presentation.GLOBAL_DATA.update({
+    train_presentation.WORKER_CONTEXT.clear()
+    train_presentation.WORKER_CONTEXT.update({
         "predictor": FakePresentationPredictor(),
         "data": df,
         "experiment_to_alleles": {
@@ -308,7 +308,7 @@ def test_estimate_presentation_feature_worker_gb_uses_model_shape(monkeypatch):
     monkeypatch.setenv("MHCFLURRY_PRESENTATION_WORKER_TRANSIENT_ROWS", "10")
     monkeypatch.setattr(
         train_presentation,
-        "_estimate_peak_bytes_per_row",
+        "estimate_peak_bytes_per_row",
         lambda network: 512 * 1024 * 1024
         if network is processing_network else 1024,
     )
@@ -325,13 +325,13 @@ def test_presentation_worker_estimator_uses_cartesian_merged_peak(monkeypatch):
     merged_network = FakeNetwork()
     merged_network.networks = [FakeNetwork(), FakeNetwork()]
     monkeypatch.setattr(
-        train_presentation.Class1AffinityPredictor,
-        "_estimate_calibration_peak_bytes_per_row",
-        staticmethod(lambda network: 123 if network is merged_network else 0),
+        train_presentation,
+        "estimate_calibration_peak_bytes_per_row",
+        lambda network: 123 if network is merged_network else 0,
     )
     monkeypatch.setattr(
         train_presentation,
-        "_estimate_peak_bytes_per_row",
+        "estimate_peak_bytes_per_row",
         lambda network: 999,
     )
 

--- a/test/test_class1_processing_neural_network.py
+++ b/test/test_class1_processing_neural_network.py
@@ -267,7 +267,7 @@ def test_fit_uses_eager_network_for_validation_by_default(monkeypatch):
 
 def test_processing_peak_estimate_scales_with_conv_shape():
     """Processing prediction autosizing should see Conv1d activation width."""
-    from mhcflurry.pytorch_sizing import _estimate_peak_bytes_per_row
+    from mhcflurry.pytorch_sizing import estimate_peak_bytes_per_row
 
     small = Class1ProcessingNeuralNetwork(
         peptide_max_length=15,
@@ -289,8 +289,8 @@ def test_processing_peak_estimate_scales_with_conv_shape():
         **large.network_hyperparameter_defaults.subselect(large.hyperparameters)
     )
 
-    small_estimate = _estimate_peak_bytes_per_row(small_network)
-    large_estimate = _estimate_peak_bytes_per_row(large_network)
+    small_estimate = estimate_peak_bytes_per_row(small_network)
+    large_estimate = estimate_peak_bytes_per_row(large_network)
 
     assert small_estimate == 15 * 21 * 4 * 2 * 4
     assert large_estimate == 25 * 512 * 4 * 2 * 4

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -123,7 +123,6 @@ def test_legacy_command_module_shims_reexport_cli_modules():
     for module_name in command_modules:
         legacy = importlib.import_module("mhcflurry.%s" % module_name)
         canonical = importlib.import_module("mhcflurry.cli.%s" % module_name)
-        assert legacy is canonical
         assert legacy.run is canonical.run
         assert legacy.parser is canonical.parser
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -351,9 +351,18 @@ def test_probe_run_dir_finds_affinity_via_allele_sequences(tmp_path):
 
 
 def test_probe_run_dir_finds_presentation_via_weights_csv(tmp_path):
-    target = tmp_path / "run" / "presentation" / "models.combined"
+    target = tmp_path / "run" / "presentation" / "models"
     target.mkdir(parents=True)
     # Class1PresentationPredictor.save() writes weights.csv at the top level.
+    (target / "weights.csv").write_text(",kind\npresentation_score,affinity\n")
+    resolved = compare_models._probe_run_dir(
+        str(tmp_path / "run"), "presentation")
+    assert resolved == str(target)
+
+
+def test_probe_run_dir_still_finds_legacy_presentation_models_combined(tmp_path):
+    target = tmp_path / "run" / "presentation" / "models.combined"
+    target.mkdir(parents=True)
     (target / "weights.csv").write_text(",kind\npresentation_score,affinity\n")
     resolved = compare_models._probe_run_dir(
         str(tmp_path / "run"), "presentation")

--- a/test/test_local_parallelism.py
+++ b/test/test_local_parallelism.py
@@ -635,7 +635,7 @@ def test_resolve_local_parallelism_args_auto_detects_gpus(monkeypatch):
     )
     monkeypatch.setenv("MHCFLURRY_AUTO_MAX_WORKERS_PER_GPU_HARD_CAP", "4")
     monkeypatch.setattr(
-        planning, "_detect_num_cuda_devices_no_torch", lambda: 4)
+        planning, "detect_num_cuda_devices_no_torch", lambda: 4)
     args = Namespace(
         max_workers_per_gpu="auto",
         num_jobs="auto",
@@ -681,7 +681,7 @@ def test_resolve_local_parallelism_args_detects_gpus_before_explicit_jobs(
     )
     monkeypatch.setenv("MHCFLURRY_AUTO_MAX_WORKERS_PER_GPU_HARD_CAP", "4")
     monkeypatch.setattr(
-        planning, "_detect_num_cuda_devices_no_torch", lambda: 8)
+        planning, "detect_num_cuda_devices_no_torch", lambda: 8)
     args = Namespace(
         max_workers_per_gpu="auto",
         num_jobs=16,
@@ -699,7 +699,7 @@ def test_worker_pool_from_args_preserves_serial_mode_with_auto_gpus(
     """Explicit ``--num-jobs 0`` must not become invalid after GPU detect."""
     monkeypatch.delenv("MHCFLURRY_TORCH_COMPILE", raising=False)
     monkeypatch.setattr(
-        planning, "_detect_num_cuda_devices_no_torch", lambda: 2)
+        planning, "detect_num_cuda_devices_no_torch", lambda: 2)
     configured = []
     monkeypatch.setattr(
         worker_pool_module, "configure_pytorch",
@@ -751,7 +751,7 @@ def test_resolve_local_parallelism_args_skips_auto_detect_with_explicit_gpus(
         monkeypatch):
     """An explicit --gpus value isn't overridden by auto-detect."""
     monkeypatch.setattr(
-        planning, "_detect_num_cuda_devices_no_torch",
+        planning, "detect_num_cuda_devices_no_torch",
         lambda: 8)  # would lie if called
     args = Namespace(
         max_workers_per_gpu="auto",
@@ -769,7 +769,7 @@ def test_resolve_local_parallelism_args_no_auto_detect_for_cpu_backend(
     """backend=cpu must not auto-detect GPUs (we don't want CUDA-pinned
     workers when the user explicitly asked for CPU inference)."""
     monkeypatch.setattr(
-        planning, "_detect_num_cuda_devices_no_torch",
+        planning, "detect_num_cuda_devices_no_torch",
         lambda: 8)
     args = Namespace(
         max_workers_per_gpu="auto",
@@ -789,7 +789,7 @@ def test_detect_num_cuda_devices_uses_empty_cuda_visible_devices(monkeypatch):
 
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "")
     monkeypatch.setattr(planning.subprocess, "check_output", boom)
-    assert planning._detect_num_cuda_devices_no_torch() == 0
+    assert planning.detect_num_cuda_devices_no_torch() == 0
 
 
 def test_free_vram_from_nvidia_smi_uses_cuda_visible_devices(monkeypatch):
@@ -803,7 +803,7 @@ def test_free_vram_from_nvidia_smi_uses_cuda_visible_devices(monkeypatch):
     monkeypatch.setenv("CUDA_VISIBLE_DEVICES", "2,3")
     monkeypatch.setattr(
         planning.subprocess, "check_output", fake_check_output)
-    assert planning._free_vram_from_nvidia_smi_gb(2) == 1.0
+    assert planning.free_vram_from_nvidia_smi_gb(2) == 1.0
     assert calls == [[
         "nvidia-smi",
         "-i",
@@ -821,14 +821,14 @@ def test_detect_free_vram_per_gpu_preserves_heterogeneity(monkeypatch):
         planning.subprocess, "check_output",
         lambda args, **kw: b"8192\n71680\n")  # 8 GB, 70 GB
     assert planning.detect_free_vram_per_gpu_gb(2) == [8.0, 70.0]
-    assert planning._free_vram_from_nvidia_smi_gb(2) == 8.0
+    assert planning.free_vram_from_nvidia_smi_gb(2) == 8.0
 
 
 def test_free_vram_env_override_single_value_broadcasts(monkeypatch):
     monkeypatch.setenv(
         "MHCFLURRY_AUTO_MAX_WORKERS_PER_GPU_FREE_VRAM_GB", "12")
-    assert planning._free_vram_per_gpu_override_gb(4) == [12.0] * 4
-    assert planning._free_vram_override_gb(4) == 12.0
+    assert planning.free_vram_per_gpu_override_gb(4) == [12.0] * 4
+    assert planning.free_vram_override_gb(4) == 12.0
 
 
 def test_capacity_warnings_flags_below_safe_range():
@@ -899,7 +899,7 @@ def test_detect_num_cuda_devices_parses_nvidia_smi_l(monkeypatch):
     )
     monkeypatch.setattr(
         planning.subprocess, "check_output", lambda *a, **kw: sample)
-    assert planning._detect_num_cuda_devices_no_torch() == 2
+    assert planning.detect_num_cuda_devices_no_torch() == 2
 
 
 def test_detect_num_cuda_devices_returns_zero_when_smi_missing(monkeypatch):
@@ -907,7 +907,7 @@ def test_detect_num_cuda_devices_returns_zero_when_smi_missing(monkeypatch):
     def boom(*a, **kw):
         raise OSError("nvidia-smi: not found")
     monkeypatch.setattr(planning.subprocess, "check_output", boom)
-    assert planning._detect_num_cuda_devices_no_torch() == 0
+    assert planning.detect_num_cuda_devices_no_torch() == 0
 
 
 @pytest.mark.slow

--- a/test/test_orchestrator_helpers.py
+++ b/test/test_orchestrator_helpers.py
@@ -212,7 +212,7 @@ def test_attach_constant_data_skips_fork_pool():
 
     assert attached is False
     assert all("constant_data" not in item for item in work_items)
-    assert any("inherit GLOBAL_DATA" in line for line in logs)
+    assert any("inherit WORKER_CONTEXT" in line for line in logs)
 
 
 def test_attach_constant_data_attaches_for_non_fork_pool():

--- a/test/test_predict_command.py
+++ b/test/test_predict_command.py
@@ -20,7 +20,7 @@ import pandas
 
 import torch
 
-from mhcflurry import predict_command
+import mhcflurry.cli.predict_command as predict_command
 
 from mhcflurry.testing_utils import cleanup, startup
 

--- a/test/test_predict_scan_command.py
+++ b/test/test_predict_scan_command.py
@@ -17,7 +17,7 @@ import pandas
 import pytest
 from numpy.testing import assert_array_less
 
-from mhcflurry import predict_scan_command
+import mhcflurry.cli.predict_scan_command as predict_scan_command
 
 from . import data_path
 

--- a/test/test_train_and_related_commands.py
+++ b/test/test_train_and_related_commands.py
@@ -107,11 +107,11 @@ def write_tiny_affinity_data(filename):
 
 
 def run_command(command_module, args):
-    command_module.GLOBAL_DATA.clear()
+    command_module.WORKER_CONTEXT.clear()
     try:
         command_module.run(args)
     finally:
-        command_module.GLOBAL_DATA.clear()
+        command_module.WORKER_CONTEXT.clear()
 
 
 def test_train_calibrate_and_select_commands():


### PR DESCRIPTION
## Summary
- Bump the 2.3.0 release candidate references to `2.3.0rc12`.
- Remove compatibility tests and aliases that cement private/internal APIs: promote shared helpers, keep legacy modules as thin wrappers, and update implementation tests to import canonical modules.
- Rename command worker globals from `GLOBAL_DATA` to `WORKER_CONTEXT`, consolidate SIGUSR1 stack-trace handler setup, and document the follow-up plan for private API and fallback cleanup.
- Clarify calibration peptide feature sizing and extract the dense CUDA batch-sizing logic into smaller helpers.
- Add a 2023 retraining notebook audit, a missing-figure porting plan, a single retrain/evaluate/deploy workflow, a Brev/runplz launcher, and trained-model deployment helper scripts.
- Fix `compare-models` run-dir probing to use the current presentation output layout while retaining the legacy fallback.

## Verification
- `bash -n scripts/release/deploy_trained_models.sh scripts/release/retrain_evaluate_deploy.sh`
- `python -m py_compile scripts/training/runplz_release_full.py`
- `scripts/release/deploy_trained_models.sh --dry-run` on a synthetic release-run layout
- `scripts/release/retrain_evaluate_deploy.sh --dry-run` for local and ssh backends
- `./lint.sh`
- `pytest test/test_cli.py -q`
- `pytest test/` -> 630 passed, 7 skipped
- GitHub CI matrix: Python 3.10, 3.11, 3.12 passed