### PR TITLE
Keep install guidance version agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,15 @@ for candidate epitopes, or train models on your own data.
 
 ## Quick start
 
-Install MHCflurry and download the pretrained presentation models:
+Install MHCflurry, including prereleases, and download the pretrained
+presentation models:
 
 ```shell
-pip install --pre mhcflurry
+pip install --upgrade --pre mhcflurry
 mhcflurry downloads fetch models_class1_presentation
 ```
+
+Omit `--pre` to install the latest stable release.
 
 Predict a few peptides:
 
@@ -43,11 +46,6 @@ mhcflurry predict-scan \
 
 To try MHCflurry without installing anything, open the
 [Colab notebook](https://colab.research.google.com/github/openvax/mhcflurry/blob/master/notebooks/mhcflurry-colab.ipynb).
-
-> [!IMPORTANT]
-> This source tree documents `2.3.0rc15`. Use
-> `pip install mhcflurry==2.3.0rc15` for that exact version. Omitting `--pre`
-> installs the latest stable 2.2.x release until 2.3.0 is final.
 
 The historical `mhcflurry-*` command names remain supported for existing
 scripts. See the [2.3.0 release notes](RELEASE_NOTES_2.3.0.md) for details.

--- a/RELEASE_NOTES_2.3.0.md
+++ b/RELEASE_NOTES_2.3.0.md
@@ -4,6 +4,12 @@ Release-candidate notes for 2.3.0. Held in this file (vs upstream into a
 single `CHANGELOG.md`) until after the validation training run completes
 and any last revisions land; will move to `CHANGELOG.md` at tag time.
 
+## rc18
+
+- Make README and installation-guide prerelease instructions independent of
+  the current release-candidate number so they cannot become stale on later
+  releases.
+
 ## rc17
 
 - Move first-party GitHub Actions to their Node.js 24 releases, removing

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -19,14 +19,14 @@ detected automatically.
 
 ## Install MHCflurry
 
-This documentation describes the 2.3.0 release candidate. Install it with:
+Install MHCflurry, including prereleases, with:
 
 ```shell
-pip install --pre mhcflurry
+pip install --upgrade --pre mhcflurry
 ```
 
-To stay on the latest stable 2.2.x release, omit `--pre`. The stable release
-continues to use the historical `mhcflurry-*` command names.
+Omit `--pre` to install the latest stable release. Older releases may use the
+historical `mhcflurry-*` command names shown in the command reference.
 
 Download the pretrained presentation models:
 

--- a/mhcflurry/version.py
+++ b/mhcflurry/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.3.0rc17"
+__version__ = "2.3.0rc18"

--- a/test/test_packaging.py
+++ b/test/test_packaging.py
@@ -12,10 +12,23 @@
 
 """Packaging metadata tests."""
 
+import re
 import runpy
 from pathlib import Path
 
 import setuptools
+
+
+def test_install_guidance_is_not_pinned_to_a_release():
+    repo_dir = Path(__file__).resolve().parents[1]
+    prerelease = re.compile(r"\b\d+\.\d+\.\d+(?:a|b|rc)\d+\b")
+    stable_series = re.compile(r"\blatest stable \d+\.\d+(?:\.\w+)?\b", re.I)
+
+    for relative_path in ("README.md", "docs/intro.md"):
+        text = (repo_dir / relative_path).read_text()
+        assert "pip install --upgrade --pre mhcflurry" in text
+        assert not prerelease.search(text), relative_path
+        assert not stable_series.search(text), relative_path
 
 
 def test_setup_packages_cli_subpackage(monkeypatch):


### PR DESCRIPTION
## Summary

- replace stale, hard-coded release-candidate installation text with durable
  stable/prerelease guidance
- update the installation guide to use the same wording
- add regression coverage that rejects pinned prerelease or stable-series
  versions in both entry points
- bump the package version to 2.3.0rc18

## Root cause

The README independently embedded `2.3.0rc15` even though package and Sphinx
versions are derived from `mhcflurry/version.py`. Later release bumps therefore
updated package metadata and the documentation footer without updating that
prose. The README is also reused as the PyPI long description, which propagated
the stale statement.

The fix removes the redundant version field instead of adding another manual
synchronization step.

## Verification

- `./lint.sh`
- `python -m pytest test/` — 938 passed
- `make -C docs html SPHINXOPTS=-W`
- `make -C docs doctest SPHINXOPTS=-W` — 20 passed
- `python setup.py --version` — `2.3.0rc18`
- `git diff --check`
