### PR TITLE
Fix Colab installation on Python 3.13

### DIFF
--- a/mhcflurry/version.py
+++ b/mhcflurry/version.py
@@ -10,4 +10,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.3.0rc19"
+__version__ = "2.3.0rc20"

--- a/notebooks/mhcflurry-colab.ipynb
+++ b/notebooks/mhcflurry-colab.ipynb
@@ -12,7 +12,9 @@
     {
       "cell_type": "markdown",
       "source": [
-        "This notebook demonstrates how to generate predictions using MHCflurry."
+        "This notebook demonstrates how to generate predictions using MHCflurry.\n",
+        "\n",
+        "The setup includes prereleases for compatibility with Colab's Python runtime."
       ],
       "metadata": {
         "id": "c4ukEYkrco5H"
@@ -22,7 +24,7 @@
       "cell_type": "code",
       "source": [
         "# Install the package and download models\n",
-        "!pip install -q mhcflurry\n",
+        "%pip install --upgrade --pre mhcflurry\n",
         "!mhcflurry-downloads --quiet fetch models_class1_presentation"
       ],
       "metadata": {

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,4 @@
+# Keep the core error checks explicit so Ruff upgrades do not silently
+# enable additional style rules across the existing codebase (issue #361).
+[lint]
+select = ["E4", "E7", "E9", "F"]

--- a/test/test_packaging.py
+++ b/test/test_packaging.py
@@ -12,6 +12,7 @@
 
 """Packaging metadata tests."""
 
+import json
 import re
 import runpy
 from pathlib import Path
@@ -29,6 +30,15 @@ def test_install_guidance_is_not_pinned_to_a_release():
         assert "pip install --upgrade --pre mhcflurry" in text
         assert not prerelease.search(text), relative_path
         assert not stable_series.search(text), relative_path
+
+    notebook = json.loads(
+        (repo_dir / "notebooks/mhcflurry-colab.ipynb").read_text())
+    setup_cell = next(
+        cell for cell in notebook["cells"] if cell["cell_type"] == "code")
+    source = "".join(setup_cell["source"])
+    assert "%pip install --upgrade --pre mhcflurry" in source
+    assert "mhcflurry-downloads --quiet fetch models_class1_presentation" in source
+    assert not prerelease.search(source)
 
 
 def test_setup_packages_cli_subpackage(monkeypatch):

--- a/test/test_released_presentation_highscore_rows.py
+++ b/test/test_released_presentation_highscore_rows.py
@@ -21,6 +21,7 @@ and are stored under test/data/.
 import os
 import warnings
 
+import mhcgnomes
 import numpy as np
 import pandas as pd
 
@@ -53,8 +54,14 @@ def teardown_module():
 
 def _load_expected():
     data_dir = os.path.join(os.path.dirname(__file__), "data")
-    return pd.read_csv(
+    expected = pd.read_csv(
         os.path.join(data_dir, EXPECTED_CSV), keep_default_na=False)
+    # Historical TF output uses allele spellings that can differ from current
+    # canonical names (for example, DLA-88*01:01 versus DLA-88*001:01).
+    for column in ["allele"] + STRING_COLUMNS:
+        expected[column] = expected[column].map(
+            lambda value: mhcgnomes.parse(value).to_string())
+    return expected
 
 
 def _atol_for_output(column):


### PR DESCRIPTION
The Colab setup installs stable 2.2.1, whose download command imports `pipes` and crashes on Python 3.13. Install with `%pip install --upgrade --pre mhcflurry` to select the compatible published prerelease, matching the README and using the notebook kernel interpreter. Explain the prerelease opt-in and extend the installation-guidance regression test to cover the notebook. Bump the package to 2.3.0rc20.

Fixes #414. Fixes #416. The underlying import was already fixed for #292; this change makes that fix available in the notebook.

The required local lint gate encountered #361: newer Ruff defaults enable additional rules and report 1,372 findings in existing code. Add `ruff.toml` with the established core error rules (`E4`, `E7`, `E9`, `F`) so rule selection is explicit. With that configuration, `./lint.sh` passes across the repository. Pinning Ruff and adding lint to CI remain follow-up work in #361.

The full suite also reproduced #416 on unchanged master: a historical DLA label in the high-score prediction fixture differs from current mhcgnomes canonical output. Normalize only the fixture allele-label columns with mhcgnomes. All 315 rows retain their original numeric values and strict tolerances; the prediction regression now passes. Canonical nomenclature was checked against [IPD-MHC](https://www.ebi.ac.uk/ipd/mhc/version/v3300/).

Validation:
- Python 3.13.11: executed the updated setup cell in a separate environment using the published package. It installed 2.3.0rc19, fetched the presentation bundle into an empty data directory, and produced finite presentation predictions for SIINFEKL and SLYNTVATL.
- Packaging and download-command tests: 3 passed. The new notebook assertion fails against the original notebook.
- `./lint.sh`: passes.
- Full Python 3.13.11 suite: **931 passed, 7 skipped** (28m20s).
- Wheel and source distribution build successfully.
- Python 3.10, 3.11, 3.12, and documentation CI all passed on commit c0710886.
