### PR TITLE
Credit MHCflurry contributors in documentation

### DIFF
--- a/RELEASE_NOTES_2.3.0.md
+++ b/RELEASE_NOTES_2.3.0.md
@@ -4,6 +4,11 @@ Release-candidate notes for 2.3.0. Held in this file (vs upstream into a
 single `CHANGELOG.md`) until after the validation training run completes
 and any last revisions land; will move to `CHANGELOG.md` at tag time.
 
+## rc16
+
+- Credit all MHCflurry contributors in generated documentation metadata and
+  the site footer.
+
 ## rc15
 
 - Make the unified `mhcflurry` command primary throughout user documentation.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -105,8 +105,8 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'MHCflurry'
-copyright = 'Timothy O\'Donnell'
-author = 'Timothy O\'Donnell'
+copyright = '2017–2026, MHCflurry contributors'
+author = 'MHCflurry contributors'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/mhcflurry/version.py
+++ b/mhcflurry/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.3.0rc15"
+__version__ = "2.3.0rc16"


### PR DESCRIPTION
## Summary

- replace the generated documentation's individual copyright attribution with `2017–2026, MHCflurry contributors`
- use `MHCflurry contributors` as the generated-document author metadata
- bump the package version to `2.3.0rc16`

## Why

The documentation has substantial contributions from multiple people, so naming one person in the global footer is incomplete. A collective contributor notice reflects the project history without implying that AI tools are copyright holders. Current [U.S. Copyright Office guidance](https://www.copyright.gov/newsnet/2025/1060.html) distinguishes human authorship from purely AI-generated material while preserving protection for human-authored and human-arranged work made with AI assistance.

## Validation

- `./lint.sh`
- `python setup.py check`
- `python -m pytest -q test/test_release_provenance.py` (9 passed)
- `make -C docs html SPHINXOPTS=-W`
- `make -C docs doctest SPHINXOPTS=-W` (20 passed)
- rendered footer inspected in `docs/_build/html/index.html`
