### PR TITLE
Reorganize documentation for progressive disclosure

### DIFF
--- a/RELEASE_NOTES_2.3.0.md
+++ b/RELEASE_NOTES_2.3.0.md
@@ -4,6 +4,12 @@ Release-candidate notes for 2.3.0. Held in this file (vs upstream into a
 single `CHANGELOG.md`) until after the validation training run completes
 and any last revisions land; will move to `CHANGELOG.md` at tag time.
 
+## rc19
+
+- Reorganize the user documentation around progressive disclosure: explain
+  prediction concepts and common workflows first, then introduce score
+  interpretation, schemas, performance overrides, and exhaustive references.
+
 ## rc18
 
 - Make README and installation-guide prerelease instructions independent of

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,6 +2,10 @@
 
 # API Documentation
 
+This is the complete generated API reference. Start with the
+{doc}`python_tutorial` for the common prediction workflow, then use this page to
+look up individual classes and methods.
+
 ```{include} _build/mhcflurry.rst
 :start-line: 2
 ```

--- a/docs/commandline_tools.md
+++ b/docs/commandline_tools.md
@@ -1,6 +1,8 @@
 # Command-line reference
 
-See also the {ref}`tutorial <commandline_tutorial>`.
+This page lists every command and option. If you are new to MHCflurry or are
+choosing a workflow, start with the {ref}`tutorial <commandline_tutorial>` and
+return here to look up specific arguments.
 
 MHCflurry 2.3.0 provides a unified `mhcflurry` command while retaining the
 historical `mhcflurry-*` names. Both forms use the same implementation. See

--- a/docs/commandline_tutorial.md
+++ b/docs/commandline_tutorial.md
@@ -2,6 +2,11 @@
 
 # Command-line tutorial
 
+This tutorial follows the common workflow: download the released models, score
+peptides, then scan proteins for candidate ligands. Most users can stop there;
+training, evaluation, configuration, and exhaustive flag descriptions are
+linked later.
+
 (downloading)=
 (downloading-models)=
 
@@ -25,11 +30,6 @@ directory. Use `info` to list available bundles and `path` to locate one:
 
 `mhcflurry predict` scores individual peptides with the downloaded models:
 
-Allele names are parsed as sequence-resolved MHC class I alleles. Invalid,
-ambiguous, class-II, pseudogene, null, or unsupported names produce a specific
-error. Add `--no-throw` when processing mixed-quality tables to keep those rows
-with `NaN` predictions instead.
-
 ```{command-output} mhcflurry predict --alleles HLA-A0201 HLA-A0301 --peptides SIINFEKL SIINFEKD SIINFEKQ --out /tmp/predictions.csv
 :nostderr:
 ```
@@ -47,6 +47,11 @@ with `NaN` predictions instead.
 Affinity thresholds of 500 nM or 2nd percentile are common screening choices.
 Presentation scores are useful for ranking candidates, but there is no
 universal presentation-score threshold.
+
+Allele names are parsed as sequence-resolved MHC class I alleles. Invalid,
+ambiguous, class-II, pseudogene, null, or unsupported names produce a specific
+error. Add `--no-throw` when processing mixed-quality tables to keep those rows
+with `NaN` predictions instead.
 
 (allele-input-semantics)=
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,23 +5,6 @@ Most users should start without environment-variable overrides or fixed worker
 counts, then pin a value only when reproducing a benchmark or diagnosing a
 specific machine.
 
-## Runtime defaults
-
-`MHCFLURRY_DEFAULT_CLASS1_MODELS`
-: Path to the default model directory. If unset, MHCflurry uses the models from
-  the installed download bundle.
-
-`MHCFLURRY_OPTIMIZATION_LEVEL`
-: Controls pan-allele ensemble merging. The default, `1`, enables the faster
-  merged-network path. Set it to `0` when debugging or comparing the unmerged
-  implementation.
-
-`MHCFLURRY_DEFAULT_PREDICT_BATCH_SIZE`
-: Overrides the default prediction batch size. The normal value is `auto`,
-  which sizes batches from available device memory and can retry with a smaller
-  batch after an allocator out-of-memory error. A fixed integer disables that
-  resizing behavior and should be used only when you know the workload fits.
-
 ## Automatic hardware planning
 
 Prediction, training, calibration, selection, and evaluation commands share a
@@ -56,6 +39,26 @@ machine, but it also bypasses some automatic safeguards.
 
 See {doc}`orchestrator` for implementation details and expert environment
 overrides.
+
+## Environment overrides
+
+These variables are intended for custom model locations, debugging, and
+controlled benchmarks. Ordinary prediction and training do not require them.
+
+`MHCFLURRY_DEFAULT_CLASS1_MODELS`
+: Path to the default model directory. If unset, MHCflurry uses the models from
+  the installed download bundle.
+
+`MHCFLURRY_OPTIMIZATION_LEVEL`
+: Controls pan-allele ensemble merging. The default, `1`, enables the faster
+  merged-network path. Set it to `0` when debugging or comparing the unmerged
+  implementation.
+
+`MHCFLURRY_DEFAULT_PREDICT_BATCH_SIZE`
+: Overrides the default prediction batch size. The normal value is `auto`,
+  which sizes batches from available device memory and can retry with a smaller
+  batch after an allocator out-of-memory error. A fixed integer disables that
+  resizing behavior and should be used only when you know the workload fits.
 
 ## Reproducible training
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,9 @@
 
 MHCflurry predicts MHC class I binding affinity, antigen processing, and peptide
 presentation. Start with the introduction for installation and a first
-prediction, then choose a task-oriented guide below.
+prediction, then choose either the command-line or Python tutorial. The
+reference pages are intentionally exhaustive and are best used to look up a
+specific option after you know which workflow you need.
 
 ## Start here
 
@@ -13,10 +15,10 @@ prediction, then choose a task-oriented guide below.
 
 ## Common next steps
 
+- {doc}`training` explains custom model fitting and release-style retraining.
 - {doc}`evaluation` compares trained models and builds diagnostic or
   publication-style figures.
-- {doc}`training` explains custom model fitting and release-style retraining.
-- {doc}`configuration` explains automatic hardware planning, runtime defaults,
+- {doc}`configuration` explains automatic hardware planning, expert overrides,
   and reproducibility.
 - {doc}`commandline_tools` and {doc}`api` are the complete references.
 
@@ -37,8 +39,8 @@ python_tutorial
 :caption: User guides
 :hidden:
 
-evaluation
 training
+evaluation
 ```
 
 ```{toctree}

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,13 +1,13 @@
 # Introduction and installation
 
 MHCflurry predicts which peptides are likely to be displayed by MHC class I
-molecules. It includes pretrained models and tools for three related tasks:
+molecules. Its pretrained models answer three related questions:
 
-| Prediction | What it answers | Output direction |
-|---|---|---|
-| Binding affinity | How strongly does this peptide bind this MHC allele? | Lower affinity in nM is stronger. |
-| Antigen processing | Does cellular processing favor this peptide? | Higher score is stronger. |
-| Presentation | Is this peptide likely to be presented, considering binding and processing? | Higher score is stronger. |
+- **Binding affinity:** can this peptide bind a particular MHC allele?
+- **Antigen processing:** is cellular processing likely to produce this
+  peptide?
+- **Presentation:** is the peptide likely to reach the cell surface, considering
+  both binding and processing?
 
 For most epitope-prioritization work, start with the **presentation** predictor.
 Use binding affinity when you specifically need peptide–MHC binding estimates,
@@ -46,15 +46,17 @@ mhcflurry predict \
     --out predictions.csv
 ```
 
-The output contains one row per peptide and allele or genotype query. The main
-columns are:
+## Understand the results
 
-- `mhcflurry_affinity`: predicted binding affinity in nM; lower is stronger.
-- `mhcflurry_affinity_percentile`: allele-specific rank from 0–100; lower is
-  stronger.
-- `mhcflurry_processing_score`: processing score from 0–1; higher is stronger.
-- `mhcflurry_presentation_score`: combined presentation score from 0–1; higher
-  is stronger.
+The output contains one row per peptide and allele or genotype query. These are
+the main prediction columns:
+
+| Column | Interpretation |
+|---|---|
+| `mhcflurry_presentation_score` | Combined binding and processing score from 0–1; higher is stronger. |
+| `mhcflurry_affinity` | Predicted binding affinity in nM; lower is stronger. |
+| `mhcflurry_affinity_percentile` | Allele-specific rank from 0–100; lower is stronger. |
+| `mhcflurry_processing_score` | Processing score from 0–1; higher is stronger. |
 
 Separate allele arguments request separate predictions. A delimited allele
 list represents one genotype and reports its strongest-binding allele. See

--- a/docs/python_tutorial.md
+++ b/docs/python_tutorial.md
@@ -4,6 +4,12 @@ Use the Python API to add MHCflurry predictions to notebooks and analysis
 pipelines. This page covers the common presentation and affinity calls; the
 {ref}`API-documentation` contains the complete interfaces.
 
+For most applications, use
+{class}`~mhcflurry.Class1PresentationPredictor`: it returns binding, processing,
+and combined presentation predictions from one interface. Use the lower-level
+affinity or processing predictors only when you need those components by
+themselves.
+
 ## Loading a predictor
 
 {class}`~mhcflurry.Class1PresentationPredictor` provides binding, processing,

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,21 +1,8 @@
 # Testing
 
-The default pytest command is a full test suite. It is not a fast
-unit-only loop.
-
-The suite intentionally covers several layers:
-
-* pure unit tests for encoding, losses, random-negative planning, and
-  argument resolution;
-* small neural-network training tests that verify numerical behavior;
-* command-level subprocess tests that train, select, and calibrate tiny
-  predictors end-to-end;
-* public-model smoke tests that require cached MHCflurry download bundles.
-
-That mix is useful before merging a release branch, but it makes a plain
-`python -m pytest test/` run take many minutes on a laptop. On macOS, prefer
-`python -m pytest` over the generated `pytest` console script so PyTorch can
-see MPS accelerators.
+Use focused tests while iterating and the full suite before merge or release.
+The default pytest command runs unit, training, command-level, and downloaded
+model checks; it is not a fast unit-only loop.
 
 ## Quick local feedback
 
@@ -63,10 +50,21 @@ If the run is unexpectedly slow, ask pytest for the slowest tests:
 $ python -m pytest -q test --durations=25 --durations-min=0.5
 ```
 
-## Current slow buckets
+On macOS, prefer `python -m pytest` over the generated `pytest` console script
+so PyTorch can see MPS accelerators.
 
-The slowest tests are usually not pure unit tests. They are small
-integration tests that do real model work:
+## What the full suite covers
+
+The full suite includes:
+
+* pure unit tests for encoding, losses, random-negative planning, and argument
+  resolution;
+* small neural-network training tests that verify numerical behavior;
+* command-level subprocess tests that train, select, and calibrate tiny
+  predictors end-to-end; and
+* public-model smoke tests that require cached MHCflurry download bundles.
+
+The slowest tests are usually small integration tests that do real model work:
 
 * `test/test_train_pan_allele_models_command.py` runs serial,
   parallel, and cluster-shaped pan-allele train/select command flows.

--- a/docs/training.md
+++ b/docs/training.md
@@ -17,30 +17,17 @@ The low-level commands fit candidate models. Production ensembles also require
 model selection and percentile calibration; use the release workflow when you
 need the complete pipeline.
 
-## Training data
-
-Affinity training tables use one row per measurement. Allele-specific training
-requires `allele`, `peptide`, `measurement_value`, and `measurement_type`.
-Use `measurement_type` to identify quantitative or qualitative measurements.
-The optional `measurement_inequality` column records `=`, `<`, or `>`; if the
-column is omitted, all measurements are treated as equalities.
-
-Alleles must be sequence-resolved MHC class I names. Allele-specific training
-does not require a pseudosequence table unless the hyperparameters enable
-cross-allele pretraining with `pretrain_min_points`.
-
-The curated data used for released models is available as a download:
-
-```shell
-mhcflurry downloads fetch data_curated
-mhcflurry downloads path data_curated
-```
-
 ## Small allele-specific example
 
 The training command accepts a YAML list of architectures. This single,
 four-member architecture is suitable for learning the workflow; it is not a
 replacement for the released ensemble search:
+
+Fetch the curated example data:
+
+```shell
+mhcflurry downloads fetch data_curated
+```
 
 ```yaml
 - activation: tanh
@@ -75,6 +62,22 @@ mhcflurry class1-train-allele-specific-models \
 
 The output directory is a complete predictor. Keep its manifest, metadata, and
 weights together; pass the directory to prediction commands with `--models`.
+
+## Prepare training data
+
+Affinity training tables use one row per measurement. Allele-specific training
+requires `allele`, `peptide`, `measurement_value`, and `measurement_type`.
+Use `measurement_type` to identify quantitative or qualitative measurements.
+The optional `measurement_inequality` column records `=`, `<`, or `>`; if the
+column is omitted, all measurements are treated as equalities.
+
+Alleles must be sequence-resolved MHC class I names. Allele-specific training
+does not require a pseudosequence table unless the hyperparameters enable
+cross-allele pretraining with `pretrain_min_points`.
+
+The curated data used in the example and for released models is the
+`data_curated` download bundle. Use `mhcflurry downloads path data_curated` to
+locate it.
 
 ## Pan-allele and release training
 

--- a/mhcflurry/version.py
+++ b/mhcflurry/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.3.0rc18"
+__version__ = "2.3.0rc19"


### PR DESCRIPTION
## What changed

- replace the opening score-direction table with a concise explanation of the
  three prediction tasks
- move score interpretation after the first prediction
- lead CLI and Python tutorials with the common user path
- put the runnable training example before custom data schemas
- put automatic hardware behavior before environment overrides
- move test-suite internals behind the actual testing commands
- clearly label generated CLI and API pages as exhaustive references
- bump the package version to 2.3.0rc19

## Why

New readers were seeing low-level output and configuration details before they
had a mental model of what MHCflurry does or which workflow to choose. The
revised order uses progressive disclosure while preserving detailed material
later in each guide.

## Validation

- `./lint.sh`
- `make -C docs generate html SPHINXOPTS=-W`
- `make -C docs doctest SPHINXOPTS=-W` (20 passed)
- `python -m pytest -q test/test_packaging.py` (2 passed)
- `python -m pytest test/` (938 passed)
