### PR TITLE
Rename pan-allele remote training launcher for rc13

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ Have a bugfix or other contribution? We would love your help. See our [contribut
 ## 2.3.0 release candidate
 
 > [!IMPORTANT]
-> 2.3.0 is currently a release candidate (`2.3.0rc12`), not yet a final release.
+> 2.3.0 is currently a release candidate (`2.3.0rc13`), not yet a final release.
 > It keeps the same public API and pre-trained models as 2.2.x. Install it with
 > `pip install --pre mhcflurry`, or pin the version with
-> `pip install mhcflurry==2.3.0rc12`. A plain `pip install --upgrade mhcflurry`
+> `pip install mhcflurry==2.3.0rc13`. A plain `pip install --upgrade mhcflurry`
 > stays on the latest stable release (2.2.x) until 2.3.0 is final, since pip
 > skips pre-releases.
 

--- a/docs/2023_retraining_notebook_audit.md
+++ b/docs/2023_retraining_notebook_audit.md
@@ -98,8 +98,8 @@ committed as the workflow.
    `short_flanks` is the canonical with-flank presentation input for 2.3.x.
 9. Make the release gate one command:
    `scripts/release/retrain_evaluate_deploy.sh` trains, evaluates, plots, and
-   runs deployment validation. It supports local, runplz/Brev, and SSH-backed
-   remote machines.
+   runs deployment validation. It supports local execution, existing
+   Brev/runplz capacity, and SSH-backed remote machines.
 
 ## Current Single-Command Entry Point
 
@@ -113,13 +113,13 @@ scripts/release/retrain_evaluate_deploy.sh \
     --deploy-mode dry-run
 ```
 
-Brev through runplz:
+Brev through existing runplz capacity:
 
 ```bash
 scripts/release/retrain_evaluate_deploy.sh \
     --run-dir /path/to/release-run \
     --release 2.3.0 \
-    --backend runplz \
+    --backend brev-existing \
     --deploy-mode dry-run
 ```
 

--- a/mhcflurry/version.py
+++ b/mhcflurry/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.3.0rc12"
+__version__ = "2.3.0rc13"

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -51,8 +51,8 @@ The maintained scripts are generally well scoped: release training lives
 under `training/`, development helpers live under `dev/`, and the
 top-level validation tools are narrow checks. The main gap was that Brev
 training and model-asset deployment were living outside this maintained
-surface. `scripts/training/runplz_release_full.py` is now the reusable
-Brev/runplz training entry point, and
+surface. `scripts/training/launch_pan_allele_training_remote.py` is now the
+reusable remote/cloud pan-allele training entry point, and
 `scripts/release/retrain_evaluate_deploy.sh` is the single maintained
 workflow for training, evaluating, plotting, and deployment validation.
 

--- a/scripts/release/README.md
+++ b/scripts/release/README.md
@@ -32,8 +32,16 @@ scripts/release/retrain_evaluate_deploy.sh \
     --deploy-mode dry-run
 ```
 
-Use `--backend runplz` for the maintained Brev/runplz path or `--backend ssh`
-with `--remote`, `--remote-repo`, and `--remote-run-dir` for a generic remote
-machine. The script runs training, `mhcflurry compare-models`,
+Supported backends are:
+
+- `local`: train in the current checkout on the current machine.
+- `brev-existing`: train on existing Brev/runplz capacity. This does not
+  provision a new machine; runplz/Brev handles remote execution, package sync,
+  and credentials.
+- `ssh`: train on a specific remote host, with `--remote`, `--remote-repo`, and
+  `--remote-run-dir`. Authentication comes from local `ssh` / `rsync`
+  configuration, typically SSH keys or an SSH config `Host`.
+
+The script runs training, `mhcflurry compare-models`,
 `mhcflurry plot-model-comparison`, and deployment validation in order; each
 stage has a `--skip-*` flag for resuming.

--- a/scripts/release/retrain_evaluate_deploy.sh
+++ b/scripts/release/retrain_evaluate_deploy.sh
@@ -21,17 +21,19 @@ Usage:
   scripts/release/retrain_evaluate_deploy.sh \
       --run-dir /path/to/release-run \
       --release 2.3.0 \
-      [--backend local|runplz|ssh] \
+      [--backend local|brev-existing|ssh] \
       [--skip-train] [--skip-eval] [--skip-plots] [--skip-deploy] \
       [--deploy-mode dry-run|draft|publish]
 
 Backends:
-  local   Run scripts/training/pan_allele_release_full.sh in this checkout.
-  runplz  Launch scripts/training/runplz_release_full.py. This is the Brev
-          path when runplz is configured for Brev instances.
-  ssh     Run the local training script on a remote host, then rsync the remote
-          run directory back. Requires --remote, --remote-repo, and
-          --remote-run-dir.
+  local          Run scripts/training/pan_allele_release_full.sh here.
+  brev-existing  Run on existing Brev/runplz capacity. This does not provision
+                 a new machine; runplz/Brev handles the remote container,
+                 package sync, and credentials.
+  ssh            Run on a specific remote host, then rsync the run directory
+                 back. Requires --remote, --remote-repo, and --remote-run-dir.
+                 Authentication is whatever your local ssh/rsync configuration
+                 uses, typically SSH keys or an SSH config Host entry.
 
 Evaluation:
   After training, the script runs:
@@ -181,8 +183,8 @@ if [ -z "$GITHUB_RELEASE" ]; then
     GITHUB_RELEASE=$RELEASE
 fi
 case "$BACKEND" in
-    local|runplz|ssh) ;;
-    *) die "--backend must be one of: local, runplz, ssh" ;;
+    local|brev-existing|ssh) ;;
+    *) die "--backend must be one of: local, brev-existing, ssh" ;;
 esac
 case "$DEPLOY_MODE" in
     dry-run|draft|publish) ;;
@@ -208,14 +210,14 @@ if [ "$SKIP_TRAIN" != "1" ]; then
                 "REPO=$REPO" \
                 bash "$REPO/scripts/training/pan_allele_release_full.sh"
             ;;
-        runplz)
+        brev-existing)
             require_command runplz
             run_cmd mkdir -p "$RUN_DIR"
             run_cmd env \
                 "MHCFLURRY_OUT=$RUN_DIR" \
                 "REPO=$REPO" \
                 runplz --outputs-dir "$RUN_DIR" \
-                "$REPO/scripts/training/runplz_release_full.py"
+                "$REPO/scripts/training/launch_pan_allele_training_remote.py"
             ;;
         ssh)
             require_command ssh

--- a/scripts/training/README.md
+++ b/scripts/training/README.md
@@ -16,14 +16,16 @@ one-off tuning runs do not belong here.
   predictor on top. Use this as a tail-on after a sweep.
 - **`pan_allele_release_full.sh`** — Composition wrapper that runs Stage
   1 then inlines Stages 2–3. The full release in one invocation.
-- **`runplz_release_full.py`** — Brev/runplz launcher for the same full
-  release pipeline. Use this when training remotely; keep machine-
-  specific patching or interrupted-run recovery in ignored `jobs/`.
+- **`launch_pan_allele_training_remote.py`** — remote/cloud launcher for
+  the same pan-allele training pipeline. It currently uses runplz, with
+  Brev configuration when runplz is pointed at Brev instances. Use this
+  when training remotely; keep machine-specific patching or interrupted-
+  run recovery in ignored `jobs/`.
 
 For Brev/runplz execution:
 
 ```bash
-runplz --outputs-dir /path/to/output scripts/training/runplz_release_full.py
+runplz --outputs-dir /path/to/output scripts/training/launch_pan_allele_training_remote.py
 ```
 
 For the full release gate (training, comparison, plots, and deployment

--- a/scripts/training/launch_pan_allele_training_remote.py
+++ b/scripts/training/launch_pan_allele_training_remote.py
@@ -12,10 +12,11 @@
 # limitations under the License.
 
 """
-Launch the full pan-allele release training pipeline on Brev through runplz.
+Launch pan-allele training on remote GPU machines.
 
-This is the maintained remote wrapper for pan_allele_release_full.sh. Local runs
-should call that shell script directly.
+This is the maintained remote wrapper for pan_allele_release_full.sh. It uses
+runplz as the transport, with Brev configuration when runplz is pointed at Brev
+instances. Local runs should call the shell script directly.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- Rename `scripts/training/runplz_release_full.py` to `scripts/training/launch_pan_allele_training_remote.py` so the filename describes the remote pan-allele training job rather than the runplz transport.
- Rename the supported runplz/Brev backend mode from `runplz` to `brev-existing`, making clear that this uses existing Brev/runplz capacity and does not provision a machine.
- Document the currently-supported backend modes: `local`, `brev-existing`, and `ssh`.
- Bump the 2.3.0 release candidate references to `2.3.0rc13`.
- File #316 for unsupported backend gaps: `brev-provision`, Slurm, gcloud, and AWS.

## Verification
- `python -m py_compile scripts/training/launch_pan_allele_training_remote.py`
- `bash -n scripts/release/retrain_evaluate_deploy.sh`
- `scripts/release/retrain_evaluate_deploy.sh --run-dir /tmp/mhcflurry-rename-dryrun --release 2.3.0 --backend brev-existing --skip-train --skip-eval --skip-plots --skip-deploy --dry-run`
- `scripts/release/retrain_evaluate_deploy.sh --run-dir /tmp/mhcflurry-rename-dryrun --release 2.3.0 --backend ssh --remote user@example --remote-repo /repo --remote-run-dir /remote/run --skip-train --skip-eval --skip-plots --skip-deploy --dry-run`
- `git diff --check`
- `./lint.sh`
- `pytest test/test_cli.py -q`
- `pytest test/` -> 630 passed, 7 skipped