### PR TITLE
Update GitHub Actions to Node 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: 3.11
           cache: pip
@@ -27,7 +27,7 @@ jobs:
           python -m build -sw
           ls -lh dist/
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -39,7 +39,7 @@ jobs:
           sudo apt-get install -y pandoc
 
       - name: Cache Conda packages
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         env:
           CACHE_NUMBER: 0
         with:
@@ -83,7 +83,7 @@ jobs:
       #    # flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
       - name: Cache MHCflurry downloads
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: .mhcflurry-data
           key: mhcflurry-data-${{ runner.os }}-${{ hashFiles('mhcflurry/downloads.yml') }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
           cache: pip
@@ -44,7 +44,7 @@ jobs:
           python -m pip install -r docs/requirements.txt
 
       - name: Cache presentation models
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: .mhcflurry-data
           key: mhcflurry-docs-data-${{ runner.os }}-${{ hashFiles('mhcflurry/downloads.yml') }}
@@ -61,7 +61,7 @@ jobs:
           make -C docs doctest SPHINXOPTS=-W
 
       - name: Save rendered documentation
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: documentation-html
           path: docs/_build/html
@@ -75,14 +75,14 @@ jobs:
 
     steps:
       - name: Checkout archived documentation
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: gh-pages
           path: archived-docs
           sparse-checkout: previous-versions
 
       - name: Download rendered documentation
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: documentation-html
           path: documentation-html

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,9 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-

--- a/.github/workflows/release_testpypi.yml
+++ b/.github/workflows/release_testpypi.yml
@@ -17,7 +17,7 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: dist
           path: dist

--- a/RELEASE_NOTES_2.3.0.md
+++ b/RELEASE_NOTES_2.3.0.md
@@ -4,6 +4,12 @@ Release-candidate notes for 2.3.0. Held in this file (vs upstream into a
 single `CHANGELOG.md`) until after the validation training run completes
 and any last revisions land; will move to `CHANGELOG.md` at tag time.
 
+## rc17
+
+- Move first-party GitHub Actions to their Node.js 24 releases, removing
+  deprecated Node.js 20 runtime warnings from CI, documentation, and package
+  publishing workflows.
+
 ## rc16
 
 - Credit all MHCflurry contributors in generated documentation metadata and

--- a/mhcflurry/version.py
+++ b/mhcflurry/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.3.0rc16"
+__version__ = "2.3.0rc17"


### PR DESCRIPTION
## Summary

- update first-party GitHub Actions to their current Node.js 24 major releases
- cover CI, documentation, reusable package builds, PyPI, and TestPyPI workflows
- bump the package version to 2.3.0rc17

## Root cause

The workflows pinned action majors whose bundled JavaScript targets Node.js
20. GitHub now forces those actions onto Node.js 24 and emits deprecation
annotations on every run.

The replacement majors are `actions/checkout@v7`,
`actions/setup-python@v7`, `actions/cache@v6`,
`actions/upload-artifact@v7`, and `actions/download-artifact@v8`. These
workflows use only stable inputs and run on GitHub-hosted runners, which
satisfy the new runner requirement.

## Verification

- `./lint.sh`
- `python -m pytest test/` — 937 passed
- `python setup.py --version` — `2.3.0rc17`
- `git diff --check`

Closes #355.
