### PR TITLE
Prepare rc15 documentation and maintenance fixes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,10 @@ on:
     branches: ["master"]
   workflow_dispatch:
 
+concurrency:
+  group: documentation-pages-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -70,11 +74,21 @@ jobs:
       contents: write
 
     steps:
+      - name: Checkout archived documentation
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+          path: archived-docs
+          sparse-checkout: previous-versions
+
       - name: Download rendered documentation
         uses: actions/download-artifact@v4
         with:
           name: documentation-html
           path: documentation-html
+
+      - name: Preserve archived documentation
+        run: cp -R archived-docs/previous-versions documentation-html/
 
       - name: Publish GitHub Pages branch
         uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,84 @@
+name: Documentation
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["master"]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      MHCFLURRY_DATA_DIR: ${{ github.workspace }}/.mhcflurry-data
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: |
+            docs/requirements.txt
+            setup.py
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pandoc
+
+      - name: Install package and documentation dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .
+          python -m pip install -r docs/requirements.txt
+
+      - name: Cache presentation models
+        uses: actions/cache@v4
+        with:
+          path: .mhcflurry-data
+          key: mhcflurry-docs-data-${{ runner.os }}-${{ hashFiles('mhcflurry/downloads.yml') }}
+          restore-keys: |
+            mhcflurry-docs-data-${{ runner.os }}-
+
+      - name: Download presentation models
+        run: mhcflurry downloads fetch models_class1_presentation
+
+      - name: Build documentation
+        run: |
+          make -C docs generate
+          make -C docs html SPHINXOPTS=-W
+          make -C docs doctest SPHINXOPTS=-W
+
+      - name: Save rendered documentation
+        uses: actions/upload-artifact@v4
+        with:
+          name: documentation-html
+          path: docs/_build/html
+
+  publish:
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/master'
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Download rendered documentation
+        uses: actions/download-artifact@v4
+        with:
+          name: documentation-html
+          path: documentation-html
+
+      - name: Publish GitHub Pages branch
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: documentation-html
+          force_orphan: true

--- a/README.md
+++ b/README.md
@@ -19,14 +19,14 @@ for candidate epitopes, or train models on your own data.
 Install MHCflurry and download the pretrained presentation models:
 
 ```shell
-pip install mhcflurry
-mhcflurry-downloads fetch models_class1_presentation
+pip install --pre mhcflurry
+mhcflurry downloads fetch models_class1_presentation
 ```
 
 Predict a few peptides:
 
 ```shell
-mhcflurry-predict \
+mhcflurry predict \
     --alleles HLA-A0201 HLA-A0301 \
     --peptides SIINFEKL SIINFEKD SIINFEKQ \
     --out predictions.csv
@@ -35,7 +35,7 @@ mhcflurry-predict \
 Or scan a protein sequence for candidate ligands:
 
 ```shell
-mhcflurry-predict-scan \
+mhcflurry predict-scan \
     --sequences MFVFLVLLPLVSSQCVNLTTRTQLPPAYTNSFTRGVYYPDKVFRSSVLHS \
     --alleles 'HLA-A*02:01' \
     --out scan.csv
@@ -45,22 +45,19 @@ To try MHCflurry without installing anything, open the
 [Colab notebook](https://colab.research.google.com/github/openvax/mhcflurry/blob/master/notebooks/mhcflurry-colab.ipynb).
 
 > [!IMPORTANT]
-> The current source tree documents the 2.3.0 release candidate
-> (`2.3.0rc14`). Install it with `pip install --pre mhcflurry` or
-> `pip install mhcflurry==2.3.0rc14`. A normal `pip install mhcflurry` stays on
-> the latest stable 2.2.x release until 2.3.0 is final.
+> This source tree documents `2.3.0rc15`. Use
+> `pip install mhcflurry==2.3.0rc15` for that exact version. Omitting `--pre`
+> installs the latest stable 2.2.x release until 2.3.0 is final.
 
-In 2.3.0, the same commands are also available through one parent command, for
-example `mhcflurry predict` and `mhcflurry predict-scan`. The historical
-`mhcflurry-*` commands remain supported. See the
-[2.3.0 release notes](RELEASE_NOTES_2.3.0.md) for training, performance, and
-evaluation changes.
+The historical `mhcflurry-*` command names remain supported for existing
+scripts. See the [2.3.0 release notes](RELEASE_NOTES_2.3.0.md) for details.
 
 ## Documentation
 
 - [Introduction and installation](https://openvax.github.io/mhcflurry/intro.html)
 - [Command-line tutorial](https://openvax.github.io/mhcflurry/commandline_tutorial.html)
 - [Python tutorial](https://openvax.github.io/mhcflurry/python_tutorial.html)
+- [Training models](https://openvax.github.io/mhcflurry/training.html)
 - [Command reference](https://openvax.github.io/mhcflurry/commandline_tools.html)
 - [API reference](https://openvax.github.io/mhcflurry/api.html)
 

--- a/RELEASE_NOTES_2.3.0.md
+++ b/RELEASE_NOTES_2.3.0.md
@@ -4,25 +4,28 @@ Release-candidate notes for 2.3.0. Held in this file (vs upstream into a
 single `CHANGELOG.md`) until after the validation training run completes
 and any last revisions land; will move to `CHANGELOG.md` at tag time.
 
-## Headline
+## rc15
 
-Pan-allele training pipeline modernization. ``fit()`` now defaults to
-**device-resident** tensors on CUDA — the inner training loop, random-
-negative pool, and validation forward pass all stay on-GPU, closing the
-GPU-starvation gap that the host-side batching path was working
-around. The post-training pipeline (select → calibrate → eval → plot)
-is unified into a single resumable script, and calibration runs on
-device end-to-end (`PercentRankTransform.fit_batch_torch`,
-`motif_summary.motif_summary_chunk_gpu`) for an additional per-worker speedup on
-top of the legacy `--gpu-batched` allele batching. Recipe tightening
-(``min_delta=1e-7``, ``max_epochs=500``) kills the patience-reset
-noise tail. Auto-resolvers pick workers/dataloader/compile settings
-from hardware so per-box tuning stops being manual.
+- Make the unified `mhcflurry` command primary throughout user documentation.
+- Clarify allele, genotype, and sample semantics in CLI help and tutorials;
+  `predict-scan` now accepts semicolon-delimited genotypes like `predict`.
+- Move detailed training configuration out of the beginner tutorial into a
+  dedicated training guide.
+- Remove the unused `--proteome-peptides` argument from model-selection decoy
+  generation.
 
-The orchestrator-as-locus-of-control architecture is documented in
-[docs/orchestrator.md](docs/orchestrator.md) — read that for the
-"who owns what" picture across parallelism, tensor residency, and env
-knobs.
+## Summary
+
+MHCflurry 2.3 modernizes pan-allele training and release evaluation:
+
+- affinity training keeps its working tensors on the active device;
+- one resumable workflow covers selection, calibration, evaluation, and plots;
+- automatic resource planning replaces machine-specific worker overrides; and
+- training defaults stop unproductive runs earlier.
+
+The sections below describe measured performance, behavioral changes, and
+compatibility. Maintainer-level parallelism and tensor-residency details are in
+[docs/orchestrator.md](docs/orchestrator.md).
 
 No changes to the prediction interface. **Saved 2.2.x model bundles remain
 compatible, and predictions for valid class-I alleles are unchanged.** Loading
@@ -60,7 +63,7 @@ validation run completes.
 
 | Hyperparameter | 2.2.x | 2.3.0 | Why |
 |---|---|---|---|
-| `max_epochs` | 5000 | 500 | Median observed was 67; max 174. The 5000 ceiling was theatrical and let pathological patience-reset tasks burn unbounded compute. 500 leaves comfortable headroom. |
+| `max_epochs` | 5000 | 500 | Observed runs had a median of 67 epochs and a maximum of 174; 500 retains headroom while bounding pathological runs. |
 | `min_delta` | 0.0 | 1e-7 | With `min_delta=0`, a 1e-9 RMSprop noise-floor improvement resets the 20-epoch patience counter, stretching some tasks to 174+ epochs at val_loss ~0.28 with no real signal. 1e-7 is two orders of magnitude above the observed noise rate; preserves real escape trajectories (typically ≥1e-3/epoch). |
 | `validation_interval` | 1 (always validated) | 5 | Skip the validation forward pass on 4 of 5 epochs; saves ~150 ms/epoch + a GPU sync barrier. The final epoch and any patience-trigger epoch are always measured (the saved model reflects an up-to-date val_loss). |
 | `dataloader_num_workers` (job-env default) | 0 | 1 | Applies to streaming pretraining batches only. Affinity fine-tuning no longer uses a per-fit DataLoader; it batches from device-resident tensors. One streaming worker per fit is the release wrapper default; tune upward only when CPU headroom and measurements justify it. |
@@ -111,7 +114,7 @@ validation run completes.
   passes `--gpu-batched` and uses larger chunk sizes. Bit-identical
   on CUDA per the existing flag's behavior (issue #272).
 
-## Behavioral changes worth knowing
+## Behavioral changes
 
 ### Training and calibration are reproducible by default (`--random-seed`)
 
@@ -137,8 +140,7 @@ matching `seed=` keyword (defaults to `None` = the prior stochastic behavior
 for direct API callers).
 
 **Reproducibility caveats.** "Bit-for-bit" is exact on CPU and for the default
-(Linear/RMSprop) affinity/processing architecture. Two scope conditions are
-worth knowing:
+(Linear/RMSprop) affinity/processing architecture. Two limits apply:
 
 - **Fixed effective minibatch size.** `fit()` may shrink the minibatch to fit
   available VRAM, and that shrink depends on free GPU memory and how many

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,18 +6,19 @@ orphan: true
 
 To generate Sphinx documentation, from this directory run:
 
-```
-$ pip install -r requirements.txt  # for the first time you generate docs
-$ make generate html
+```shell
+pip install -r requirements.txt  # first build only
+make generate html
 ```
 
-Documentation is written to the _build/ directory. These files should not be
-checked into the repo.
+Documentation is written to `_build/html`. These files should not be checked
+into the source branch. Pull requests build and test the docs; merges to
+`master` publish them to the `gh-pages` branch.
 
 To test example code:
-```
-$ make doctest 
+
+```shell
+make doctest
 ```
 
-Then take a look at _build/doctest for detailed output.
-
+See `_build/doctest` for detailed output.

--- a/docs/commandline_tutorial.md
+++ b/docs/commandline_tutorial.md
@@ -3,6 +3,7 @@
 # Command-line tutorial
 
 (downloading)=
+(downloading-models)=
 
 ## Download models
 

--- a/docs/commandline_tutorial.md
+++ b/docs/commandline_tutorial.md
@@ -4,88 +4,79 @@
 
 (downloading)=
 
-## Downloading models
+## Download models
 
-Most users will use pre-trained MHCflurry models that we release. These models
-are distributed separately from the pip package and may be downloaded with the
-{ref}`mhcflurry-downloads <ref-mhcflurry-downloads>` tool:
+Most users need only the presentation bundle. It includes the binding-affinity
+and antigen-processing components:
 
 ```shell
-$ mhcflurry-downloads fetch models_class1_presentation
+$ mhcflurry downloads fetch models_class1_presentation
 ```
 
-Files downloaded with {ref}`mhcflurry-downloads <ref-mhcflurry-downloads>` are stored in a platform-specific
-directory. To get the path to downloaded data, you can use:
+Downloads are stored outside the Python package in a platform-specific data
+directory. Use `info` to list available bundles and `path` to locate one:
 
-```{command-output} mhcflurry-downloads path models_class1_presentation
+```{command-output} mhcflurry downloads path models_class1_presentation
 :nostderr:
 ```
 
-We also release a number of other "downloads," such as curated training data and some
-experimental models. To see what's available and what you have downloaded, run
-`mhcflurry-downloads info`.
+## Predict peptides
 
-Most users need only `models_class1_presentation`, which includes both the
-binding-affinity and antigen-processing components.
-
-
-## Generating predictions
-
-The {ref}`mhcflurry-predict <ref-mhcflurry-predict>` command generates predictions for individual peptides
-(see the next section for how to scan protein sequences for epitopes). By
-default it will use the pre-trained models you downloaded above. Other
-models can be used by specifying the `--models` argument.
+`mhcflurry predict` scores individual peptides with the downloaded models:
 
 Allele names are parsed as sequence-resolved MHC class I alleles. Invalid,
 ambiguous, class-II, pseudogene, null, or unsupported names produce a specific
 error. Add `--no-throw` when processing mixed-quality tables to keep those rows
 with `NaN` predictions instead.
 
-Running:
-
-```{command-output} mhcflurry-predict --alleles HLA-A0201 HLA-A0301 --peptides SIINFEKL SIINFEKD SIINFEKQ --out /tmp/predictions.csv
+```{command-output} mhcflurry predict --alleles HLA-A0201 HLA-A0301 --peptides SIINFEKL SIINFEKD SIINFEKQ --out /tmp/predictions.csv
 :nostderr:
 ```
-
-results in a file like this:
 
 ```{command-output} cat /tmp/predictions.csv
 ```
 
-The binding predictions are given as predicted affinities in nM in the
-`mhcflurry_affinity` column. Lower values indicate stronger binders. A commonly used
-threshold for peptides with a reasonable chance of being immunogenic is 500 nM.
+| Output | Interpretation |
+|---|---|
+| `mhcflurry_affinity` | Predicted nM affinity; lower is stronger. |
+| `mhcflurry_affinity_percentile` | Allele-specific rank from 0–100; lower is stronger. |
+| `mhcflurry_processing_score` | Allele-independent processing score; higher is stronger. |
+| `mhcflurry_presentation_score` | Combined binding and processing score; higher is stronger. |
 
-The `mhcflurry_affinity_percentile` gives the percentile of the affinity
-prediction among a large number of random peptides tested on that allele (range
-0 - 100). Lower is stronger. Two percent is a commonly-used threshold.
+Affinity thresholds of 500 nM or 2nd percentile are common screening choices.
+Presentation scores are useful for ranking candidates, but there is no
+universal presentation-score threshold.
 
-The last two columns give the antigen processing and presentation scores,
-respectively. These range from 0 to 1 with higher values indicating more
-favorable processing or presentation.
+(allele-input-semantics)=
 
-```{note}
-The processing predictor is experimental. It models allele-independent
-effects that influence whether a
-peptide will be detected in a mass spec experiment. The presentation score is
-a simple logistic regression model that combines the (log) binding affinity
-prediction with the processing score to give a composite prediction. The resulting
-prediction may be useful for prioritizing potential epitopes, but no
-thresholds have been established for what constitutes a "high enough"
-presentation score.
-```
+### Alleles, genotypes, and samples
 
-In most cases you'll want to specify the input as a CSV file instead of passing
-peptides and alleles as commandline arguments. If you're relying on the
-processing or presentation scores, you may also want to pass the upstream and
-downstream sequences of the peptides from their source proteins for potentially more
-accurate cleavage prediction. See the {ref}`mhcflurry-predict <ref-mhcflurry-predict>` docs.
+MHCflurry treats each allele argument or CSV cell as one query. Delimiters
+inside a query (`;`, `,`, or whitespace) combine alleles into one genotype;
+separate command-line arguments remain separate queries.
+
+| Input | Meaning |
+|---|---|
+| `--alleles A0201 A0301 --peptides P1 P2` | Four independent allele–peptide rows. |
+| `--alleles 'A0201;A0301' --peptides P1 P2` | Two genotype–peptide rows; `best_allele` identifies the stronger allele. |
+| CSV rows `P1,A0201` and `P1,A0301` | Two independent rows. |
+| CSV row `P1,A0201;A0301` | One genotype row with the strongest allele reported. |
+
+`mhcflurry predict-scan` uses the same rule: each `--alleles` argument names
+one sample. A quoted comma-separated panel is scored as one group and reports
+the best allele across that group; separate arguments keep per-allele or
+per-genotype results. A large population panel is therefore not the same thing
+as one person's genotype.
+
+For CSV prediction, optional `n_flank` and `c_flank` columns provide source
+protein context for cleavage prediction. See the
+{ref}`command reference <ref-mhcflurry-predict>` for the complete input schema.
 
 
 ## Scanning protein sequences for predicted MHC I ligands
 
-Starting in version 1.6.0, MHCflurry supports scanning proteins for MHC-binding
-peptides using the `mhcflurry-predict-scan` command.
+Use `mhcflurry predict-scan` to score every supported peptide window in a
+protein sequence.
 
 We'll generate predictions across `example.fasta`, a FASTA file with two short
 sequences:
@@ -93,92 +84,31 @@ sequences:
 ```{literalinclude} /example.fasta
 ```
 
-Here's a `mhcflurry-predict-scan` invocation using a 100 nM affinity threshold:
+This invocation keeps peptides predicted to bind at 100 nM or tighter:
 
 ```shell
-$ mhcflurry-predict-scan example.fasta \
+$ mhcflurry predict-scan example.fasta \
     --alleles HLA-A*02:01 \
     --threshold-affinity 100
 ```
 
-See the {ref}`mhcflurry-predict-scan <ref-mhcflurry-predict-scan>` docs for more options.
+See the {ref}`command reference <ref-mhcflurry-predict-scan>` for FASTA/CSV
+input, presentation-score filtering, peptide lengths, and output options.
 
 
-## Fitting your own models
+## Training models
 
-If you have your own data and want to fit your own MHCflurry models, you have
-a few options. If you have data for only one or a few MHC I alleles, the best
-approach is to use the
-{ref}`mhcflurry-class1-train-allele-specific-models <ref-mhcflurry-class1-train-allele-specific-models>` command to fit an
-"allele-specific" predictor, in which separate neural networks are used for
-each allele.
+Training is an advanced workflow; most users should use the released models.
+If you have custom measurements, choose the smallest workflow that matches the
+data:
 
-To call {ref}`mhcflurry-class1-train-allele-specific-models <ref-mhcflurry-class1-train-allele-specific-models>` you'll need some
-training data. The data we use for our released predictors can be downloaded with
-{ref}`mhcflurry-downloads <ref-mhcflurry-downloads>`:
+- allele-specific affinity models for one or a few well-covered alleles;
+- pan-allele affinity models for measurements spanning many alleles; or
+- `mhcflurry train pan-allele-release` for a complete retrain, selection,
+  calibration, and evaluation run.
 
-```shell
-$ mhcflurry-downloads fetch data_curated
-```
-
-It looks like this:
-
-```{command-output} bzcat "$(mhcflurry-downloads path data_curated)/curated_training_data.csv.bz2" | head -n 3
-:shell:
-:nostderr:
-```
-
-Here's an example invocation to fit a predictor:
-
-```shell
-$ mhcflurry-class1-train-allele-specific-models \
-    --data curated_training_data.csv.bz2 \
-    --hyperparameters hyperparameters.yaml \
-    --min-measurements-per-allele 75 \
-    --out-models-dir models
-```
-
-The `hyperparameters.yaml` file gives the list of neural network architectures
-to train models for. Here's an example specifying a single architecture:
-
-```yaml
-- activation: tanh
-  dense_layer_l1_regularization: 0.0
-  dropout_probability: 0.0
-  early_stopping: true
-  layer_sizes: [8]
-  locally_connected_layers: []
-  loss: custom:mse_with_inequalities
-  max_epochs: 500
-  minibatch_size: 16384
-  n_models: 4
-  output_activation: sigmoid
-  patience: 20
-  peptide_amino_acid_encoding: BLOSUM62
-  random_negative_affinity_max: 50000.0
-  random_negative_affinity_min: 20000.0
-  random_negative_constant: 25
-  random_negative_rate: 0.0
-  validation_split: 0.1
-```
-
-The available hyperparameters for binding predictors are defined in
-{class}`~mhcflurry.Class1NeuralNetwork`. To see exactly how
-these are used you will need to read the source code.
-
-The output directory is a complete predictor and can be passed to prediction
-commands with `--models`. Its `manifest.csv` records the component models; do
-not copy individual weight files out of that directory.
-
-To fit pan-allele models like the ones released with MHCflurry, you can use
-a similar tool, {ref}`mhcflurry-class1-train-pan-allele-models <ref-mhcflurry-class1-train-pan-allele-models>`. You'll probably
-also want to take a look at the scripts used to generate the production models,
-which are available in the *downloads-generation* directory in the MHCflurry
-repository. See the scripts in the *models_class1_pan* subdirectory to see how the
-fitting and model selection was done for models currently distributed with MHCflurry.
-
-Released ensembles evaluate many architectures, but smaller searches can be
-trained with substantially fewer resources.
+The {doc}`training` guide covers input schemas, hyperparameters, output bundles,
+and release-style training without interrupting this prediction tutorial.
 
 
 ## Evaluating trained models
@@ -206,11 +136,11 @@ MHCflurry still distributes the allele-specific predictors described in the
 2018 paper. Download them and pass their model directory explicitly:
 
 ```shell
-$ mhcflurry-downloads fetch models_class1
-$ mhcflurry-predict \
+$ mhcflurry downloads fetch models_class1
+$ mhcflurry predict \
     --alleles HLA-A0201 HLA-A0301 \
     --peptides SIINFEKL SIINFEKD SIINFEKQ \
-    --models "$(mhcflurry-downloads path models_class1)/models" \
+    --models "$(mhcflurry downloads path models_class1)/models" \
     --out /tmp/predictions.csv
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,14 +8,14 @@ prediction, then choose a task-oriented guide below.
 
 - {doc}`intro` explains the three prediction types and gets you to a first
   result.
-- {doc}`commandline_tutorial` covers peptide prediction, protein scanning, and
-  model training.
+- {doc}`commandline_tutorial` covers peptide prediction and protein scanning.
 - {doc}`python_tutorial` shows the same predictors through the Python API.
 
 ## Common next steps
 
 - {doc}`evaluation` compares trained models and builds diagnostic or
   publication-style figures.
+- {doc}`training` explains custom model fitting and release-style retraining.
 - {doc}`configuration` explains automatic hardware planning, runtime defaults,
   and reproducibility.
 - {doc}`commandline_tools` and {doc}`api` are the complete references.
@@ -38,6 +38,7 @@ python_tutorial
 :hidden:
 
 evaluation
+training
 ```
 
 ```{toctree}

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -19,23 +19,19 @@ detected automatically.
 
 ## Install MHCflurry
 
-Install the latest stable release:
-
-```shell
-pip install mhcflurry
-```
-
-The current documentation also covers the 2.3.0 release candidate. To use its
-new unified command and training/evaluation features, install the prerelease:
+This documentation describes the 2.3.0 release candidate. Install it with:
 
 ```shell
 pip install --pre mhcflurry
 ```
 
+To stay on the latest stable 2.2.x release, omit `--pre`. The stable release
+continues to use the historical `mhcflurry-*` command names.
+
 Download the pretrained presentation models:
 
 ```shell
-mhcflurry-downloads fetch models_class1_presentation
+mhcflurry downloads fetch models_class1_presentation
 ```
 
 This bundle includes the binding-affinity and antigen-processing components
@@ -44,13 +40,13 @@ needed for presentation prediction.
 ## Make a first prediction
 
 ```shell
-mhcflurry-predict \
+mhcflurry predict \
     --alleles HLA-A0201 HLA-A0301 \
     --peptides SIINFEKL SIINFEKD SIINFEKQ \
     --out predictions.csv
 ```
 
-The output contains one row per peptide and allele/sample combination. The main
+The output contains one row per peptide and allele or genotype query. The main
 columns are:
 
 - `mhcflurry_affinity`: predicted binding affinity in nM; lower is stronger.
@@ -60,13 +56,16 @@ columns are:
 - `mhcflurry_presentation_score`: combined presentation score from 0–1; higher
   is stronger.
 
-With MHCflurry 2.3.0, the equivalent unified command is `mhcflurry predict`.
-The historical `mhcflurry-*` commands remain supported.
+Separate allele arguments request separate predictions. A delimited allele
+list represents one genotype and reports its strongest-binding allele. See
+{ref}`allele-input-semantics` for examples. Historical `mhcflurry-*` command
+names remain supported for existing scripts.
 
 ## Where to go next
 
-- {doc}`commandline_tutorial`: predict peptides, scan proteins, and train models.
+- {doc}`commandline_tutorial`: predict peptides and scan proteins.
 - {doc}`python_tutorial`: use predictors from Python.
+- {doc}`training`: fit and select custom models.
 - {doc}`evaluation`: compare trained models and generate evaluation figures.
 - {doc}`commandline_tools`: complete generated command reference.
 - {doc}`configuration`: runtime defaults, hardware autosizing, and
@@ -79,8 +78,8 @@ You can install into a conda environment and then use pip normally:
 ```shell
 conda create -q -n mhcflurry-env python=3.10
 conda activate mhcflurry-env
-pip install mhcflurry
-mhcflurry-downloads fetch models_class1_presentation
+pip install --pre mhcflurry
+mhcflurry downloads fetch models_class1_presentation
 ```
 
 MHCflurry supports Python 3.10+ on Linux and macOS. Windows may work but is not

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -5,7 +5,7 @@ orphan: true
 # Orchestrator architecture
 
 > Internals doc — for contributors. End users running
-> `mhcflurry-class1-train-pan-allele-models` don't need to read this.
+> `mhcflurry class1-train-pan-allele-models` don't need to read this.
 
 ## The one-line summary
 

--- a/docs/python_tutorial.md
+++ b/docs/python_tutorial.md
@@ -1,28 +1,15 @@
 # Python library tutorial
 
-The MHCflurry Python API exposes additional options and features beyond those
-supported by the commandline tools and can be more convenient for interactive
-analyses and bioinformatic pipelines. This tutorial gives a basic overview
-of the most important functionality. See the {ref}`API-documentation` for further
-details.
+Use the Python API to add MHCflurry predictions to notebooks and analysis
+pipelines. This page covers the common presentation and affinity calls; the
+{ref}`API-documentation` contains the complete interfaces.
 
 ## Loading a predictor
 
-Most prediction tasks can be performed using the
-{class}`~mhcflurry.Class1PresentationPredictor` class, which provides a programmatic API
-to the functionality in the {ref}`mhcflurry-predict <ref-mhcflurry-predict>` and
-{ref}`mhcflurry-predict-scan <ref-mhcflurry-predict-scan>` commands.
-
-Instances of {class}`~mhcflurry.Class1PresentationPredictor` wrap a
-{class}`~mhcflurry.Class1AffinityPredictor` to generate binding affinity predictions
-and a {class}`~mhcflurry.Class1ProcessingPredictor` to generate antigen processing
-predictions. The presentation score is computed using a logistic regression
-model over binding affinity and processing predictions.
-
-Use the {meth}`~mhcflurry.Class1PresentationPredictor.load` static method to load a
-trained predictor from disk. With no arguments this method will load the predictor
-released with MHCflurry (see {ref}`downloading`). If you pass a path to a
-models directory, then it will load that predictor instead.
+{class}`~mhcflurry.Class1PresentationPredictor` provides binding, processing,
+and combined presentation predictions. Calling `load()` without a path uses
+the downloaded release model (see {ref}`downloading`); pass a model directory
+to load a custom predictor.
 
 ```{doctest}
 >>> from mhcflurry import Class1PresentationPredictor
@@ -49,9 +36,15 @@ predictions:
 [0.02, 0.97]
 ```
 
-Here, the list of alleles is taken to be an individual's MHC I genotype (i.e. up
-to 6 alleles), and the strongest binder across alleles for each peptide is
-reported.
+Here, the allele list is one MHC I genotype (up to six alleles), and the
+strongest binder across that genotype is reported for each peptide.
+
+| Python input | Meaning |
+|---|---|
+| `alleles=["A0201", "A0301"]` | One genotype; one result per peptide. |
+| `alleles={"sample1": [...], "sample2": [...]}` | Multiple named genotypes; one result per sample and peptide. |
+| `Class1AffinityPredictor.predict_to_dataframe(allele="A0201", ...)` | Score every peptide against one allele. |
+| `Class1AffinityPredictor.predict_to_dataframe(alleles=[...], ...)` | Pair each peptide with the allele at the same position. |
 
 ```{note}
 MHCflurry normalizes allele names using the [mhcgnomes](https://github.com/pirl-unc/mhcgnomes)
@@ -65,7 +58,7 @@ raise a descriptive `ValueError` by default. For streaming or mixed-quality
 data, pass `throw=False`; affected prediction rows are retained with `NaN`
 scores (or ignored when another valid allele in the genotype supplies the
 sample's best affinity) while valid inputs are still evaluated. The
-command-line equivalent is `mhcflurry-predict --no-throw`.
+command-line equivalent is `mhcflurry predict --no-throw`.
 
 If you have multiple sample genotypes, you can pass a dict, where the
 keys are arbitrary sample names:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -95,5 +95,5 @@ that cannot be covered at a narrower level.
 `downloads`
 : Tests that require locally cached MHCflurry download bundles. These
   tests should not fetch from the network; missing bundles should fail
-  or skip with an instruction to run `mhcflurry-downloads fetch`
+  or skip with an instruction to run `mhcflurry downloads fetch`
   outside pytest.

--- a/docs/training.md
+++ b/docs/training.md
@@ -1,0 +1,99 @@
+# Training models
+
+Most users should start with the released models. Train a model when you have
+new measurements, need a controlled experiment, or are preparing a release.
+Always evaluate a trained ensemble on held-out data before using it for
+scientific conclusions.
+
+## Choose a workflow
+
+| Data and goal | Command |
+|---|---|
+| One or a few well-covered alleles | `mhcflurry class1-train-allele-specific-models` |
+| Measurements spanning many alleles | `mhcflurry class1-train-pan-allele-models` |
+| Full retrain, selection, calibration, and evaluation | `mhcflurry train pan-allele-release` |
+
+The low-level commands fit candidate models. Production ensembles also require
+model selection and percentile calibration; use the release workflow when you
+need the complete pipeline.
+
+## Training data
+
+Affinity training tables use one row per measurement. The important columns
+are `allele`, `peptide`, `measurement_value`, and `measurement_inequality`.
+Alleles must be sequence-resolved MHC class I names supported by the supplied
+pseudosequence registry.
+
+The curated data used for released models is available as a download:
+
+```shell
+mhcflurry downloads fetch data_curated
+mhcflurry downloads path data_curated
+```
+
+## Small allele-specific example
+
+The training command accepts a YAML list of architectures. This single,
+four-member architecture is suitable for learning the workflow; it is not a
+replacement for the released ensemble search:
+
+```yaml
+- activation: tanh
+  dropout_probability: 0.0
+  early_stopping: true
+  layer_sizes: [8]
+  locally_connected_layers: []
+  loss: custom:mse_with_inequalities
+  max_epochs: 500
+  minibatch_size: 16384
+  n_models: 4
+  output_activation: sigmoid
+  patience: 20
+  peptide_amino_acid_encoding: BLOSUM62
+  random_negative_affinity_max: 50000.0
+  random_negative_affinity_min: 20000.0
+  random_negative_constant: 25
+  random_negative_rate: 0.0
+  validation_split: 0.1
+```
+
+Save it as `hyperparameters.yaml`, then run:
+
+```shell
+mhcflurry class1-train-allele-specific-models \
+    --data "$(mhcflurry downloads path data_curated)/curated_training_data.csv.bz2" \
+    --hyperparameters hyperparameters.yaml \
+    --min-measurements-per-allele 75 \
+    --out-models-dir models
+```
+
+The output directory is a complete predictor. Keep its manifest, metadata, and
+weights together; pass the directory to prediction commands with `--models`.
+
+## Pan-allele and release training
+
+Pan-allele training additionally needs an allele pseudosequence table and a
+model-selection step. Start with the command help and the maintained training
+recipes rather than copying individual flags from an old run:
+
+```shell
+mhcflurry class1-train-pan-allele-models --help
+mhcflurry train pan-allele-release --help
+```
+
+The release workflow can run locally or on a configured remote backend. It
+records source and workflow provenance, resumes completed phases, compares the
+candidate with public models, and copies review artifacts back to the control
+machine. Deployment is opt-in.
+
+Leave worker counts, GPU packing, DataLoader workers, and prediction batches on
+`auto` initially. See {doc}`configuration` before pinning resource values and
+the [maintained training scripts](https://github.com/openvax/mhcflurry/tree/master/scripts/training)
+for the current release recipe.
+
+## Evaluate before use
+
+Run `mhcflurry eval compare-models` against a public baseline and inspect the
+summary metrics and plots. Prediction-affecting changes need held-out evidence,
+not only a successful unit-test run. See {doc}`evaluation` for the evaluation
+workflow.

--- a/docs/training.md
+++ b/docs/training.md
@@ -63,6 +63,7 @@ Save it as `hyperparameters.yaml`, then run:
 mhcflurry class1-train-allele-specific-models \
     --data "$(mhcflurry downloads path data_curated)/curated_training_data.csv.bz2" \
     --hyperparameters hyperparameters.yaml \
+    --allele 'HLA-A*02:01' \
     --min-measurements-per-allele 75 \
     --out-models-dir models
 ```

--- a/docs/training.md
+++ b/docs/training.md
@@ -19,10 +19,15 @@ need the complete pipeline.
 
 ## Training data
 
-Affinity training tables use one row per measurement. The important columns
-are `allele`, `peptide`, `measurement_value`, and `measurement_inequality`.
-Alleles must be sequence-resolved MHC class I names supported by the supplied
-pseudosequence registry.
+Affinity training tables use one row per measurement. Allele-specific training
+requires `allele`, `peptide`, `measurement_value`, and `measurement_type`.
+Use `measurement_type` to identify quantitative or qualitative measurements.
+The optional `measurement_inequality` column records `=`, `<`, or `>`; if the
+column is omitted, all measurements are treated as equalities.
+
+Alleles must be sequence-resolved MHC class I names. Allele-specific training
+does not require a pseudosequence table unless the hyperparameters enable
+cross-allele pretraining with `pretrain_min_points`.
 
 The curated data used for released models is available as a download:
 
@@ -74,8 +79,10 @@ weights together; pass the directory to prediction commands with `--models`.
 ## Pan-allele and release training
 
 Pan-allele training additionally needs an allele pseudosequence table and a
-model-selection step. Start with the command help and the maintained training
-recipes rather than copying individual flags from an old run:
+model-selection step. Each training allele must resolve to a key in that table;
+rows for alleles without a matching pseudosequence are excluded. Start with
+the command help and the maintained training recipes rather than copying
+individual flags from an old run:
 
 ```shell
 mhcflurry class1-train-pan-allele-models --help

--- a/downloads-generation/README.md
+++ b/downloads-generation/README.md
@@ -1,8 +1,10 @@
 # Downloads generation
 
-This directory contains code and instructions needed to *generate* the datasets and trained models published with MHCflurry.
+This directory contains reproducible generators for datasets and trained models
+published with MHCflurry.
 
-If you are only looking to download datasets and trained models, you do not need to use any of this. Just run `mhcflurry-downloads fetch` to download the standard models and datasets.
+Prediction users do not need these generators. Use `mhcflurry downloads fetch`
+to install published models and datasets.
 
 ## Class I Pseudosequence Files
 
@@ -11,10 +13,10 @@ The canonical pseudosequence filename registry is
 hardcoding pseudosequence artifact names:
 
 ```bash
-mhcflurry-pseudosequences list
-mhcflurry-pseudosequences filename --length 39
-mhcflurry-pseudosequences path \
-    --directory "$(mhcflurry-downloads path allele_sequences)" \
+mhcflurry pseudosequences list
+mhcflurry pseudosequences filename --length 39
+mhcflurry pseudosequences path \
+    --directory "$(mhcflurry downloads path allele_sequences)" \
     --length 39 \
     --fallback-legacy
 ```

--- a/downloads-generation/analysis_predictor_info/GENERATE.sh
+++ b/downloads-generation/analysis_predictor_info/GENERATE.sh
@@ -90,7 +90,6 @@ else
     cp $SCRIPT_DIR/generate_model_selection_with_decoys.py .
     time python generate_model_selection_with_decoys.py \
         "$(mhcflurry-downloads path models_class1_pan)/models.combined/model_selection_data.csv.bz2" \
-        --proteome-peptides "$(mhcflurry-downloads path data_references)/uniprot_proteins.csv.bz2" \
         --out "$(pwd)/model_selection_with_decoys.csv"
     bzip2 -f model_selection_with_decoys.csv
 fi

--- a/downloads-generation/analysis_predictor_info/generate_model_selection_with_decoys.py
+++ b/downloads-generation/analysis_predictor_info/generate_model_selection_with_decoys.py
@@ -34,11 +34,6 @@ parser.add_argument(
     metavar="CSV",
     help="Model selection data")
 parser.add_argument(
-    "--proteome-peptides",
-    metavar="CSV",
-    required=True,
-    help="Proteome peptides")
-parser.add_argument(
     "--protein-data",
     metavar="CSV",
     default=get_path("data_references", "uniprot_proteins.csv.bz2", test_exists=False),

--- a/mhcflurry/cli/predict_command.py
+++ b/mhcflurry/cli/predict_command.py
@@ -23,7 +23,7 @@ Examples:
 Write a CSV file containing the contents of INPUT.csv plus additional columns
 giving MHCflurry predictions:
 
-$ mhcflurry-predict INPUT.csv --out RESULT.csv
+$ mhcflurry predict INPUT.csv --out RESULT.csv
 
 The input CSV file is expected to contain columns "allele", "peptide", and,
 optionally, "n_flank", and "c_flank". An allele cell may contain one allele
@@ -36,20 +36,17 @@ You can also run on alleles and peptides specified on the commandline, in
 which case predictions are written for *all combinations* of alleles and
 peptides:
 
-$ mhcflurry-predict --alleles HLA-A0201 H-2Kb --peptides SIINFEKL DENDREKLLL
+$ mhcflurry predict --alleles HLA-A0201 H-2Kb --peptides SIINFEKL DENDREKLLL
 
 Instead of individual alleles (in a CSV or on the command line), you can also
-give a comma separated list of alleles giving a sample genotype. In this case,
+give a comma- or semicolon-separated sample genotype. In this case,
 the tightest binding affinity across the alleles for the sample will be
 returned. For example:
 
-$ mhcflurry-predict --peptides SIINFEKL DENDREKLLL \
-    --alleles \
-        HLA-A*02:01,HLA-A*03:01,HLA-B*57:01,HLA-B*45:01,HLA-C*02:01,HLA-C*07:02 \
-        HLA-A*01:01,HLA-A*02:06,HLA-B*44:02,HLA-B*07:02,HLA-C*01:01,HLA-C*03:01
+$ mhcflurry predict --peptides SIINFEKL --alleles 'HLA-A*02:01;HLA-A*03:01'
 
-will give the tightest predicted affinities across alleles for each of the two
-genotypes specified for each peptide.
+will report the tightest predicted affinity across the two alleles for each
+peptide.
 """
 import sys
 import argparse
@@ -119,7 +116,9 @@ input_args.add_argument(
     "--alleles",
     metavar="ALLELE",
     nargs="+",
-    help="Alleles to predict (exclusive with passing an input CSV)")
+    help="Allele or genotype queries (exclusive with an input CSV). "
+    "Separate arguments are independent queries; delimit alleles within one "
+    "argument with ';' or ',' to score them as one genotype.")
 input_args.add_argument(
     "--peptides",
     metavar="PEPTIDE",
@@ -131,7 +130,8 @@ input_mod_args.add_argument(
     "--allele-column",
     metavar="NAME",
     default="allele",
-    help="Input column name for alleles. Default: '%(default)s'")
+    help="Input column name for allele or delimited-genotype queries. "
+    "Default: '%(default)s'")
 input_mod_args.add_argument(
     "--peptide-column",
     metavar="NAME",

--- a/mhcflurry/cli/predict_scan_command.py
+++ b/mhcflurry/cli/predict_scan_command.py
@@ -22,9 +22,7 @@ Examples:
 Scan a set of sequences in a FASTA file for binders to any alleles in a MHC I
 genotype:
 
-$ mhcflurry-predict-scan \
-    test/data/example.fasta \
-    --alleles HLA-A*02:01,HLA-A*03:01,HLA-B*57:01,HLA-B*45:01,HLA-C*02:01,HLA-C*07:02
+$ mhcflurry predict-scan test/data/example.fasta --alleles 'HLA-A*02:01;HLA-A*03:01'
 
 Instead of a FASTA, you can also pass a CSV that has "sequence_id" and "sequence"
 columns.
@@ -32,19 +30,13 @@ columns.
 You can also specify multiple MHC I genotypes to scan as space-separated
 arguments to the --alleles option:
 
-$ mhcflurry-predict-scan \
-    test/data/example.fasta \
-    --alleles \
-        HLA-A*02:01,HLA-A*03:01,HLA-B*57:01,HLA-B*45:01,HLA-C*02:02,HLA-C*07:02 \
-        HLA-A*01:01,HLA-A*02:06,HLA-B*44:02,HLA-B*07:02,HLA-C*01:02,HLA-C*03:01
+$ mhcflurry predict-scan example.fasta --alleles 'A0201;A0301' 'B0702;B0801'
 
 If `--out` is not specified, results are written to standard out.
 
 You can also specify sequences on the commandline:
 
-mhcflurry-predict-scan \
-    --sequences MGYINVFAFPFTIYSLLLCRMNSRNYIAQVDVVNFNLT \
-    --alleles HLA-A*02:01,HLA-A*03:01,HLA-B*57:01,HLA-B*45:01,HLA-C*02:02,HLA-C*07:02
+mhcflurry predict-scan --sequences MGYINVFAFPFTIYSLLLCRMNSRNYIAQVDVVNFNLT --alleles HLA-A*02:01
 
 """
 import sys
@@ -118,7 +110,8 @@ input_args.add_argument(
     "--alleles",
     metavar="ALLELE",
     nargs="+",
-    help="Alleles to predict")
+    help="Sample allele or genotype queries. Each argument is one sample; "
+    "delimit alleles within a sample with ',' or ';'.")
 input_args.add_argument(
     "--sequences",
     metavar="SEQ",
@@ -198,7 +191,7 @@ model_args.add_argument(
     "--models",
     metavar="DIR",
     default=None,
-    help="Directory containing presentation models."
+    help="Directory containing presentation models. "
     "Default: %s" % get_default_class1_presentation_models_dir(
         test_exists=False))
 model_args.add_argument(
@@ -371,7 +364,7 @@ def run(argv=sys.argv[1:]):
     df = df.set_index(args.sequence_id_column)
 
     if args.alleles:
-        genotypes = pandas.Series(args.alleles).str.split(r"[,\s]+")
+        genotypes = pandas.Series(args.alleles).str.split(r"[;,\s]+")
         genotypes.index = genotypes.index.map(lambda i: "genotype_%02d" % i)
         alleles = genotypes.to_dict()
     else:

--- a/mhcflurry/version.py
+++ b/mhcflurry/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.3.0rc14"
+__version__ = "2.3.0rc15"

--- a/test/test_predict_scan_command.py
+++ b/test/test_predict_scan_command.py
@@ -117,7 +117,7 @@ def test_fasta_percentile():
 def test_commandline_sequences():
     args = [
         "--sequences", "ASDFGHKL", "QWERTYIPCVNM",
-        "--alleles", "HLA-A0201,HLA-A0301", "H-2-Kb",
+        "--alleles", "HLA-A0201;HLA-A0301", "H-2-Kb",
         "--peptide-lengths", "8",
         "--results-all",
     ]

--- a/test/test_processing_prep_scripts.py
+++ b/test/test_processing_prep_scripts.py
@@ -65,6 +65,28 @@ def test_generate_scripts_keep_packaged_proteome_peptide_artifacts():
     assert "proteome_peptides.$subset.csv.bz2" in predictions_generate
 
 
+def test_model_selection_decoys_do_not_require_unused_proteome_peptides():
+    module = load_script(
+        REPO_ROOT / "downloads-generation/analysis_predictor_info"
+        / "generate_model_selection_with_decoys.py"
+    )
+
+    args = module.parser.parse_args([
+        "model_selection.csv",
+        "--protein-data", "proteins.csv",
+        "--out", "with_decoys.csv",
+    ])
+    assert args.data == "model_selection.csv"
+    assert args.protein_data == "proteins.csv"
+    assert args.out == "with_decoys.csv"
+    assert not hasattr(args, "proteome_peptides")
+
+    generate = (
+        REPO_ROOT / "downloads-generation/analysis_predictor_info/GENERATE.sh"
+    ).read_text()
+    assert "--proteome-peptides" not in generate
+
+
 @pytest.mark.parametrize("relative_path", [
     "scripts/training/release_exact/make_train_data.processing.py",
     "downloads-generation/models_class1_processing/make_train_data.py",

--- a/test/test_release_provenance.py
+++ b/test/test_release_provenance.py
@@ -16,6 +16,8 @@ import subprocess
 
 import pytest
 
+from mhcflurry.version import __version__ as PACKAGE_VERSION
+
 
 REPO = pathlib.Path(__file__).resolve().parents[1]
 SCRIPT = REPO / "scripts" / "release" / "validate_release_provenance.py"
@@ -51,7 +53,7 @@ def write_model_info(run_dir, version, commit=None, workflow_id="run-123"):
 
 def test_collect_provenance_accepts_matching_release_candidate(tmp_path):
     module = load_module()
-    write_model_info(tmp_path, "2.3.0rc14")
+    write_model_info(tmp_path, PACKAGE_VERSION)
 
     result = module.collect_provenance(
         repo=REPO,
@@ -65,11 +67,11 @@ def test_collect_provenance_accepts_matching_release_candidate(tmp_path):
     )
 
     assert result["release_base_version"] == "2.3.0"
-    assert result["source"]["package_version"] == "2.3.0rc14"
+    assert result["source"]["package_version"] == PACKAGE_VERSION
     assert result["workflow_id"] == "run-123"
     assert {
         item["package_version"] for item in result["artifacts"].values()
-    } == {"2.3.0rc14"}
+    } == {PACKAGE_VERSION}
 
 
 def test_collect_provenance_rejects_mislabeled_model(tmp_path):
@@ -119,7 +121,7 @@ def test_artifact_paths_reject_invalid_processing_variants(
 
 def test_collect_provenance_rejects_model_from_another_commit(tmp_path):
     module = load_module()
-    write_model_info(tmp_path, "2.3.0rc14", commit="deadbeef")
+    write_model_info(tmp_path, PACKAGE_VERSION, commit="deadbeef")
 
     with pytest.raises(ValueError, match="does not match source commit"):
         module.collect_provenance(
@@ -136,7 +138,7 @@ def test_collect_provenance_rejects_model_from_another_commit(tmp_path):
 
 def test_collect_provenance_allows_later_evaluation_workflow(tmp_path):
     module = load_module()
-    write_model_info(tmp_path, "2.3.0rc14", workflow_id="training-run")
+    write_model_info(tmp_path, PACKAGE_VERSION, workflow_id="training-run")
 
     result = module.collect_provenance(
         repo=REPO,
@@ -156,7 +158,7 @@ def test_collect_artifact_provenance_without_git_checkout(tmp_path):
     module = load_module()
     write_model_info(
         tmp_path,
-        "2.3.0rc14",
+        PACKAGE_VERSION,
         commit="remote-commit",
         workflow_id="remote-run",
     )
@@ -175,7 +177,7 @@ def test_collect_artifact_provenance_without_git_checkout(tmp_path):
 
 def test_artifact_only_cli_requires_expected_identity(tmp_path):
     module = load_module()
-    write_model_info(tmp_path, "2.3.0rc14")
+    write_model_info(tmp_path, PACKAGE_VERSION)
 
     with pytest.raises(SystemExit, match="expected-artifact-git-commit"):
         module.main([


### PR DESCRIPTION
## Summary

- reorganize the README and user guides around installation, first prediction, and task-oriented next steps
- move detailed model-training material out of the beginner CLI tutorial into a dedicated training guide
- make the unified `mhcflurry` command primary while retaining compatibility notes for historical entry points
- clarify allele, genotype, and sample semantics in CLI help and docs, including semicolon-delimited scan genotypes
- automatically build documentation on PRs and publish merged docs to the existing `gh-pages` site
- remove the unused required `--proteome-peptides` argument from analysis decoy generation
- bump the package version to `2.3.0rc15`

## Documentation audit

The opening pages now answer, in order: what MHCflurry predicts, which predictor to use, how to install it, and how to make a first prediction. Operational details, full command references, evaluation, and training are linked as later task-specific guides instead of appearing as long blocks before the first useful example.

The public site currently serves documentation generated in July 2020. The new workflow builds HTML with warnings treated as errors, runs the documentation examples, and publishes successful `master` builds to the repository's configured `gh-pages` branch.

## Validation

- `./lint.sh`
- focused regression suite: 43 passed
- full suite before the version-fixture cleanup: 936 passed, with the sole failure being the fixture's hard-coded `2.3.0rc14`; the corrected provenance tests then passed 9/9
- `make -C docs html SPHINXOPTS=-W`
- `make -C docs doctest SPHINXOPTS=-W` (20 passed)
- `python setup.py check`
- shell syntax and workflow-YAML checks

Fixes #236
Fixes #285
Fixes #289
